### PR TITLE
migrate community.vmware.vmware_cluster module

### DIFF
--- a/changelogs/fragments/60-add-cluster-module.yaml
+++ b/changelogs/fragments/60-add-cluster-module.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - cluster - Added cluster module, which is meant to succeed the community.vmware.vmware_cluster module (https://github.com/ansible-collections/vmware.vmware/pull/60).

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -1,0 +1,206 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: cluster
+short_description: Manage VMware vSphere clusters
+description:
+    - Adds or removes VMware vSphere clusters.
+    - >-
+      To manage DRS, HA and VSAN related configurations, use the modules cluster_drs,
+      community.vmware.vmware_cluster_ha and community.vmware.vmware_cluster_vsan.
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    cluster:
+      description:
+        - The name of the cluster to be managed.
+      type: str
+      required: true
+      aliases: [cluster_name, name]
+    datacenter:
+      description:
+        - The name of the datacenter.
+      type: str
+      required: true
+      aliases: [datacenter_name]
+    state:
+      description:
+        - Create V(present) or remove V(absent) a VMware vSphere cluster.
+      choices: [ absent, present ]
+      default: present
+      type: str
+
+seealso:
+    - module: vmware.vmware.cluster_drs
+    - module: community.vmware.vmware_cluster_ha
+    - module: community.vmware.vmware_cluster_vsan
+extends_documentation_fragment:
+    - vmware.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Create Cluster
+  vmware.vmware.cluster:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: datacenter
+    cluster_name: cluster
+
+- name: Delete Cluster
+  vmware.vmware.cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: datacenter
+    name: cluster
+    state: absent
+'''
+
+RETURN = r'''
+cluster:
+    description:
+        - Identifying nformation about the cluster
+        - If the cluster was removed, only the name is returned
+    returned: On success
+    type: dict
+    sample: {
+        "cluster": {
+            "moid": "domain-c111111",
+            "name": "example-cluster"
+        },
+    }
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
+    PyVmomi,
+    vmware_argument_spec
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import (
+    TaskError,
+    RunningTaskMonitor
+)
+
+
+class VMwareCluster(PyVmomi):
+    def __init__(self, module):
+        super(VMwareCluster, self).__init__(module)
+        self.datacenter_obj = None
+        self.cluster_obj = None
+
+    def update_state(self):
+        """
+        Creates or deletes a cluster depending on params. Includes error handling
+        """
+        try:
+            if self.params['state'] == 'present':
+                self.__create()
+            elif self.params['state'] == 'absent':
+                self.__destroy()
+        except vmodl.fault.InvalidArgument as invalid_args:
+            self.module.fail_json(msg="Cluster configuration specification"
+                                      " is invalid : %s" % to_native(invalid_args.msg))
+        except vim.fault.InvalidName as invalid_name:
+            self.module.fail_json(msg="'%s' is an invalid name for a"
+                                      " cluster : %s" % (self.params['cluster'],
+                                                         to_native(invalid_name.msg)))
+        except (vim.fault.VimFault, vmodl.RuntimeFault, vmodl.MethodFault) as _fault:
+            self.module.fail_json(msg=to_native(_fault.msg))
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to process cluster"
+                                      " due to exception %s" % to_native(generic_exc))
+
+    def __create(self):
+        """
+        Creates a cluster
+        """
+        cluster_config_spec = vim.cluster.ConfigSpecEx()
+        self.cluster_obj = self.datacenter_obj.hostFolder.CreateClusterEx(self.params['cluster'], cluster_config_spec)
+
+    def __destroy(self):
+        """
+        Destroys a cluster
+        """
+        task = self.cluster_obj.Destroy_Task()
+        try:
+            _, _ = RunningTaskMonitor(task).wait_for_completion()   # pylint: disable=disallowed-name
+        except TaskError as e:
+            self.module.fail_json(msg=to_native(e))
+        self.cluster_obj = None
+
+    def actual_state_matches_desired_state(self):
+        """
+        Checks if cluster exists and compares that to the desired state.
+        Returns: True if cluster state matches desired state, False otherwise
+        """
+        self.datacenter_obj = self.get_datacenter_by_name(self.params['datacenter'], fail_on_missing=True)
+        self.cluster_obj = self.get_cluster_by_name(
+            cluster_name=self.params['cluster'],
+            datacenter=self.datacenter_obj,
+            fail_on_missing=False
+        )
+
+        if self.params['state'] == 'present' and self.cluster_obj:
+            return True
+
+        if self.params['state'] == 'absent' and not self.cluster_obj:
+            return True
+
+        return False
+
+    def get_cluster_outputs(self):
+        """
+        Returns a dictionary with identifying information about the cluster, if one existed or exists.
+        Returns: dict
+        """
+        out = {'name': self.params['cluster']}
+        if self.cluster_obj:
+            out['moid'] = self.cluster_obj._GetMoId()
+
+        return out
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **vmware_argument_spec(), **dict(
+                cluster=dict(type='str', required=True, aliases=['cluster_name', 'name']),
+                datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
+                state=dict(type='str', default='present', choices=['absent', 'present']),
+            )
+        },
+        supports_check_mode=True,
+    )
+
+    vmware_cluster = VMwareCluster(module)
+    if vmware_cluster.actual_state_matches_desired_state():
+        module.exit_json(changed=False, cluster=vmware_cluster.get_cluster_outputs())
+
+    if module.check_mode:
+        module.exit_json(changed=True, cluster=vmware_cluster.get_cluster_outputs())
+
+    vmware_cluster.update_state()
+    module.exit_json(changed=True, cluster=vmware_cluster.get_cluster_outputs())
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vmware_cluster/defaults/main.yml
+++ b/tests/integration/targets/vmware_cluster/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+test_cluster: "{{ tiny_prefix }}_cluster_test"
+run_on_simulator: false

