### PR TITLE
add qe reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default code owners for all files and directories
+*       @bardielle @machacekondra @mikemorency
+
+# Integration tests permissions
+/tests/integration/ @shellymiron @elsapassaro @prabinovRedhat @anna-savina
+
+# Workflow files permissions
+.github/workflows/* @shellymiron @elsapassaro @prabinovRedhat @anna-savina
+
+# Scripts directory permissions
+/tools/ @shellymiron @elsapassaro @anna-savina @prabinovRedhat
+/changelogs/ @shellymiron @elsapassaro @anna-savina @prabinovRedhat


### PR DESCRIPTION
##### SUMMARY
This PR adds the code owners file so that QE could see the pipelines run without manual intervention of devs.
The names will be unrecognized now, but after merging it should give the right permissions. 
