### PR TITLE
Add tiny_prefix to vmware object's names in integration tests

### DIFF
--- a/tests/integration/targets/vmware_content_template/defaults/main.yml
+++ b/tests/integration/targets/vmware_content_template/defaults/main.yml
@@ -1,7 +1,7 @@
 vcenter_port: 443
 run_on_simulator: false
 
-vm: test-content_template
+vm: "{{ tiny_prefix }}-vm"
 vm_cluster: "Eco-Cluster"
 vm_datacenter: "Eco-Datacenter"
 vm_folder: "/Eco-Datacenter/vm/e2e-qe"
@@ -17,5 +17,5 @@ vm_hardware:
 
 template_host: 10.46.29.208
 datastore: datastore2
-library: content_template_library
-template_name: template-test-content_template
+library: "{{ tiny_prefix }}-content-library"
+template_name: "{{ tiny_prefix }}-template"

--- a/tests/integration/targets/vmware_content_template/vars.yml
+++ b/tests/integration/targets/vmware_content_template/vars.yml
@@ -8,4 +8,5 @@ mock_file: "vmware_content_template"
 run_on_simulator: true
 vm: test
 template_host: 1.2.3.4.
+library: templates
 template_name: mytemplate

--- a/tests/integration/targets/vmware_vm_list_group_by_clusters_info/defaults/main.yml
+++ b/tests/integration/targets/vmware_vm_list_group_by_clusters_info/defaults/main.yml
@@ -1,9 +1,9 @@
 vcenter_port: 443
 run_on_simulator: false
 
-test_folder: test-vm_list_group_by_cluster_info
+test_folder: "{{ tiny_prefix }}-folder"
 
-vm_name: test-vm_list_group_by_cluster_info
+vm_name: "{{ tiny_prefix }}-vm"
 vm_cluster: "Eco-Cluster"
 vm_datacenter: "Eco-Datacenter"
 vm_folder: "/Eco-Datacenter/vm/{{ test_folder }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In order to allow to run integration targets in parallel and avoid interference between them, we are adding `"{{ tiny_prefix }}"` to all VMware object's names that are created in integration tests. 

For each integration target the `tiny_prefix` variable will be populated with a uuid string that will be used as prefix for all VMware objects created in that specific target, thus ensuring that there will be no interference when executing in parallel the other integration targets.
