### PR TITLE
Drop unsupported Python from CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -207,16 +207,6 @@ jobs:
             python: '3.11'
           # ansible-core 2.15
           - ansible: stable-2.15
-            python: '2.7'
-          - ansible: stable-2.15
-            python: '3.5'
-          - ansible: stable-2.15
-            python: '3.6'
-          - ansible: stable-2.15
-            python: '3.7'
-          - ansible: stable-2.15
-            python: '3.8'
-          - ansible: stable-2.15
             python: '3.9'
           - ansible: stable-2.15
             python: '3.10'

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -214,16 +214,6 @@ jobs:
             python: '3.11'
           # ansible-core 2.16
           - ansible: stable-2.16
-            python: '2.7'
-          - ansible: stable-2.16
-            python: '3.6'
-          - ansible: stable-2.16
-            python: '3.7'
-          - ansible: stable-2.16
-            python: '3.8'
-          - ansible: stable-2.16
-            python: '3.9'
-          - ansible: stable-2.16
             python: '3.10'
           - ansible: stable-2.16
             python: '3.11'

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -200,16 +200,6 @@ jobs:
           # consider dropping testing against EOL versions and versions you don't support.
           # ansible-core 2.14
           - ansible: stable-2.14
-            python: '2.7'
-          - ansible: stable-2.14
-            python: '3.5'
-          - ansible: stable-2.14
-            python: '3.6'
-          - ansible: stable-2.14
-            python: '3.7'
-          - ansible: stable-2.14
-            python: '3.8'
-          - ansible: stable-2.14
             python: '3.9'
           - ansible: stable-2.14
             python: '3.10'

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,2 @@
+modules:
+  python_requires: '>=3.9'


### PR DESCRIPTION
##### SUMMARY
It looks like the CI runs sanity tests with ansible-core and [unsupported Python versions](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix). There are a lot of other issues in the CI, but I think this at least a start to fix them.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/ansible-test.yml
tests/config.yml

##### ADDITIONAL INFORMATION
#5 