### PR TITLE
Add checks in folder_template_from_vm tests

### DIFF
--- a/tests/integration/targets/vmware_folder_template_from_vm/defaults/main.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 run_on_simulator: false
-template_folder: e2e-qe
+vm_folder: e2e-qe
+template_folder: "{{ tiny_prefix }}-folder"
 vm_name: "{{ tiny_prefix }}_folder_template_from_vm_test"
 vm_name_match: first
 template_name: "{{ vm_name }}_template"

--- a/tests/integration/targets/vmware_folder_template_from_vm/defaults/main.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 run_on_simulator: false
-vm_folder: e2e-qe
-template_folder: "{{ tiny_prefix }}-folder"
+template_folders:
+  - "{{ tiny_prefix }}_folder_1"
+  - "{{ tiny_prefix }}_folder_2"
+vm_folder: "{{ template_folders[0] }}"
 vm_name: "{{ tiny_prefix }}_folder_template_from_vm_test"
 vm_name_match: first
 template_name: "{{ vm_name }}_template"

--- a/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
@@ -46,6 +46,19 @@
       ansible.builtin.include_vars:
         file: ../group_vars.yml
 
+    - name: "Test setup: Create Folders"
+      community.vmware.vcenter_folder:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        folder_name: "{{ item }}"
+        folder_type: vm
+        state: present
+      loop: "{{ template_folders }}"
+
     - name: "Test setup: Create VM guest {{ vm_name }}"
       community.vmware.vmware_guest:
         validate_certs: false
@@ -62,18 +75,6 @@
         guest_id: "{{ vm_guest_id }}"
         hardware: "{{ vm_hardware }}"
 
-    - name: "Test setup: Create Folder"
-      community.vmware.vcenter_folder:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        port: "{{ vcenter_port }}"
-        datacenter: "{{ vcenter_datacenter }}"
-        folder_name: "{{ template_folder }}"
-        folder_type: vm
-        state: present
-
     - name: Create templates from vm in vcenter folders
       vmware.vmware.folder_template_from_vm:
         validate_certs: false
@@ -85,16 +86,12 @@
         template_folder: "{{ item }}"
         vm_name: "{{ vm_name }}"
         template_name: "{{ template_name }}"
-      loop:
-        - "{{ vm_folder }}"
-        - "{{ template_folder }}"
+      loop: "{{ template_folders }}"
       register: __res
 
     - name: Verify template creation
       ansible.builtin.include_tasks: verify_template_creation.yml
-      loop:
-        - "{{ vm_folder }}"
-        - "{{ template_folder }}"
+      loop: "{{ template_folders }}"
 
     - name: Destroy template
       vmware.vmware.folder_template_from_vm:
@@ -108,15 +105,11 @@
         vm_name: "{{ vm_name }}"
         template_name: "{{ template_name }}"
         state: absent
-      loop:
-        - "{{ vm_folder }}"
-        - "{{ template_folder }}"
+      loop: "{{ template_folders }}"
 
     - name: Verify template deletion
       ansible.builtin.include_tasks: verify_template_deletion.yml
-      loop:
-        - "{{ vm_folder }}"
-        - "{{ template_folder }}"
+      loop: "{{ template_folders }}"
 
   always:
     - name: "Test teardown: Destroy VM guest {{ vm_name }}"
@@ -133,7 +126,7 @@
         force: true
         name: "{{ vm_name }}"
 
-    - name: "Test teardown: Destroy VM template {{ template_name }}"
+    - name: "Test teardown: Destroy VM template from folder {{ item }}"
       community.vmware.vmware_guest:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
@@ -146,11 +139,9 @@
         state: absent
         force: true
         name: "{{ template_name }}"
-      loop:
-        - "{{ vm_folder }}"
-        - "{{ template_folder }}"
+      loop: "{{ template_folders }}"
 
-    - name: "Test teardown: Delete Folder {{ template_folder }}"
+    - name: "Test teardown: Delete Folder {{ item }}"
       community.vmware.vcenter_folder:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
@@ -158,5 +149,6 @@
         password: "{{ vcenter_password }}"
         port: "{{ vcenter_port }}"
         datacenter: "{{ vcenter_datacenter }}"
-        folder_name: "{{ template_folder }}"
+        folder_name: "{{ item }}"
         state: absent
+      loop: "{{ template_folders }}"

--- a/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
@@ -10,7 +10,7 @@
         password: "{{ vcenter_password }}"
         port: "{{ vcenter_port }}"
         datacenter: "{{ vcenter_datacenter }}"
-        folder_name: "{{ template_folder }}"
+        folder_name: "{{ vm_folder }}"
         folder_type: vm
         state: present
 
@@ -34,7 +34,7 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ vcenter_datacenter }}"
         port: "{{ vcenter_port }}"
-        template_folder: "{{ template_folder }}"
+        template_folder: "{{ vm_folder }}"
         vm_name: "{{ vm_name }}"
         template_name: "{{ template_name }}"
       register: __res
@@ -45,7 +45,8 @@
     - name: Import common vars
       ansible.builtin.include_vars:
         file: ../group_vars.yml
