### PR TITLE
Fix folder_template_from_vm test failure

### DIFF
--- a/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
@@ -69,11 +69,24 @@
         port: "{{ vcenter_port }}"
         datacenter: "{{ vcenter_datacenter }}"
         folder: "{{ vm_folder }}"
-        state: present
+        state: poweredon
         name: "{{ vm_name }}"
         disk: "{{ vm_disk }}"
         guest_id: "{{ vm_guest_id }}"
         hardware: "{{ vm_hardware }}"
+
+    - name: "Test setup: Power off VM guest {{ vm_name }}"
+      community.vmware.vmware_guest:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster: "{{ vcenter_cluster_name }}"
+        port: "{{ vcenter_port }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        folder: "{{ vm_folder }}"
+        state: poweredoff
+        name: "{{ vm_name }}"
 
     - name: Create templates from vm in vcenter folders
       vmware.vmware.folder_template_from_vm:


### PR DESCRIPTION
##### SUMMARY
When running `vmware_folder_template_from_vm` integration test in Jenkins CI on real vcenter, the test is failing when trying to create the template with the following error:

```
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1722237961.4638362-112-170133260483632/AnsiballZ_folder_template_from_vm.py", line 107, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1722237961.4638362-112-170133260483632/AnsiballZ_folder_template_from_vm.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1722237961.4638362-112-170133260483632/AnsiballZ_folder_template_from_vm.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.vmware.vmware.plugins.modules.folder_template_from_vm', init_globals=dict(_module_fqn='ansible_collections.vmware.vmware.plugins.modules.folder_template_from_vm', _modlib_path=modlib_path),
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/ansible_vmware.vmware.folder_template_from_vm_payload_zoujjh6r/ansible_vmware.vmware.folder_template_from_vm_payload.zip/ansible_collections/vmware/vmware/plugins/modules/folder_template_from_vm.py", line 312, in <module>
  File "/tmp/ansible_vmware.vmware.folder_template_from_vm_payload_zoujjh6r/ansible_vmware.vmware.folder_template_from_vm_payload.zip/ansible_collections/vmware/vmware/plugins/modules/folder_template_from_vm.py", line 298, in main
  File "/tmp/ansible_vmware.vmware.folder_template_from_vm_payload_zoujjh6r/ansible_vmware.vmware.folder_template_from_vm_payload.zip/ansible_collections/vmware/vmware/plugins/modules/folder_template_from_vm.py", line 177, in check_if_template_exists
  File "/tmp/ansible_vmware.vmware.folder_template_from_vm_payload_zoujjh6r/ansible_vmware.vmware.folder_template_from_vm_payload.zip/ansible_collections/vmware/vmware/plugins/module_utils/vmware.py", line 330, in get_vm_using_params
  File "/tmp/ansible_vmware.vmware.folder_template_from_vm_payload_zoujjh6r/ansible_vmware.vmware.folder_template_from_vm_payload.zip/ansible_collections/vmware/vmware/plugins/module_utils/vmware.py", line 250, in get_objs_by_name_or_moid
  File "/usr/local/lib/python3.11/site-packages/pyVmomi/VmomiSupport.py", line 608, in __call__
    return self.f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pyVmomi/VmomiSupport.py", line 396, in _InvokeAccessor
    return self._stub.InvokeAccessor(self, info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pyVmomi/StubAdapterAccessorImpl.py", line 57, in InvokeAccessor
    return self.InvokeMethod(mo, info, (prop, ))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pyVmomi/SoapAdapter.py", line 1472, in InvokeMethod
    raise obj  # pylint: disable-msg=E0702
    ^^^^^^^^^
pyVmomi.VmomiSupport.vmodl.fault.ManagedObjectNotFound: (vmodl.fault.ManagedObjectNotFound) {
   dynamicType = <unset>,
   dynamicProperty = (vmodl.DynamicProperty) [],
   msg = "The object 'vim.VirtualMachine:vm-13537' has already been deleted or has not been completely created",
   faultCause = <unset>,
   faultMessage = (vmodl.LocalizableMessage) [],
   obj = 'vim.VirtualMachine:vm-13537'
}
```

I tried to add a previous task that checks that the VM is created using the `community.vmware.vmware_guest_info` module:

```
    - name: Get info on VM {{ vm_name }}
      community.vmware.vmware_guest_info:
        validate_certs: false
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_username }}"
        password: "{{ vcenter_password }}"
        datacenter: "{{ vcenter_datacenter }}"
        folder: "{{ vm_folder }}"
        port: "{{ vcenter_port }}"
        name: "{{ vm_name }}"
      register: vm_info
      retries: 5
      delay: 10
      until: vm_info.failed == false
```

but this is not solving the issue because this task successfully retrieves the VM info but the `folder_template_from_vm` module still fails with the same error.

It seems to work if we set the VM state to `poweredon` at VM creation and we power it off afterwards ([link to Jenkins run](https://main-jenkins-csb-aap.apps.ocp-c1.prod.psi.redhat.com/job/AAPQA/job/Content/job/Cloud/job/VMware/job/Content-VMware-Collection-Tests/13/))