### PR TITLE
Run CI with core 2.17

### DIFF
--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -77,6 +77,7 @@ jobs:
           # consider dropping testing against EOL versions and versions you don't support.
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
         # - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.


### PR DESCRIPTION
I think for the inclusion into the community package / Ansible we will be asked to test with ansible-core 2.17. Let's implement this.