### PR TITLE
migrating community vm info modules into guest_info

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,6 +1,6 @@
 ---
 name: Ansible Test
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   pull_request:
   merge_group:
     branches:
@@ -18,7 +18,10 @@ jobs:
         run: |
           set -euxo pipefail
           sudo apt-get update
-          sudo apt-get install podman
+
+          # recent version of podman has a bug. Fix is waiting deployment
+          # see https://github.com/actions/runner-images/issues/7753
+          sudo apt-get install podman=3.4.4+ds1-1ubuntu1 --allow-downgrades
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/changelogs/fragments/51-migrate_vm_info_modules.yml
+++ b/changelogs/fragments/51-migrate_vm_info_modules.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - guest_info - migrated functionality from community vmware_guest_info and vmware_vm_info into guest_info. Changes are backwards compatible but legacy outputs are deprecated

--- a/plugins/doc_fragments/vmware_rest_client.py
+++ b/plugins/doc_fragments/vmware_rest_client.py
@@ -16,9 +16,9 @@ notes:
   - All modules requires API write access and hence is not supported on a free ESXi license.
   - All variables and VMware object names are case sensitive.
   - >-
-    Modules may rely on the requests python library, which does not use the system certificate store by default. You can
-    specify the certificate store by setting the REQUESTS_CA_BUNDLE environment variable.
-    Example: 'export REQUESTS_CA_BUNDLE=/path/to/your/ca_bundle.pem'
+      Modules may rely on the requests python library, which does not use the system certificate store by default. You can
+      specify the certificate store by setting the REQUESTS_CA_BUNDLE environment variable.
+      Example: 'export REQUESTS_CA_BUNDLE=/path/to/your/ca_bundle.pem'
 options:
   hostname:
     description:

--- a/plugins/doc_fragments/vmware_rest_client.py
+++ b/plugins/doc_fragments/vmware_rest_client.py
@@ -15,7 +15,8 @@ class ModuleDocFragment(object):
 notes:
   - All modules requires API write access and hence is not supported on a free ESXi license.
   - All variables and VMware object names are case sensitive.
-  - Modules may rely on the requests python library, which does not use the system certificate store by default. You can
+  - >-
+    Modules may rely on the requests python library, which does not use the system certificate store by default. You can
     specify the certificate store by setting the REQUESTS_CA_BUNDLE environment variable.
     Example: 'export REQUESTS_CA_BUNDLE=/path/to/your/ca_bundle.pem'
 options:

--- a/plugins/doc_fragments/vmware_rest_client.py
+++ b/plugins/doc_fragments/vmware_rest_client.py
@@ -15,6 +15,9 @@ class ModuleDocFragment(object):
 notes:
   - All modules requires API write access and hence is not supported on a free ESXi license.
   - All variables and VMware object names are case sensitive.
+  - Modules may rely on the requests python library, which does not use the system certificate store by default. You can
+    specify the certificate store by setting the REQUESTS_CA_BUNDLE environment variable.
+    Example: 'export REQUESTS_CA_BUNDLE=/path/to/your/ca_bundle.pem'
 options:
   hostname:
     description:

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -405,7 +405,19 @@ class PyVmomi(object):
             self.module.fail_json("Unable to find resource pool with name %s" % pool_name)
         return pool
 
-    def get_all_objs_by_type(self, vimtype, folder=None, recurse=True):
+    def list_all_objs_by_type(self, vimtype, folder=None, recurse=True):
+        """
+            Returns a dictionary of all objects matching a given VMWare type.
+            You can also limit the search by folder and recurse if desired
+            Args:
+                vimtype: The type of object to search for
+                folder: vim.Folder, the folder object to use as a base for the search. If
+                        none is provided, the datacenter root will be used
+                recurse: If true, the search will recurse through the folder structure
+            Returns:
+                dicttionary of {obj: str}. The keys are the object while the values are the
+                object name
+        """
         if not folder:
             folder = self.content.rootFolder
 
@@ -422,4 +434,4 @@ class PyVmomi(object):
         """
         Get all virtual machines.
         """
-        return self.get_all_objs_by_type([vim.VirtualMachine], folder=folder, recurse=recurse)
+        return self.list_all_objs_by_type([vim.VirtualMachine], folder=folder, recurse=recurse)

