### PR TITLE
[WIP] vm_list_group_by_clusters: Fix return value

### DIFF
--- a/changelogs/fragments/36-vm_list_group_by_clusters_info.yml
+++ b/changelogs/fragments/36-vm_list_group_by_clusters_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vm_list_group_by_clusters_info - Fix return value (https://github.com/ansible-collections/vmware.vmware/pull/36).

--- a/plugins/modules/vm_list_group_by_clusters_info.py
+++ b/plugins/modules/vm_list_group_by_clusters_info.py
@@ -191,7 +191,13 @@ def main():
 
     vmware_vm_list_group_by_clusters_mgr = VmwareVMList(module)
     vm_list_group_by_clusters_info = vmware_vm_list_group_by_clusters_mgr.get_vm_list_group_by_clusters()
-    module.exit_json(changed=False, vm_list_group_by_clusters_info=vm_list_group_by_clusters_info)
+    if vmware_vm_list_group_by_clusters_mgr.module._name == 'vm_list_group_by_clusters_info':
+        module.exit_json(changed=False, vm_list_group_by_clusters_info=vm_list_group_by_clusters_info)
+    elif vmware_vm_list_group_by_clusters_mgr.module._name == 'vm_list_group_by_clusters':
+        module.exit_json(changed=False, vm_list_group_by_clusters=vm_list_group_by_clusters_info)
+    else:
+        # module.fail_json(msg="There seems to be bug in this module. Please open an issue. This should never happen.")
+        module.fail_json(msg="module name %s" % vmware_vm_list_group_by_clusters_mgr.module._name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
This is a follow-up to #25

The problem is that the new module changes the return value. It mustn't, at least not when called with the old name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vm_list_group_by_clusters
vm_list_group_by_clusters_info

##### ADDITIONAL INFORMATION
[Include vmware.vmware collection into Ansible package comment](https://github.com/ansible-collections/ansible-inclusion/discussions/75#discussioncomment-9640994)