--- a/tests/integration/targets/vmware_cluster/run.yml
+++ b/tests/integration/targets/vmware_cluster/run.yml
@@ -1,0 +1,27 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.general
+
+  tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
+    - name: Vcsim
+      ansible.builtin.import_role:
+        name: prepare_vcsim
+      tags: integration-ci
+
+    - name: Import vmware_cluster role
+      ansible.builtin.import_role:
+        name: vmware_cluster
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_cluster/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: Test On Simulator
+  when: run_on_simulator
+  block:
+    - name: Create Cluster
+      vmware.vmware.cluster:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        state: present
+      register: _create
+    - name: Check Cluster Output
+      ansible.builtin.assert:
+        that:
+          - _create.cluster.moid is defined
+    # deleting a cluster in the simulator is not supporter
+
+- name: Test On VCenter
+  when: not run_on_simulator
+  block:
+    - name: Import common vars
+      ansible.builtin.include_vars:
+        file: ../group_vars.yml
+    - name: Create Test Cluster
+      vmware.vmware.cluster:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        validate_certs: false
+        port: "{{ vcenter_port }}"
+        cluster_name: "{{ test_cluster }}"
+      register: _create
+    - name: Gather Cluster Info
+      community.vmware.vmware_cluster_info:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster_name: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+      register: _cluster_info
+    - name: Check Cluster Output
+      ansible.builtin.assert:
+        that:
+          - _create.cluster.moid is defined
+          - _create.cluster.moid == _cluster_info.clusters[test_cluster].moid
+
+  always:
+    - name: Destroy Test Cluster
+      vmware.vmware.cluster:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        port: "{{ vcenter_port }}"
+        validate_certs: false
+        cluster_name: "{{ test_cluster }}"
+        state: absent

--- a/tests/integration/targets/vmware_cluster/vars.yml
+++ b/tests/integration/targets/vmware_cluster/vars.yml
@@ -1,0 +1,8 @@
+vcenter_hostname: "127.0.0.1"
+vcenter_username: "user"
+vcenter_password: "pass"
+vcenter_port: 8989
+vcenter_datacenter: DC0
+test_cluster: cluster_test
+
+run_on_simulator: true

--- a/tests/integration/targets/vmware_vm_portgroup_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_portgroup_info/tasks/main.yml
@@ -52,10 +52,10 @@
         that:
           - __res.changed == False
           - __res.vm_portgroup_info[vm_name] | length == 1
-          - __res.vm_portgroup_info[vm_name][0]['name'] == "VM Network"
+          - __res.vm_portgroup_info[vm_name][0]['portgroup_name'] == "VM Network"
           - __res.vm_portgroup_info[vm_name][0]['nic_mac_address'] == "00:50:56:bd:d2:9e"
           - __res.vm_portgroup_info[vm_name][0]['nic_type'] == "VMXNET3"
-          - __res.vm_portgroup_info[vm_name][0]['type'] == "STANDARD_PORTGROUP"
+          - __res.vm_portgroup_info[vm_name][0]['type'] == "DISTRIBUTED_PORTGROUP"
 
   always:
     - name: "Test teardown: Destroy VM guest {{ vm_name }}"

--- a/tests/unit/plugins/modules/test_cluster.py
+++ b/tests/unit/plugins/modules/test_cluster.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules import cluster
+
+from .common.utils import (
+    AnsibleExitJson, ModuleTestCase, set_module_args,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestCluster(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        init_mock = mocker.patch.object(cluster.VMwareCluster, "__init__")
+        init_mock.return_value = None
+
+        update_state = mocker.patch.object(cluster.VMwareCluster, "update_state")
+        update_state.return_value = None
+
+        actual_state_matches_desired_state = mocker.patch.object(cluster.VMwareCluster, "actual_state_matches_desired_state")
+        actual_state_matches_desired_state.return_value = False
+
+        get_cluster_outputs = mocker.patch.object(cluster.VMwareCluster, "get_cluster_outputs")
+        get_cluster_outputs.return_value = {"name": "test", "moid": "11111"}
+
+    def test_cluster(self, mocker):
+        self.__prepare(mocker)
+
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            datacenter="test",
+            name="test"
+        )
+
+        with pytest.raises(AnsibleExitJson) as c:
+            cluster.main()
+
+        assert c.value.args[0]["changed"] is True
+        assert c.value.args[0]["cluster"] == {"name": "test", "moid": "11111"}


### PR DESCRIPTION
##### SUMMARY
This is a migration of the community.vmware.vmware_cluster module.

The inputs have remained the same (although more aliases are allowed for the `cluster` attribute).

Ive added identifying information about the cluster in the outputs. When a cluster is destroyed, only the name is returned. When a cluster is created (or already exists) the cluster name and moid are returned.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
cluster
