### PR TITLE
README: Add Communication section with Forum information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This repo hosts the `vmware.vmware` Ansible Collection.
 
 The collection includes the VMware modules and plugins to help the management of VMware infrastructure.
 
+## Communication
+
+* Join the Ansible forum:
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  * [Posts tagged with 'vmware'](https://forum.ansible.com/tag/vmware): subscribe to participate in collection-related conversations.
+  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 ## Ansible version compatibility
 
 This collection has been tested against following Ansible versions: **>=2.15.0**.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The collection includes the VMware modules and plugins to help the management of
 * Join the Ansible forum:
   * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
   * [Posts tagged with 'vmware'](https://forum.ansible.com/tag/vmware): subscribe to participate in collection-related conversations.
+  * [Ansible VMware Automation Working Group](https://forum.ansible.com/g/ansible-vmware): by joining the team you will automatically get subscribed to the posts tagged with ['vmware'](https://forum.ansible.com/tag/vmware).
   * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 


### PR DESCRIPTION
##### SUMMARY
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README. Similar PRs are being raised across all included collections under the ansible-collection org for now.

If you have other tags/forum groups related to the collection I didn't spot, please update corresponding lines by suggesting changes to the PR.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
README.md