### PR TITLE
Add action_groups

### DIFF
--- a/changelogs/fragments/59-add-action_groups.yaml
+++ b/changelogs/fragments/59-add-action_groups.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add action group (https://github.com/ansible-collections/vmware.vmware/pull/59).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,16 @@
 ---
 requires_ansible: '>=2.15.0'
+action_groups:
+  vmware:
+    - appliance_info
+    - cluster_drs
+    - content_template
+    - folder_template_from_vm
+    - guest_info
+    - license_info
+    - vcsa_settings
+    - vm_list_group_by_clusters_info
+    - vm_portgroup_info
 plugin_routing:
     modules:
         vm_list_group_by_clusters:


### PR DESCRIPTION
##### SUMMARY
I think we should implement an action group since this can be quite useful. I guess sooner or later someone will open a feature request for this, anyway.

amazon.aws and community.aws seem to share the action group `aws`. I suggest the same here: community.vmware already uses `vmware`, so let's also use it here.

Additionally, we might consider renaming the action group of the modules in vmware.vmware_rest from `vmware_rest` to `vmware`, but this is off-topic here. Just wanted to mention it as an idea.

If you think it would be better to not share action groups between those collections, that's also fine for me. The important thing is to have one in order to allow people to use module defaults. If you think it would be better to have a unique name for the action group, it would be great if you could suggest one.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meta/runtime.yml

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware_rest#440