### PR TITLE
fix guest info bug

### DIFF
--- a/changelogs/fragments/27-guest-info-vm-name-bug.yml
+++ b/changelogs/fragments/27-guest-info-vm-name-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - guest_info - Fixed bugs that caused module failure when specifying the guest_name attribute

--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -41,7 +41,8 @@ try:
                                            ResourcePool,
                                            Datastore,
                                            Cluster,
-                                           Host)
+                                           Host,
+                                           VM)
     HAS_VSPHERE = True
 except ImportError:
     VSPHERE_IMP_ERR = traceback.format_exc()
@@ -339,6 +340,26 @@ class VmwareRestClient(object):
             tags.append(tag_obj.name)
 
         return tags
+
+    def get_vm_by_name(self, name):
+        """
+        Returns a VM object that matches the given name.
+
+        Args:
+            name (str): The name of VM to look for
+
+        Returns:
+            list(str): VM object matching the name provided. Returns None if no
+            matches are found
+        """
+        vms = self.api_client.vcenter.VM.list(
+            VM.FilterSpec(names=set([name]))
+        )
+
+        if len(vms) == 0:
+            return None
+
+        return vms[0]
 
     def get_library_item_by_name(self, name):
         """

--- a/plugins/modules/guest_info.py
+++ b/plugins/modules/guest_info.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import traceback
 
 DOCUMENTATION = r'''
 ---
@@ -71,7 +72,12 @@ guest:
 '''
 
 from collections import defaultdict
-from com.vmware.vcenter_client import VM
+
+try:
+    from com.vmware.vcenter_client import VM
+except ImportError:
+    # handled during class init
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware.plugins.module_utils.vmware import PyVmomi
@@ -117,7 +123,7 @@ class VmwareGuestInfo(PyVmomi):
         if self.params.get('guest_name'):
             matching_vms = self._get_vm(self.params.get('guest_name'))
             try:
-                _ = iter(matching_vms)
+                _ = iter(matching_vms)  # pylint: disable=disallowed-name
                 vms = matching_vms
             except TypeError:
                 vms = [] if not matching_vms else [matching_vms]

--- a/plugins/modules/guest_info.py
+++ b/plugins/modules/guest_info.py
@@ -71,12 +71,6 @@ guest:
 
 from collections import defaultdict
 
-try:
-    from com.vmware.vcenter_client import VM
-except ImportError:
-    # handled during class init
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware.plugins.module_utils.vmware import PyVmomi
 from ansible_collections.vmware.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
@@ -119,7 +113,9 @@ class VmwareGuestInfo(PyVmomi):
         guests = []
 
         if self.params.get('guest_name'):
-            matching_vms = self._get_vm(self.params.get('guest_name'))
+            matching_vms = self.vmware_client.get_vm_by_name(
+                name=self.params.get('guest_name')
+            )
             try:
                 _ = iter(matching_vms)  # pylint: disable=disallowed-name
                 vms = matching_vms
@@ -146,17 +142,6 @@ class VmwareGuestInfo(PyVmomi):
                     self._vvars(v, r[k])
                 else:
                     r[k] = str(v)
-
-    def _get_vm(self, vm_name):
-        names = set([vm_name])
-        vms = self.vmware_client.api_client.vcenter.VM.list(
-            VM.FilterSpec(names=names)
-        )
-
-        if len(vms) == 0:
-            return None
-
-        return vms[0]
 
 
 def main():

--- a/plugins/modules/guest_info.py
+++ b/plugins/modules/guest_info.py
@@ -71,6 +71,7 @@ guest:
 '''
 
 from collections import defaultdict
+from com.vmware.vcenter_client import VM
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware.plugins.module_utils.vmware import PyVmomi
@@ -114,7 +115,12 @@ class VmwareGuestInfo(PyVmomi):
         guests = []
 
         if self.params.get('guest_name'):
-            vms = self._get_vm(self.params.get('guest_name'))
+            matching_vms = self._get_vm(self.params.get('guest_name'))
+            try:
+                _ = iter(matching_vms)
+                vms = matching_vms
+            except TypeError:
+                vms = [] if not matching_vms else [matching_vms]
         else:
             vms = self.vmware_client.api_client.vcenter.VM.list()
 
@@ -140,7 +146,7 @@ class VmwareGuestInfo(PyVmomi):
     def _get_vm(self, vm_name):
         names = set([vm_name])
         vms = self.vmware_client.api_client.vcenter.VM.list(
-            self.vmware_client.api_client.VM.FilterSpec(names=names)
+            VM.FilterSpec(names=names)
         )
 
         if len(vms) == 0:

--- a/plugins/modules/guest_info.py
+++ b/plugins/modules/guest_info.py
@@ -8,8 +8,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import traceback
-
 DOCUMENTATION = r'''
 ---
 module: guest_info


### PR DESCRIPTION
##### SUMMARY
Fixes ACA-1564

This PR fixes an exception thrown when specifying a guest name in the guest_info module. The `VM.FilterSpec` function used to apply the name filter was incorrectly qualified.

Additionally, the return value from the `_get_vm` function can be None, a single dictionary, or a list of dictionaries. I added logic to catch non-iterable values and fix them so the following `for vm in vms` loop will not fail 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
guest_info

##### ADDITIONAL INFORMATION
```yaml
---
- hosts: localhost
  gather_facts: false
  tasks:
    - name: Gather guest info
      vmware.vmware.guest_info:
        validate_certs: false
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_username }}"
        password: "{{ vcenter_password }}"
        guest_name: foo
```

Before:
```bash

PLAY [localhost] *******************************************************************************************************************************************************************************************************************************************

TASK [Gather guest info] ***********************************************************************************************************************************************************************************************************************************
task path: /home/mikemorency/git/vmware.vmware/test.yml:5
<mikemorency> ESTABLISH LOCAL CONNECTION FOR USER: mikemorency
<mikemorency> EXEC /bin/sh -c 'echo ~mikemorency && sleep 0'
<mikemorency> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/mikemorency/.ansible/tmp `"&& mkdir "` echo /home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122 `" && echo ansible-tmp-1716471751.9657607-1985382-207808250187122="` echo /home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122 `" ) && sleep 0'
Using module file /home/mikemorency/.ansible/collections/ansible_collections/vmware/vmware/plugins/modules/guest_info.py
<mikemorency> PUT /home/mikemorency/.ansible/tmp/ansible-local-1985379jj99kqmf/tmp344d9qh4 TO /home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py
<mikemorency> EXEC /bin/sh -c 'chmod u+x /home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/ /home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py && sleep 0'
<mikemorency> EXEC /bin/sh -c '/home/mikemorency/miniconda3/envs/vmware.vmware/bin/python /home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py && sleep 0'
<mikemorency> EXEC /bin/sh -c 'rm -f -r /home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py", line 107, in <module>
    _ansiballz_main()
  File "/home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.vmware.vmware.plugins.modules.guest_info', init_globals=dict(_module_fqn='ansible_collections.vmware.vmware.plugins.modules.guest_info', _modlib_path=modlib_path),
  File "/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/runpy.py", line 209, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py", line 175, in <module>
  File "/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py", line 170, in main
  File "/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py", line 117, in get_guest_info
  File "/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py", line 143, in _get_vm
  File "/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/site-packages/vmware/vapi/bindings/stub.py", line 443, in __getattr__
    return getattr(self._stub_factory, name)
  File "/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/site-packages/vmware/vapi/bindings/stub.py", line 413, in __getattribute__
    result = object.__getattribute__(self, name)
AttributeError: 'StubFactory' object has no attribute 'VM'
fatal: [mikemorency]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/mikemorency/.ansible/tmp/ansible-tmp-1716471751.9657607-1985382-207808250187122/AnsiballZ_guest_info.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.vmware.vmware.plugins.modules.guest_info', init_globals=dict(_module_fqn='ansible_collections.vmware.vmware.plugins.modules.guest_info', _modlib_path=modlib_path),\n  File \"/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/runpy.py\", line 209, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py\", line 175, in <module>\n  File \"/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py\", line 170, in main\n  File \"/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py\", line 117, in get_guest_info\n  File \"/tmp/ansible_vmware.vmware.guest_info_payload_lbnlkypm/ansible_vmware.vmware.guest_info_payload.zip/ansible_collections/vmware/vmware/plugins/modules/guest_info.py\", line 143, in _get_vm\n  File \"/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/site-packages/vmware/vapi/bindings/stub.py\", line 443, in __getattr__\n    return getattr(self._stub_factory, name)\n  File \"/home/mikemorency/miniconda3/envs/vmware.vmware/lib/python3.10/site-packages/vmware/vapi/bindings/stub.py\", line 413, in __getattribute__\n    result = object.__getattribute__(self, name)\nAttributeError: 'StubFactory' object has no attribute 'VM'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

PLAY RECAP *************************************************************************************************************************************************************************************************************************************************
mikemorency : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

After:
```bash
PLAY [localhost] *******************************************************************************************************************************************************************************************************************************************

TASK [Gather guest info] ***********************************************************************************************************************************************************************************************************************************
task path: /home/mikemorency/git/vmware.vmware/test.yml:5
<mikemorency> ESTABLISH LOCAL CONNECTION FOR USER: mikemorency
<mikemorency> EXEC /bin/sh -c 'echo ~mikemorency && sleep 0'
<mikemorency> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/mikemorency/.ansible/tmp `"&& mkdir "` echo /home/mikemorency/.ansible/tmp/ansible-tmp-1716472909.6809666-1987625-162051415794280 `" && echo ansible-tmp-1716472909.6809666-1987625-162051415794280="` echo /home/mikemorency/.ansible/tmp/ansible-tmp-1716472909.6809666-1987625-162051415794280 `" ) && sleep 0'
Using module file /home/mikemorency/.ansible/collections/ansible_collections/vmware/vmware/plugins/modules/guest_info.py
<mikemorency> PUT /home/mikemorency/.ansible/tmp/ansible-local-1987622x82681yw/tmpqfvl1a5c TO /home/mikemorency/.ansible/tmp/ansible-tmp-1716472909.6809666-1987625-162051415794280/AnsiballZ_guest_info.py
<mikemorency> EXEC /bin/sh -c 'chmod u+x /home/mikemorency/.ansible/tmp/ansible-tmp-1716472909.6809666-1987625-162051415794280/ /home/mikemorency/.ansible/tmp/ansible-tmp-1716472909.6809666-1987625-162051415794280/AnsiballZ_guest_info.py && sleep 0'
<mikemorency> EXEC /bin/sh -c '/home/mikemorency/miniconda3/envs/vmware.vmware/bin/python /home/mikemorency/.ansible/tmp/ansible-tmp-1716472909.6809666-1987625-162051415794280/AnsiballZ_guest_info.py && sleep 0'
<mikemorency> EXEC /bin/sh -c 'rm -f -r /home/mikemorency/.ansible/tmp/ansible-tmp-1716472909.6809666-1987625-162051415794280/ > /dev/null 2>&1 && sleep 0'
ok: [mikemorency] => {
    "changed": false,
    "guests": [
        {
            "family": "LINUX",
            "full_name": {
                "args": "[]",
                "default_message": "Other 5.x Linux (64-bit)",
                "id": "vmsg.guestos.other5xLinux64Guest.label",
                "localized": "None",
                "params": "None"
            },
            "host_name": "foo-virtual-machine",
            "ip_address": "10.10.10.10",
            "name": "OTHER_5X_LINUX_64"
        }
    ],
    "invocation": {
        "module_args": {
            "guest_name": "foo",
            "guest_password": null,
            "guest_username": null,
            "hostname": "redacted",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "protocol": "https",
            "proxy_host": null,
            "proxy_port": null,
            "username": "redacted",
            "validate_certs": false
        }
    }
}

PLAY RECAP *************************************************************************************************************************************************************************************************************************************************
mikemorency : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```