### PR TITLE
add vmware.vmware upstream CI

### DIFF
--- a/.github/workflows/eco-vcenter-ci.yaml
+++ b/.github/workflows/eco-vcenter-ci.yaml
@@ -1,0 +1,46 @@
+---
+name: Ansible Eco vCenter Integration Test
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+      - 'release-\d.\d'
+permissions:
+  contents: read
+jobs:
+  ansible_integration_test:
+    runs-on: ["self-hosted", linux, X64]
+    steps:
+      - name: Update pip, git
+        if: runner.os == 'Linux' && startsWith(runner.name, 'ubuntu')
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install podman
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ansible_collections/vmware/vmware
+
+      - name: Generate integration config
+        working-directory: ansible_collections/vmware/vmware/tests/integration
+        run: |
+          chmod +x generate_integration_config.sh
+          ./generate_integration_config.sh
+        env:
+          VCENTER_HOSTNAME: ${{ secrets.VCENTER_HOSTNAME }}
+          VCENTER_USERNAME: ${{ secrets.VCENTER_USERNAME }}
+          VCENTER_PASSWORD: ${{ secrets.VCENTER_PASSWORD }}
+
+      - name: Run integration tests
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          make eco-vcenter-ci
+        working-directory: ansible_collections/vmware/vmware
+        env:
+          ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}"

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+# Integration tests
+tests/integration/integration_config.yml
+
 # Translations
 *.mo
 *.pot

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,40 @@
+# Define ANSI escape codes for colors
+GREEN=\033[0;32m
+RED=\033[0;31m
+NC=\033[0m  # No Color
+
+.PHONY: units
 units:
 	ansible-test units --docker --python 3.12
 
-integration:
+.PHONY: prepare_symlinks
+prepare_symlinks:
+	ansible-playbook tools/prepare_symlinks.yml
+
+.PHONY: integration
+integration: prepare_symlinks
 	ansible-test integration --no-temp-workdir
+
+.PHONY: eco-vcenter-ci
+eco-vcenter-ci: prepare_symlinks
+	@[ -f /tmp/failed-tests.txt ] && rm /tmp/failed-tests.txt || true; \
+	@failed=0; \
+	total=0; \
+	echo "===============" >> /tmp/failed-tests.txt; \
+	echo "Tests Summary" >> /tmp/failed-tests.txt; \
+	echo "===============" >> /tmp/failed-tests.txt; \
+	for dir in $(shell ansible-test integration --list-target --no-temp-workdir | grep 'vmware_'); do \
+	  echo "Running integration test for $$dir"; \
+	  total=$$((total + 1)); \
+	  if ansible-test integration --no-temp-workdir $$dir; then \
+	    echo -e "Test: $$dir ${GREEN}Passed${NC}" | tee -a /tmp/failed-tests.txt; \
+	  else \
+	    echo -e "Test: $$dir ${RED}Failed${NC}" | tee -a /tmp/failed-tests.txt; \
+	    failed=$$((failed + 1)); \
+	  fi; \
+	done; \
+	if [ $$failed -gt 0 ]; then \
+	  echo "$$failed test(s) failed out of $$total." >> /tmp/failed-tests.txt; \
+	  cat /tmp/failed-tests.txt; \
+	  exit 1; \
+	fi

--- a/tests/integration/generate_integration_config.sh
+++ b/tests/integration/generate_integration_config.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155,SC2086
+
+# Resolve the script's directory reliably
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+# Truncate the output file
+truncate -s 0 integration_config.yml
+
+# Read the template and substitute environment variables
+while read -r line; do
+    eval 'echo "'"$line"'"' >> integration_config.yml
+done < "integration_config.yml.tpl"

--- a/tests/integration/integration_config.yml.tpl
+++ b/tests/integration/integration_config.yml.tpl
@@ -1,0 +1,5 @@
+---
+vcenter_hostname: ${VCENTER_HOSTNAME}
+vcenter_username: ${VCENTER_USERNAME}
+vcenter_password: ${VCENTER_PASSWORD}
+ansible_tags: eco-vcenter-ci

--- a/tests/integration/targets/init.sh
+++ b/tests/integration/targets/init.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155,SC2086
 
-BASE_DIR=$(dirname "${BASH_SOURCE[0]}")
+export DEFAULT_COLLECTIONS_PATH="$ANSIBLE_COLLECTIONS_PATH/ansible_collections"
+
+# Check if the variable is already set (e.g., in CI)
+if [ -z "$ANSIBLE_COLLECTIONS_PATH" ]; then
+    # If not, use base collections path
+    ANSIBLE_COLLECTIONS_PATH="$DEFAULT_COLLECTIONS_PATH"
+fi
+
+echo "ANSIBLE_COLLECTIONS_PATH: $ANSIBLE_COLLECTIONS_PATH"
+BASE_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 export ANSIBLE_ROLES_PATH=${BASE_DIR}

--- a/tests/integration/targets/runme.sh
+++ b/tests/integration/targets/runme.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+source ../init.sh
+
+# Generates a string starting with 'test-' followed by 4 random lowercase characters
+TINY_PREFIX="test-$(uuidgen | tr -d '-' | cut -c1-4 | tr '[:upper:]' '[:lower:]')"
+
+# Extract the ansible_tags from integration_config.yml
+ANSIBLE_TAGS=$(awk '/ansible_tags/ {print $2}' ../../integration_config.yml)
+
+# Check if the ANSIBLE_TAGS variable is set
+if [[ -n "$ANSIBLE_TAGS" ]]; then
+  echo "ANSIBLE_TAGS is set to: $ANSIBLE_TAGS"
+  exec ansible-playbook run.yml --tags "$ANSIBLE_TAGS" --extra-vars "tiny_prefix=$TINY_PREFIX"
+else
+  echo "ANSIBLE_TAGS is not set for Eco vCenter. Running on simulator."
+  exec ansible-playbook run.yml --tags integration-ci
+fi

--- a/tests/integration/targets/vmware_appliance_info/run.yml
+++ b/tests/integration/targets/vmware_appliance_info/run.yml
@@ -2,13 +2,27 @@
   gather_facts: no
   collections:
     - community.general
-  vars_files:
-    - vars.yml
+
   tasks:
+
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
     - name: Vcsim
       ansible.builtin.import_role:
         name: prepare_rest
+      tags: integration-ci
 
     - name: Import vmware_appliance_info role
       ansible.builtin.import_role:
         name: vmware_appliance_info
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_appliance_info/runme.sh
+++ b/tests/integration/targets/vmware_appliance_info/runme.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-source ../init.sh
-exec ansible-playbook run.yml

--- a/tests/integration/targets/vmware_content_template/run.yml
+++ b/tests/integration/targets/vmware_content_template/run.yml
@@ -1,12 +1,25 @@
 - hosts: localhost
   gather_facts: no
-  vars_files:
-    - vars.yml
+
   tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
     - name: Prepare rest
       ansible.builtin.import_role:
         name: prepare_rest
+      tags: integration-ci
 
     - name: Import vmware_content_template role
       ansible.builtin.import_role:
         name: vmware_content_template
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_content_template/runme.sh
+++ b/tests/integration/targets/vmware_content_template/runme.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-source ../init.sh
-exec ansible-playbook run.yml

--- a/tests/integration/targets/vmware_guest_info/run.yml
+++ b/tests/integration/targets/vmware_guest_info/run.yml
@@ -2,17 +2,32 @@
   gather_facts: no
   collections:
     - community.general
-  vars_files:
-    - vars.yml
+
   tasks:
+
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
     - name: Rest
       ansible.builtin.import_role:
         name: prepare_rest
+      tags: integration-ci
 
     - name: Vcsim
       ansible.builtin.import_role:
         name: prepare_vcsim
+      tags: integration-ci
 
     - name: Import vmware_guest_info role
       ansible.builtin.import_role:
         name: vmware_guest_info
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_guest_info/runme.sh
+++ b/tests/integration/targets/vmware_guest_info/runme.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-source ../init.sh
-exec ansible-playbook run.yml

--- a/tests/integration/targets/vmware_guest_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_info/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+# note: this test will fail due to the below known bug:
+# https://issues.redhat.com/browse/ACA-1650
 - name: Gather guest info
   vmware.vmware.guest_info:
     validate_certs: false

--- a/tests/integration/targets/vmware_license_info/run.yml
+++ b/tests/integration/targets/vmware_license_info/run.yml
@@ -2,13 +2,26 @@
   gather_facts: no
   collections:
     - community.general
-  vars_files:
-    - vars.yml
+
   tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
     - name: Vcsim
       ansible.builtin.import_role:
         name: prepare_vcsim
+      tags: integration-ci
 
     - name: Import vmware_license_info role
       ansible.builtin.import_role:
         name: vmware_license_info
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_license_info/runme.sh
+++ b/tests/integration/targets/vmware_license_info/runme.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-source ../init.sh
-exec ansible-playbook run.yml

--- a/tests/integration/targets/vmware_vm_list_group_by_clusters_info/run.yml
+++ b/tests/integration/targets/vmware_vm_list_group_by_clusters_info/run.yml
@@ -2,13 +2,26 @@
   gather_facts: no
   collections:
     - community.general
-  vars_files:
-    - vars.yml
   tasks:
+
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
     - name: Rest
       ansible.builtin.import_role:
         name: prepare_rest
+      tags: integration-ci
 
     - name: VM list group by clusters
       ansible.builtin.import_role:
         name: vmware_vm_list_group_by_clusters_info
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_vm_list_group_by_clusters_info/runme.sh
+++ b/tests/integration/targets/vmware_vm_list_group_by_clusters_info/runme.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-source ../init.sh
-exec ansible-playbook run.yml

--- a/tools/prepare_symlinks.yml
+++ b/tools/prepare_symlinks.yml
@@ -1,0 +1,19 @@
+- name: Create symlink to the runme.sh script in specific target directories
+  hosts: localhost
+  tasks:
+    - name: Find all target directories with specific prefix
+      ansible.builtin.find:
+        paths: ../tests/integration/targets
+        recurse: false
+        file_type: directory
+      register: target_dirs
+
+    - name: Create symlink and set executable permission in each target directory with prefix 'vmware_'
+      ansible.builtin.file:
+        src: "{{ playbook_dir }}/../tests/integration/targets/runme.sh"
+        dest: "{{ item.path }}/runme.sh"
+        state: link
+        mode: '0755'
+        force: true
+      loop: "{{ target_dirs.files }}"
+      when: item.path | basename | regex_search('^vmware_')


### PR DESCRIPTION
##### SUMMARY
This is a PR for adding the action to run the integration tests on the eco vcenter installed on our baremetals. 
The changes are aligned with the validated content repo, and hold the same structure.
The changes includes additional var sent to the the ansible-playbook command called tiny_prefix -
this was added to be aligned the behaviour of the downstream CI, which runs the tests in parallel and requires this var.

##### COMPONENT NAME
eco-vcenter-ci.yml

##### NOTE
The PR tested locally and from my own fork, you can see the successful result [here](https://github.com/shellymiron/vmware.vmware/actions/runs/9700098351/job/26770684753).
We will be able to see the job runs on main only after the PR will be merged. 

please review :) @anna-savina @elsapassaro 