-    - name: "Test setup: Create VM guest {{ vm }}"
+
+    - name: "Test setup: Create VM guest {{ vm_name }}"
       community.vmware.vmware_guest:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
@@ -54,14 +55,26 @@
         cluster: "{{ vcenter_cluster_name }}"
         port: "{{ vcenter_port }}"
         datacenter: "{{ vcenter_datacenter }}"
-        folder: "{{ template_folder }}"
+        folder: "{{ vm_folder }}"
         state: present
         name: "{{ vm_name }}"
         disk: "{{ vm_disk }}"
         guest_id: "{{ vm_guest_id }}"
         hardware: "{{ vm_hardware }}"
 
-    - name: Create template from vm in vcenter folder
+    - name: "Test setup: Create Folder"
+      community.vmware.vcenter_folder:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        folder_name: "{{ template_folder }}"
+        folder_type: vm
+        state: present
+
+    - name: Create templates from vm in vcenter folders
       vmware.vmware.folder_template_from_vm:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
@@ -69,10 +82,41 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ vcenter_datacenter }}"
         port: "{{ vcenter_port }}"
-        template_folder: "{{ template_folder }}"
+        template_folder: "{{ item }}"
         vm_name: "{{ vm_name }}"
         template_name: "{{ template_name }}"
+      loop:
+        - "{{ vm_folder }}"
+        - "{{ template_folder }}"
       register: __res
+
+    - name: Verify template creation
+      ansible.builtin.include_tasks: verify_template_creation.yml
+      loop:
+        - "{{ vm_folder }}"
+        - "{{ template_folder }}"
+
+    - name: Destroy template
+      vmware.vmware.folder_template_from_vm:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        port: "{{ vcenter_port }}"
+        template_folder: "{{ item }}"
+        vm_name: "{{ vm_name }}"
+        template_name: "{{ template_name }}"
+        state: absent
+      loop:
+        - "{{ vm_folder }}"
+        - "{{ template_folder }}"
+
+    - name: Verify template deletion
+      ansible.builtin.include_tasks: verify_template_deletion.yml
+      loop:
+        - "{{ vm_folder }}"
+        - "{{ template_folder }}"
 
   always:
     - name: "Test teardown: Destroy VM guest {{ vm_name }}"
@@ -84,7 +128,7 @@
         cluster: "{{ vcenter_cluster_name }}"
         port: "{{ vcenter_port }}"
         datacenter: "{{ vcenter_datacenter }}"
-        folder: "{{ template_folder }}"
+        folder: "{{ vm_folder }}"
         state: absent
         force: true
         name: "{{ vm_name }}"
@@ -98,7 +142,21 @@
         cluster: "{{ vcenter_cluster_name }}"
         port: "{{ vcenter_port }}"
         datacenter: "{{ vcenter_datacenter }}"
-        folder: "{{ template_folder }}"
+        folder: "{{ item }}"
         state: absent
         force: true
         name: "{{ template_name }}"
+      loop:
+        - "{{ vm_folder }}"
+        - "{{ template_folder }}"
+
+    - name: "Test teardown: Delete Folder {{ template_folder }}"
+      community.vmware.vcenter_folder:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        folder_name: "{{ template_folder }}"
+        state: absent

--- a/tests/integration/targets/vmware_folder_template_from_vm/tasks/verify_template_creation.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/tasks/verify_template_creation.yml
@@ -1,0 +1,19 @@
+---
+- name: Get info on templates
+  community.vmware.vmware_guest_info:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ vcenter_datacenter }}"
+    folder: "{{ item }}"
+    port: "{{ vcenter_port }}"
+    name: "{{ template_name }}"
+  register: template_info
+
+- name: Check template
+  ansible.builtin.assert:
+    that:
+      - template_info.instance.hw_folder == "/" + vcenter_datacenter + "/vm/" + item
+      - template_info.instance.hw_is_template == true
+      - template_info.instance.hw_name == template_name

--- a/tests/integration/targets/vmware_folder_template_from_vm/tasks/verify_template_deletion.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/tasks/verify_template_deletion.yml
@@ -1,0 +1,18 @@
+---
+- name: Get info on templates
+  community.vmware.vmware_guest_info:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ vcenter_datacenter }}"
+    folder: "{{ item }}"
+    port: "{{ vcenter_port }}"
+    name: "{{ template_name }}"
+  register: template_info
+  ignore_errors: true
+
+- name: Fail the task if the template still exists
+  ansible.builtin.fail:
+    msg: "Template {{ template_name }} still exists in folder {{ item }}"
+  when: not template_info.failed

--- a/tests/integration/targets/vmware_folder_template_from_vm/vars.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/vars.yml
@@ -7,4 +7,5 @@ vcenter_datacenter: DC0
 vcenter_cluster_name: DC0_C0
 
 run_on_simulator: true
+vm_folder: test_folder
 vm_name: DC0_H0_VM0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Extending integration tests for folder_template_from_vm module:

- Create templates from a VM both in the same VM folder and in a different folder
- Add assertions to check that the newly created guest is indeed marked as template
- Use the module itself to remove the template