--- a/plugins/module_utils/vmware_facts.py
+++ b/plugins/module_utils/vmware_facts.py
@@ -1,0 +1,430 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+import os
+
+PYVMOMI_IMP_ERR = None
+try:
+    from pyVmomi import vim, VmomiSupport
+except ImportError:
+    pass
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six import integer_types, string_types, iteritems
+import ansible.module_utils.common._collections_compat as collections_compat
+from ansible_collections.vmware.vmware.plugins.module_utils.vmware_folder_paths import get_folder_path_of_vm
+
+
+def _get_vm_prop(vm, attributes):
+    """Safely get a property or return None"""
+    result = vm
+    for attribute in attributes:
+        try:
+            result = getattr(result, attribute)
+        except (AttributeError, IndexError):
+            return None
+    return result
+
+
+def gather_vm_facts(content, vm):
+    """ Gather facts from vim.VirtualMachine object. """
+    facts = {
+        'module_hw': True,
+        'hw_name': vm.config.name,
+        'hw_power_status': vm.summary.runtime.powerState,
+        'hw_guest_full_name': vm.summary.guest.guestFullName,
+        'hw_guest_id': vm.summary.guest.guestId,
+        'hw_product_uuid': vm.config.uuid,
+        'hw_processor_count': vm.config.hardware.numCPU,
+        'hw_cores_per_socket': vm.config.hardware.numCoresPerSocket,
+        'hw_memtotal_mb': vm.config.hardware.memoryMB,
+        'hw_interfaces': [],
+        'hw_datastores': [],
+        'hw_files': [],
+        'hw_esxi_host': None,
+        'hw_guest_ha_state': None,
+        'hw_is_template': vm.config.template,
+        'hw_folder': None,
+        'hw_version': vm.config.version,
+        'instance_uuid': vm.config.instanceUuid,
+        'guest_tools_status': _get_vm_prop(vm, ('guest', 'toolsRunningStatus')),
+        'guest_tools_version': _get_vm_prop(vm, ('guest', 'toolsVersion')),
+        'guest_question': json.loads(json.dumps(vm.summary.runtime.question, cls=VmomiSupport.VmomiJSONEncoder,
+                                                sort_keys=True, strip_dynamic=True)),
+        'guest_consolidation_needed': vm.summary.runtime.consolidationNeeded,
+        'ipv4': None,
+        'ipv6': None,
+        'annotation': vm.config.annotation,
+        'customvalues': {},
+        'snapshots': [],
+        'current_snapshot': None,
+        'vnc': {},
+        'moid': vm._moId,
+        'vimref': "vim.VirtualMachine:%s" % vm._moId,
+        'advanced_settings': {},
+    }
+
+    # facts that may or may not exist
+    if vm.summary.runtime.host:
+        try:
+            host = vm.summary.runtime.host
+            facts['hw_esxi_host'] = host.summary.config.name
+            facts['hw_cluster'] = host.parent.name if host.parent and isinstance(host.parent, vim.ClusterComputeResource) else None
+
+        except vim.fault.NoPermission:
+            # User does not have read permission for the host system,
+            # proceed without this value. This value does not contribute or hamper
+            # provisioning or power management operations.
+            pass
+    if vm.summary.runtime.dasVmProtection:
+        facts['hw_guest_ha_state'] = vm.summary.runtime.dasVmProtection.dasProtected
+
+    datastores = vm.datastore
+    for ds in datastores:
+        facts['hw_datastores'].append(ds.info.name)
+
+    try:
+        files = vm.config.files
+        layout = vm.layout
+        if files:
+            facts['hw_files'] = [files.vmPathName]
+            for item in layout.snapshot:
+                for snap in item.snapshotFile:
+                    if 'vmsn' in snap:
+                        facts['hw_files'].append(snap)
+            for item in layout.configFile:
+                facts['hw_files'].append(os.path.join(os.path.dirname(files.vmPathName), item))
+            for item in vm.layout.logFile:
+                facts['hw_files'].append(os.path.join(files.logDirectory, item))
+            for item in vm.layout.disk:
+                for disk in item.diskFile:
+                    facts['hw_files'].append(disk)
+    except Exception:
+        pass
+
+    facts['hw_folder'] = get_folder_path_of_vm(vm)
+
+    cfm = content.customFieldsManager
+    # Resolve custom values
+    for value_obj in vm.summary.customValue:
+        kn = value_obj.key
+        if cfm is not None and cfm.field:
+            for f in cfm.field:
+                if f.key == value_obj.key:
+                    kn = f.name
+                    # Exit the loop immediately, we found it
+                    break
+
+        facts['customvalues'][kn] = value_obj.value
+
+    # Resolve advanced settings
+    for advanced_setting in vm.config.extraConfig:
+        facts['advanced_settings'][advanced_setting.key] = advanced_setting.value
+
+    net_dict = {}
+    vmnet = _get_vm_prop(vm, ('guest', 'net'))
+    if vmnet:
+        for device in vmnet:
+            if device.deviceConfigId > 0:
+                net_dict[device.macAddress] = list(device.ipAddress)
+
+    if vm.guest.ipAddress:
+        if ':' in vm.guest.ipAddress:
+            facts['ipv6'] = vm.guest.ipAddress
+        else:
+            facts['ipv4'] = vm.guest.ipAddress
+
+    ethernet_idx = 0
+    for entry in vm.config.hardware.device:
+        if not hasattr(entry, 'macAddress'):
+            continue
+
+        if entry.macAddress:
+            mac_addr = entry.macAddress
+            mac_addr_dash = mac_addr.replace(':', '-')
+        else:
+            mac_addr = mac_addr_dash = None
+
+        if (
+            hasattr(entry, "backing")
+            and hasattr(entry.backing, "port")
+            and hasattr(entry.backing.port, "portKey")
+            and hasattr(entry.backing.port, "portgroupKey")
+        ):
+            port_group_key = entry.backing.port.portgroupKey
+            port_key = entry.backing.port.portKey
+        else:
+            port_group_key = None
+            port_key = None
+
+        factname = 'hw_eth' + str(ethernet_idx)
+        facts[factname] = {
+            'addresstype': entry.addressType,
+            'label': entry.deviceInfo.label,
+            'macaddress': mac_addr,
+            'ipaddresses': net_dict.get(entry.macAddress, None),
+            'macaddress_dash': mac_addr_dash,
+            'summary': entry.deviceInfo.summary,
+            'portgroup_portkey': port_key,
+            'portgroup_key': port_group_key,
+        }
+        facts['hw_interfaces'].append('eth' + str(ethernet_idx))
+        ethernet_idx += 1
+
+    snapshot_facts = list_snapshots(vm)
+    if 'snapshots' in snapshot_facts:
+        facts['snapshots'] = snapshot_facts['snapshots']
+        facts['current_snapshot'] = snapshot_facts['current_snapshot']
+
+    facts['vnc'] = get_vnc_extraconfig(vm)
+
+    # Gather vTPM information
+    facts['tpm_info'] = {
+        'tpm_present': vm.summary.config.tpmPresent if hasattr(vm.summary.config, 'tpmPresent') else None,
+        'provider_id': vm.config.keyId.providerId.id if vm.config.keyId else None
+    }
+    return facts
+
+
+def deserialize_snapshot_obj(obj):
+    return {'id': obj.id,
+            'name': obj.name,
+            'description': obj.description,
+            'creation_time': obj.createTime,
+            'state': obj.state,
+            'quiesced': obj.quiesced}
+
+
+def list_snapshots_recursively(snapshots):
+    snapshot_data = []
+    for snapshot in snapshots:
+        snapshot_data.append(deserialize_snapshot_obj(snapshot))
+        snapshot_data = snapshot_data + list_snapshots_recursively(snapshot.childSnapshotList)
+    return snapshot_data
+
+
+def get_current_snap_obj(snapshots, snapob):
+    snap_obj = []
+    for snapshot in snapshots:
+        if snapshot.snapshot == snapob:
+            snap_obj.append(snapshot)
+        snap_obj = snap_obj + get_current_snap_obj(snapshot.childSnapshotList, snapob)
+    return snap_obj
+
+
+def list_snapshots(vm):
+    result = {}
+    snapshot = _get_vm_prop(vm, ('snapshot',))
+    if not snapshot:
+        return result
+    if vm.snapshot is None:
+        return result
+
+    result['snapshots'] = list_snapshots_recursively(vm.snapshot.rootSnapshotList)
+    current_snapref = vm.snapshot.currentSnapshot
+    current_snap_obj = get_current_snap_obj(vm.snapshot.rootSnapshotList, current_snapref)
+    if current_snap_obj:
+        result['current_snapshot'] = deserialize_snapshot_obj(current_snap_obj[0])
+    else:
+        result['current_snapshot'] = dict()
+    return result
+
+
+def get_vnc_extraconfig(vm):
+    result = {}
+    for opts in vm.config.extraConfig:
+        for optkeyname in ['enabled', 'ip', 'port', 'password']:
+            if opts.key.lower() == "remotedisplay.vnc." + optkeyname:
+                result[optkeyname] = opts.value
+    return result
+
+
+def serialize_spec(clonespec):
+    """Serialize a clonespec or a relocation spec"""
+    data = {}
+    attrs = dir(clonespec)
+    attrs = [x for x in attrs if not x.startswith('_')]
+    for x in attrs:
+        xo = getattr(clonespec, x)
+        if callable(xo):
+            continue
+        xt = type(xo)
+        if xo is None:
+            data[x] = None
+        elif isinstance(xo, vim.vm.ConfigSpec):
+            data[x] = serialize_spec(xo)
+        elif isinstance(xo, vim.vm.RelocateSpec):
+            data[x] = serialize_spec(xo)
+        elif isinstance(xo, vim.vm.device.VirtualDisk):
+            data[x] = serialize_spec(xo)
+        elif isinstance(xo, vim.vm.device.VirtualDeviceSpec.FileOperation):
+            data[x] = to_text(xo)
+        elif isinstance(xo, vim.Description):
+            data[x] = {
+                'dynamicProperty': serialize_spec(xo.dynamicProperty),
+                'dynamicType': serialize_spec(xo.dynamicType),
+                'label': serialize_spec(xo.label),
+                'summary': serialize_spec(xo.summary),
+            }
+        elif hasattr(xo, 'name'):
+            data[x] = to_text(xo) + ':' + to_text(xo.name)
+        elif isinstance(xo, vim.vm.ProfileSpec):
+            pass
+        elif issubclass(xt, list):
+            data[x] = []
+            for xe in xo:
+                data[x].append(serialize_spec(xe))
+        elif issubclass(xt, string_types + integer_types + (float, bool)):
+            if issubclass(xt, integer_types):
+                data[x] = int(xo)
+            else:
+                data[x] = to_text(xo)
+        elif issubclass(xt, bool):
+            data[x] = xo
+        elif issubclass(xt, dict):
+            data[to_text(x)] = {}
+            for k, v in xo.items():
+                k = to_text(k)
+                data[x][k] = serialize_spec(v)
+        else:
+            data[x] = str(xt)
+
+    return data
+
+
+#
+# Conversion to JSON
+#
+def deepmerge_dicts(d, u):
+    """
+    Deep merges u into d.
+
+    Credit:
+        https://bit.ly/2EDOs1B (stackoverflow question 3232943)
+    License:
+        cc-by-sa 3.0 (https://creativecommons.org/licenses/by-sa/3.0/)
+    Changes:
+        using collections_compat for compatibility
+
+    Args:
+        - d (dict): dict to merge into
+        - u (dict): dict to merge into d
+
+    Returns:
+        dict, with u merged into d
+    """
+    for k, v in iteritems(u):
+        if isinstance(v, collections_compat.Mapping):
+            d[k] = deepmerge_dicts(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
+
+def extract_object_attributes_to_dict(obj, convert_to_strings=True):
+    """
+    Takes the attribute key/values from a object and puts them in a dict. Nested attributes
+    and their hierarchy is preserved. Optionally all values are converted to strings
+    Args:
+      obj: the object your want to export to a dict
+      convert_to_strings: If true, all values will be converted to strings instead of other primitives
+    """
+    output_dict = {}
+
+    for attr_key, attr_val in vars(obj).items():
+        if not attr_key.startswith('_'):
+            if hasattr(attr_val, '__dict__') and not isinstance(attr_val, str):
+                output_dict[attr_key] = extract_object_attributes_to_dict(attr_val)
+            else:
+                output_dict[attr_key] = str(attr_val) if convert_to_strings else attr_val
+
+    return output_dict
+
+
+def extract_dotted_property_to_dict(data, remainder):
+    """
+    This is used to break down dotted properties for extraction.
+
+    Args:
+        - data (dict): result of _jsonify on a property
+        - remainder: the remainder of the dotted property to select
+
+    Return:
+        dict
+    """
+    result = dict()
+    if '.' not in remainder:
+        result[remainder] = data[remainder]
+        return result
+    key, remainder = remainder.split('.', 1)
+    if isinstance(data, list):
+        temp_ds = []
+        for i in range(len(data)):
+            temp_ds.append(extract_dotted_property_to_dict(data[i][key], remainder))
+        result[key] = temp_ds
+    else:
+        result[key] = extract_dotted_property_to_dict(data[key], remainder)
+    return result
+
+
+def _jsonify_vmware_object(obj):
+    """
+    Convert an object from pyVmomi into JSON.
+
+    Args:
+        - obj (object): vim object
+
+    Return:
+        dict
+    """
+    return json.loads(json.dumps(obj, cls=VmomiSupport.VmomiJSONEncoder,
+                                 sort_keys=True, strip_dynamic=True))
+
+
+def vmware_obj_to_json(obj, properties=None):
+    """
+    Convert a vSphere (pyVmomi) Object into JSON.  This is a deep
+    transformation.  The list of properties is optional - if not
+    provided then all properties are deeply converted.  The resulting
+    JSON is sorted to improve human readability.
+
+    Args:
+        - obj (object): vim object
+        - properties (list, optional): list of properties following
+            the property collector specification, for example:
+            ["config.hardware.memoryMB", "name", "overallStatus"]
+            default is a complete object dump, which can be large
+
+    Return:
+        dict
+    """
+    result = dict()
+    if properties:
+        for prop in properties:
+            try:
+                if '.' in prop:
+                    key, remainder = prop.split('.', 1)
+                    tmp = dict()
+                    tmp[key] = extract_dotted_property_to_dict(_jsonify_vmware_object(getattr(obj, key)), remainder)
+                    deepmerge_dicts(result, tmp)
+                else:
+                    result[prop] = _jsonify_vmware_object(getattr(obj, prop))
+                    # To match gather_vm_facts output
+                    prop_name = prop
+                    if prop.lower() == '_moid':
+                        prop_name = 'moid'
+                    elif prop.lower() == '_vimref':
+                        prop_name = 'vimref'
+                    result[prop_name] = result[prop]
+            except (AttributeError, KeyError):
+                raise AttributeError("Property '%s' not found." % prop)
+    else:
+        result = _jsonify_vmware_object(obj)
+    return result

--- a/plugins/module_utils/vmware_folder_paths.py
+++ b/plugins/module_utils/vmware_folder_paths.py
@@ -67,3 +67,25 @@ def format_folder_path_as_datastore_fq_path(folder_path, datacenter_name):
     Eg: rest/of/path -> datacenter name/datastore/rest/of/path
     """
     return __prepend_datacenter_and_folder_type(folder_path, datacenter_name, folder_type='datastore')
+
+
+def get_folder_path_of_vm(vm):
+    """
+    Find the path of virtual machine.
+    Args:
+        content: VMware content object
+        vm_name: virtual machine managed object
+
+    Returns: Folder of virtual machine if exists, else None
+
+    """
+    _folder = vm.parent
+    folder_path = [_folder.name]
+    while getattr(_folder, 'parent', None) is not None:
+        _folder = _folder.parent
+        if _folder.name == 'Datacenters':
+            break
+        folder_path += [_folder.name]
+
+    folder_path.reverse()
+    return '/'.join(folder_path)

--- a/plugins/modules/guest_info.py
+++ b/plugins/modules/guest_info.py
@@ -173,7 +173,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware.plugins.module_utils.vmware import PyVmomi
 from ansible_collections.vmware.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
 from ansible_collections.vmware.vmware.plugins.module_utils.vmware_facts import (
-    gather_vm_facts,
+    VmFacts,
     vmware_obj_to_json,
     extract_object_attributes_to_dict
 )
@@ -226,7 +226,8 @@ class VmwareGuestInfo(VmwareRestClient):
         for guest in self.get_guests():
             guest_info = {}
             if self.params['schema'] == 'summary':
-                guest_info = gather_vm_facts(self.pyvmomi.content, guest)
+                vm_facts = VmFacts(guest)
+                guest_info = vm_facts.all_facts(self.pyvmomi.content)
             else:
                 guest_info = vmware_obj_to_json(guest, self.params['properties'])
 

--- a/tests/integration/targets/prepare_combined_vcenter_simulator/files/default.conf
+++ b/tests/integration/targets/prepare_combined_vcenter_simulator/files/default.conf
@@ -1,0 +1,22 @@
+upstream soap {
+    server vmwaresoap:8989;
+}
+
+upstream rest {
+    server vmwarest:1080;
+}
+
+server {
+    listen 443 ssl http2 default_server;
+    ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+    ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+
+
+    location / {
+        proxy_pass https://soap;
+    }
+
+    location /api {
+        proxy_pass https://rest;
+    }
+}

--- a/tests/integration/targets/prepare_combined_vcenter_simulator/files/entrypoint.sh
+++ b/tests/integration/targets/prepare_combined_vcenter_simulator/files/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+openssl req -x509 -nodes -days 365 -subj "/C=CA/ST=QC/O=Company, Inc./CN=mydomain.com" \
+  -addext "subjectAltName=DNS:mydomain.com" -newkey rsa:2048 \
+  -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt
+
+nginx -g "daemon off;"

--- a/tests/integration/targets/prepare_combined_vcenter_simulator/tasks/main.yml
+++ b/tests/integration/targets/prepare_combined_vcenter_simulator/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Create a container test network
+  containers.podman.podman_network:
+    name: "{{ prepare_combined_vcenter_simulator_network }}"
+
+- name: Start VCenter REST Mock
+  ansible.builtin.import_role:
+    name: prepare_rest
+  vars:
+    prepare_rest_network: "{{ prepare_combined_vcenter_simulator_network }}"
+  tags: integration-ci
+
+- name: Vcsim
+  ansible.builtin.import_role:
+    name: prepare_vcsim
+  vars:
+    prepare_vcsim_network: "{{ prepare_combined_vcenter_simulator_network }}"
+  tags: integration-ci
+
+- name: Run API gateway container
+  containers.podman.podman_container:
+    name: combined-vcenter-gateway
+    image: docker.io/library/nginx:latest
+    state: started
+    recreate: yes
+    expose:
+      - 443
+    ports:
+      - 9000:443
+    network: "{{ prepare_combined_vcenter_simulator_network }}"
+    volumes:
+      - "{{ role_path }}/files/default.conf:/etc/nginx/conf.d/default.conf:Z"
+      - "{{ role_path }}/files/entrypoint.sh:/entrypoint.sh:Z"
+    command:
+      - /bin/bash
+      - -c
+      - chmod +x /entrypoint.sh && /entrypoint.sh
+
+- name: Pause
+  ansible.builtin.pause:
+    seconds: 10

--- a/tests/integration/targets/prepare_combined_vcenter_simulator/vars/main.yml
+++ b/tests/integration/targets/prepare_combined_vcenter_simulator/vars/main.yml
@@ -1,0 +1,2 @@
+---
+prepare_combined_vcenter_simulator_network: vmware_test_network

--- a/tests/integration/targets/prepare_rest/defaults/main.yml
+++ b/tests/integration/targets/prepare_rest/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+prepare_rest_port: 1080

--- a/tests/integration/targets/prepare_rest/tasks/main.yml
+++ b/tests/integration/targets/prepare_rest/tasks/main.yml
@@ -13,10 +13,11 @@
     image: docker.io/mockserver/mockserver:latest
     state: started
     recreate: yes
+    network: "{{ prepare_rest_network | default(omit) }}"
     exposed_ports:
       - 1080
     ports:
-      - 1080:1080
+      - "{{ prepare_rest_port }}:1080"
 
 - name: Pause
   ansible.builtin.pause:

--- a/tests/integration/targets/prepare_vcsim/defaults/main.yml
+++ b/tests/integration/targets/prepare_vcsim/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+prepare_vcsim_port: 8989

--- a/tests/integration/targets/prepare_vcsim/tasks/main.yml
+++ b/tests/integration/targets/prepare_vcsim/tasks/main.yml
@@ -12,10 +12,12 @@
     image: docker.io/vmware/vcsim:latest
     state: started
     recreate: yes
+    network: "{{ prepare_vcsim_network | default(omit) }}"
     expose:
       - 8989
     ports:
-      - 8989:8989
+      - "{{ prepare_vcsim_port }}:8989"
+    command: "{{ prepare_vcsim_command | default(omit) }}"
 
 - name: Pause
   ansible.builtin.pause:

--- a/tests/integration/targets/vmware_guest_info/run.yml
+++ b/tests/integration/targets/vmware_guest_info/run.yml
@@ -15,14 +15,9 @@
         file: vars.yml
       tags: integration-ci
 
-    - name: Rest
+    - name: Setup VCenter simulator
       ansible.builtin.import_role:
-        name: prepare_rest
-      tags: integration-ci
-
-    - name: Vcsim
-      ansible.builtin.import_role:
-        name: prepare_vcsim
+        name: prepare_combined_vcenter_simulator
       tags: integration-ci
 
     - name: Import vmware_guest_info role

--- a/tests/integration/targets/vmware_guest_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_info/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# note: this test will fail due to the below known bug:
-# https://issues.redhat.com/browse/ACA-1650
 - name: Import common vars
   ansible.builtin.include_vars:
     file: ../group_vars.yml
@@ -13,7 +11,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     port: "{{ vcenter_port }}"
-    guest_name: "{{ (run_on_simulator) | ternary(omit, vm_name) }}"
+    guest_name: "{{ vm_name }}"
   register: __res
 
 - name: Assert values

--- a/tests/integration/targets/vmware_guest_info/vars.yml
+++ b/tests/integration/targets/vmware_guest_info/vars.yml
@@ -1,8 +1,8 @@
 vcenter_hostname: "127.0.0.1"
 vcenter_username: "user"
 vcenter_password: "pass"
-vcenter_port: 1080
+vcenter_port: 9000
 
 run_on_simulator: true
 mock_file: "vmware_guest_info"
-guests_length: 0
+vm_name: DC0_H0_VM0

--- a/tests/unit/plugins/modules/test_guest_info.py
+++ b/tests/unit/plugins/modules/test_guest_info.py
@@ -21,8 +21,8 @@ class TestGuestInfo(ModuleTestCase):
         init_mock = mocker.patch.object(guest_info.VmwareGuestInfo, "__init__")
         init_mock.return_value = None
 
-        get_guest_info = mocker.patch.object(guest_info.VmwareGuestInfo, "get_guest_info")
-        get_guest_info.return_value = {}
+        gather_info_for_guests = mocker.patch.object(guest_info.VmwareGuestInfo, "gather_info_for_guests")
+        gather_info_for_guests.return_value = []
 
     def test_gather(self, mocker):
         self.__prepare(mocker)


### PR DESCRIPTION
##### SUMMARY
This is an attempt to migrate vm info modules from community.vmware (vmware_guest_info, vmware_vm_info) into vmware.vmware. Since there is already a vm info module in vmware.vmware (guest_info), the functionality from the two community modules has been added to guest_info

This module also requires the rest and soap APIs. So for the simulator tests i added an API gateway so both APIs can be accessed on the same port.

All of the changes should be backwards compatible. We do plan on deprecating the module's old output and removing it at some point in the future. More on that in the additional info section.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
guest_info

##### ADDITIONAL INFORMATION
While the inputs for guest_info has not changed, the output should probably be changed. Theres some duplicated information, and some of the values previously returned by `guest_info` have similar names. 

Here is how the guest_info module currently returns info:
```
guests: [
  {
    old values here
  }
]
```

For now, we are returning the old values in two locations to the user:
```
guests: [
  {
    old and new values mixed together
    .....
    identity: {
        old values here
    }
  }
]
```

At some point in the future, the old values _not_ nested under `identity` will be removed. Resulting in:
It makes more sense to me if the old values are nested in an attribute like:
```
guests: [
  {
    new values here
    ......
    identity: {
        old values here
   }
  }
]
```