### PR TITLE
Deprecating the old module vm_list_group_by_clusters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ vmware.vmware Release Notes
 v1.1.0
 ======
 
-Major Changes
+Minor Changes
 -------------
 
 - Added module vm_list_group_by_clusters

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -14,7 +14,7 @@ releases:
     release_date: '2024-05-07'
   1.1.0:
     changes:
-      major_changes:
+      minor_changes:
       - Added module vm_list_group_by_clusters
     fragments:
     - 16-vm_list_group_by_clusters.yml

--- a/changelogs/fragments/25-deprecated_module_vm_list_goup_by_clusters.yml
+++ b/changelogs/fragments/25-deprecated_module_vm_list_goup_by_clusters.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - vm_list_group_by_clusters - deprecate the module since it was renamed to `vm_list_group_by_clusters_info`

--- a/changelogs/fragments/25-deprecated_module_vm_list_goup_by_clusters.yml
+++ b/changelogs/fragments/25-deprecated_module_vm_list_goup_by_clusters.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - vm_list_group_by_clusters - deprecate the module since it was renamed to `vm_list_group_by_clusters_info`
+  - vm_list_group_by_clusters - deprecate the module since it was renamed to ``vm_list_group_by_clusters_info``

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,9 @@
 ---
 requires_ansible: '>=2.15.0'
+plugin_routing:
+    modules:
+        vm_list_group_by_clusters:
+            redirect: vmware.vmware.vm_list_group_by_clusters_info
+            deprecation:
+                removal_version: 2.0.0
+                warning_text: Use M(vmware.vmware.vm_list_group_by_clusters_info) instead.


### PR DESCRIPTION
##### SUMMARY
Deprecating the module vm_list_group_by_clusters since it will be replaced with vm_list_group_by_clusters_info in v2.0.0

##### ISSUE TYPE
Adding a deprecating 

##### COMPONENT NAME
Deprecating the module vm_list_group_by_clusters since it will be replaced with vm_list_group_by_clusters_info in v2.0.0 and since then we will have 2 modules. 
I used that [doc](https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html#changing-a-module-or-plugin-name-in-the-ansible-main-repository) in order to sign that module as deprecated 
