### PR TITLE
Require pyVmomi 6.7.1

### DIFF
--- a/changelogs/fragments/15-clarify-pyvmomi-requirement.yml
+++ b/changelogs/fragments/15-clarify-pyvmomi-requirement.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Clarify pyVmomi requirement (https://github.com/ansible-collections/vmware.vmware/pull/15).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -29,13 +29,11 @@ except ImportError:
 PYVMOMI_IMP_ERR = None
 try:
     from pyVim import connect
-    from pyVmomi import vim, vmodl, VmomiSupport
+    from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True
-    HAS_PYVMOMIJSON = hasattr(VmomiSupport, 'VmomiJSONEncoder')
 except ImportError:
     PYVMOMI_IMP_ERR = traceback.format_exc()
     HAS_PYVMOMI = False
-    HAS_PYVMOMIJSON = False
 
 from ansible.module_utils.basic import env_fallback, missing_required_lib
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyVmomi>=6.7
+pyVmomi>=6.7.1
 git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported


### PR DESCRIPTION
##### SUMMARY
Some modules in [community.vmware](https://github.com/ansible-collections/community.vmware) require pyVmomi 6.7.1 or later. I think it would be easier to move those modules in the future to this collection (if we want to) if we already define this in `requirements.txt` now.

Additionally, `HAS_PYVMOMIJSON` is only used to test this and we could get rid of this because a) it's not used anywhere yet and b) wouldn't be needed if we define `pyVmomi>=6.7.1` in `requirements.txt`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
requirements.txt

##### ADDITIONAL INFORMATION
ansible-collections/community.vmware#2071

[6.7.1](https://pypi.org/project/pyvmomi/6.7.1/) has been released 2018-10-23, 5 1/2 years ago.