### PR TITLE
Add returned object vm_list_group_by_clusters if deprecated module was…

### DIFF
--- a/changelogs/fragments/37-vm_list_group_by_clusters_info_returned_obj.yml
+++ b/changelogs/fragments/37-vm_list_group_by_clusters_info_returned_obj.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vm_list_group_by_clusters_info - Add the appropriate returned value for the deprecated module ``vm_list_group_by_clusters``

--- a/plugins/modules/vm_list_group_by_clusters_info.py
+++ b/plugins/modules/vm_list_group_by_clusters_info.py
@@ -191,7 +191,12 @@ def main():
 
     vmware_vm_list_group_by_clusters_mgr = VmwareVMList(module)
     vm_list_group_by_clusters_info = vmware_vm_list_group_by_clusters_mgr.get_vm_list_group_by_clusters()
-    module.exit_json(changed=False, vm_list_group_by_clusters_info=vm_list_group_by_clusters_info)
+    # Till we will release the next major version 2.0.0 we should keep the deprecated module return value
+    if not module._name.endswith('_info'):
+        module.exit_json(changed=False, vm_list_group_by_clusters_info=vm_list_group_by_clusters_info,
+                         vm_list_group_by_clusters=vm_list_group_by_clusters_info)
+    else:
+        module.exit_json(changed=False, vm_list_group_by_clusters_info=vm_list_group_by_clusters_info)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
… called

##### SUMMARY
Fixing Felix's comment from this [discussion](https://github.com/ansible-collections/ansible-inclusion/discussions/75#discussioncomment-9640996).
Add a return value's name of the deprecated module in case the module is called with the old name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vm_list_group_by_clusters_info
