### PR TITLE
ACA-1650: Rename get_vm_by_name method

### DIFF
--- a/changelogs/fragments/10-rename_get_vm_by_name.yaml
+++ b/changelogs/fragments/10-rename_get_vm_by_name.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - module_utils/vmware_rest_client - rename get_vm_by_name method as there is same signature already

--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -312,7 +312,7 @@ class VmwareRestClient(object):
         host_summaries = self.api_client.vcenter.Host.list(filter_spec)
         return host_summaries[0].host if len(host_summaries) > 0 else None
 
-    def get_vm_by_name(self, vm_name, datacenter_name=None):
+    def get_vm_obj_by_name(self, vm_name, datacenter_name=None):
         """
         Returns the identifier of a VM with the mentioned names.
         """

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -157,7 +157,7 @@ class VmwareContentTemplate(VmwareRestClient):
             name=self.template,
             placement=placement_spec,
             library=self.get_library_by_name(self.library),
-            source_vm=self.get_vm_by_name(self.vm_name),
+            source_vm=self.get_vm_obj_by_name(self.vm_name),
         )
         template_id = ''
         try:


### PR DESCRIPTION
This method is used twice in VmwareRestClient class.