### PR TITLE
migrate community.vmware.vmware_cluster_vcls module

### DIFF
--- a/changelogs/fragments/61-add-cluster_vcls.yaml
+++ b/changelogs/fragments/61-add-cluster_vcls.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - cluster_vcls - Added module to manage vCLS settings, based on community.vmware.vmware_cluster_vcls (https://github.com/ansible-collections/vmware.vmware/pull/61).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,17 +1,18 @@
 ---
-requires_ansible: '>=2.15.0'
+requires_ansible: ">=2.15.0"
 action_groups:
-  vmware:
-    - appliance_info
-    - cluster
-    - cluster_drs
-    - content_template
-    - folder_template_from_vm
-    - guest_info
-    - license_info
-    - vcsa_settings
-    - vm_list_group_by_clusters_info
-    - vm_portgroup_info
+    vmware:
+        - appliance_info
+        - cluster
+        - cluster_drs
+        - cluster_vcls
+        - content_template
+        - folder_template_from_vm
+        - guest_info
+        - license_info
+        - vcsa_settings
+        - vm_list_group_by_clusters_info
+        - vm_portgroup_info
 plugin_routing:
     modules:
         vm_list_group_by_clusters:

--- a/plugins/modules/cluster_vcls.py
+++ b/plugins/modules/cluster_vcls.py
@@ -1,0 +1,288 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: cluster_vcls
+short_description: Manage the vCLS (vSphere Cluster Services) VM disk placement for this cluster.
+description:
+    - Overrides the default vCLS VM disk placement for this cluster.
+    - >-
+      Datastores may not be configured for vCLS if they are blocked by solutions where vCLS
+      cannot be configured such as SRM or vSAN maintenance mode.
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    cluster:
+        description:
+            - The name of the cluster to be managed.
+        type: str
+        required: true
+        aliases: [cluster_name]
+    datacenter:
+        description:
+            - The name of the datacenter where the cluster and datastores can be found.
+            - If the cluster_name is unique for your environment, the datacenter is optional.
+        type: str
+        required: false
+        aliases: [datacenter_name]
+    allowed_datastores:
+        description:
+            - Exclusive list of the allowed datastores.
+            - If there is an existing list configured in vCenter, it will be overriden by this value.
+        type: list
+        elements: str
+        required: false
+    datastores_to_add:
+        description:
+            - List of datastores to add to the vCLS config
+            - >-
+                The module will make sure these datastores are present in the config, and not change
+                other datastores that are present.
+        type: list
+        elements: str
+        required: false
+    datastores_to_remove:
+        description:
+            - List of datastores to remove from the vCLS config
+            - >-
+                The module will make sure these datastores are absent from the config, and not change
+                other datastores that are present.
+        type: list
+        elements: str
+        required: false
+
+
+extends_documentation_fragment:
+    - vmware.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Set Allowed vCLS Datastores
+  vmware.vmware.cluster_vcls:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: datacenter
+    cluster_name: cluster
+    allowed_datastores:
+      - ds1
+      - ds2
+
+- name: Make sure DS1 is Allowed and DS2 is Not
+  vmware.vmware.cluster_vcls:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: datacenter
+    cluster_name: cluster
+    datastores_to_add:
+      - ds1
+    datastores_to_remove:
+      - ds2
+'''
+
+RETURN = r'''
+added_datastores:
+    description: List of datastores that were added by this module. Empty if none had to be added
+    returned: always
+    type: list
+    sample: [
+        ds3
+    ]
+removed_datastores:
+    description: List of datastores that were removed by this module. Empty if none had to be removed
+    returned: always
+    type: list
+    sample: [
+        ds4
+    ]
+allowed_datastores:
+    description: Complete list of datastores that are in the active configuration (after the module has completed)
+    returned: always
+    type: list
+    sample: [
+        ds1
+        ds2
+        ds3
+    ]
+reconfig_task_result:
+    description: Infromation about the vSphere task to re-configure vCLS
+    returned: on change
+    type: dict
+    sample: {
+        "completion_time": "2024-07-29T15:27:37.041577+00:00",
+        "entity_name": "test-5fb1_cluster",
+        "error": null,
+        "result": null,
+        "state": "success"
+    }
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
+    PyVmomi,
+    vmware_argument_spec
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import (
+    TaskError,
+    RunningTaskMonitor
+)
+
+
+class VMwareClusterVcls(PyVmomi):
+    def __init__(self, module):
+        super(VMwareClusterVcls, self).__init__(module)
+        if module.params.get('datacenter'):
+            datacenter = self.get_datacenter_by_name(module.params['datacenter'], fail_on_missing=True)
+        else:
+            datacenter = None
+
+        self.cluster = self.get_cluster_by_name(module.params['cluster'], datacenter=datacenter, fail_on_missing=True)
+
+    def get_current_configured_datastores(self):
+        """
+        Gets any currently allowed datastores from the active vCLS config
+        Returns: set of allowed datastore names
+        """
+        allowed_datastores = set()
+        if not hasattr(self.cluster.configurationEx, 'systemVMsConfig'):
+            return allowed_datastores
+
+        vcls_config = self.cluster.configurationEx.systemVMsConfig
+        for ds in getattr(vcls_config, 'allowedDatastores', []):
+            allowed_datastores.add(ds.name)
+
+        return allowed_datastores
+
+    def resolve_datastores_to_add_and_remove(self):
+        """
+        Check vCLS configuration diff
+        Returns:
+            Tuple of sets.
+                index 0 contains the datastores that will be added,
+                index 1 contains the datastores that will be removed
+                index 2 contains the complete list of allowed datastores that will be applied
+        """
+        current_allowed_datastores = self.get_current_configured_datastores()
+        if self.params['allowed_datastores'] is not None:
+            new_allowed_datastores = set(self.params['allowed_datastores'])
+        else:
+            new_allowed_datastores = current_allowed_datastores\
+                .union(set(self.params['datastores_to_add']))\
+                .difference(set(self.params['datastores_to_remove']))
+
+        datastores_to_add = new_allowed_datastores.difference(current_allowed_datastores)
+        datastores_to_remove = current_allowed_datastores.difference(new_allowed_datastores)
+
+        return datastores_to_add, datastores_to_remove, new_allowed_datastores
+
+    def __add_datastore_to_config_spec(self, ds_name, cluster_config_spec):
+        """
+        Adds a datastore to the potential new vCLS spec. Causes a failure if the datastore does not exist.
+        """
+        allowed_datastore_spec = vim.cluster.DatastoreUpdateSpec()
+        allowed_datastore_spec.datastore = self.get_datastore_by_name(ds_name, fail_on_missing=True)
+        allowed_datastore_spec.operation = 'add'
+        cluster_config_spec.systemVMsConfig.allowedDatastores.append(allowed_datastore_spec)
+
+    def __remove_datastore_from_config_spec(self, ds_name, cluster_config_spec):
+        """
+        Removes a datastore from the potential new vCLS spec
+        """
+        allowed_datastore_spec = vim.cluster.DatastoreUpdateSpec()
+        allowed_datastore_spec.removeKey = self.get_datastore_by_name(ds_name, fail_on_missing=False)
+        allowed_datastore_spec.operation = 'remove'
+        cluster_config_spec.systemVMsConfig.allowedDatastores.append(allowed_datastore_spec)
+
+    def configure_vcls(self, datastores_to_add, datastores_to_remove):
+        """
+        Applies a vCLS configuration
+        Args:
+          datastores_to_add: A list of datastore names to add to the vCLS configuration
+          datastores_to_remove: A list of datastore names to remove from the vCLS configuration
+
+        """
+        cluster_config_spec = vim.cluster.ConfigSpecEx()
+        cluster_config_spec.systemVMsConfig = vim.cluster.SystemVMsConfigSpec()
+        cluster_config_spec.systemVMsConfig.allowedDatastores = []
+
+        # Build the Spec
+        for ds_name in datastores_to_add:
+            self.__add_datastore_to_config_spec(ds_name, cluster_config_spec)
+
+        for ds_name in datastores_to_remove:
+            self.__remove_datastore_from_config_spec(ds_name, cluster_config_spec)
+
+        try:
+            task = self.cluster.ReconfigureComputeResource_Task(cluster_config_spec, True)
+            _, task_result = RunningTaskMonitor(task).wait_for_completion()   # pylint: disable=disallowed-name
+        except (vmodl.MethodFault, vmodl.RuntimeFault, TaskError) as _fault:
+            self.module.fail_json(msg=to_native(_fault.msg))
+        except Exception as generic_exc:
+            self.module.fail_json(
+                msg="Failed to update cluster vCLS due to exception %s" % to_native(generic_exc)
+            )
+
+        return task_result
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **vmware_argument_spec(), **dict(
+                cluster=dict(type='str', required=True, aliases=['cluster_name']),
+                datacenter=dict(type='str', required=False, aliases=['datacenter_name']),
+                allowed_datastores=dict(type='list', elements='str'),
+                datastores_to_add=dict(type='list', elements='str'),
+                datastores_to_remove=dict(type='list', elements='str'),
+            )
+        },
+        mutually_exclusive=[
+            ('allowed_datastores', 'datastores_to_add'),
+            ('allowed_datastores', 'datastores_to_remove'),
+        ],
+        required_one_of=[
+            ('allowed_datastores', 'datastores_to_add', 'datastores_to_remove'),
+        ],
+        supports_check_mode=True,
+    )
+
+    results = dict(
+        changed=False,
+        added_datastores=[],
+        removed_datastores=[],
+        allowed_datastores=[]
+    )
+
+    vmware_cluster_vcls = VMwareClusterVcls(module)
+    ds_to_add, ds_to_remove, new_allowed_datastores = vmware_cluster_vcls.resolve_datastores_to_add_and_remove()
+    results['allowed_datastores'] = new_allowed_datastores
+    if ds_to_add or ds_to_remove:
+        results['changed'] = True
+        results['added_datastores'] = ds_to_add
+        results['removed_datastores'] = ds_to_remove
+        if not module.check_mode:
+            results['reconfig_task_result'] = vmware_cluster_vcls.configure_vcls(ds_to_add, ds_to_remove)
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vmware_cluster_vcls/defaults/main.yml
+++ b/tests/integration/targets/vmware_cluster_vcls/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+test_cluster: "{{ tiny_prefix }}_cluster_drs_test"
+run_on_simulator: false
+
+allowed_datastores: ["datastore4"]
+datastores_to_add: ["datastore7"]
+datastores_to_remove: ["datastore4"]

--- a/tests/integration/targets/vmware_cluster_vcls/run.yml
+++ b/tests/integration/targets/vmware_cluster_vcls/run.yml
@@ -1,0 +1,27 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.general
+
+  tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
+    - name: Vcsim
+      ansible.builtin.import_role:
+        name: prepare_vcsim
+      tags: integration-ci
+
+    - name: Import vmware_cluster_vcls role
+      ansible.builtin.import_role:
+        name: vmware_cluster_vcls
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_cluster_vcls/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_vcls/tasks/main.yml
@@ -1,0 +1,117 @@
+---
+- name: Test On Simulator
+  when: run_on_simulator
+  block:
+    - name: Set vCLS Settings In Cluster
+      vmware.vmware.cluster_vcls:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        allowed_datastores: "{{ allowed_datastores }}"
+    # The simulator never seems to update its vCLS settings, so theres nothing to validate here
+
+- name: Test On VCenter
+  when: not run_on_simulator
+  block:
+    - name: Import common vars
+      ansible.builtin.include_vars:
+        file: ../group_vars.yml
+    - name: Create Test Cluster
+      vmware.vmware.cluster:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        validate_certs: false
+        port: "{{ vcenter_port }}"
+        cluster_name: "{{ test_cluster }}"
+    - name: Set vCLS Allowed Datastores
+      vmware.vmware.cluster_vcls:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        allowed_datastores: "{{ allowed_datastores }}"
+      register: _out
+    - name: Check Output
+      ansible.builtin.assert:
+        that:
+          - _out is changed
+          - _out.allowed_datastores == allowed_datastores
+          - _out.added_datastores == allowed_datastores
+          - _out.removed_datastores == []
+    - name: Set vCLS Allowed Datastores Again
+      vmware.vmware.cluster_vcls:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        allowed_datastores: "{{ allowed_datastores }}"
+      register: _out
+    - name: Check Output
+      ansible.builtin.assert:
+        that:
+          - _out is not changed
+          - _out.allowed_datastores == allowed_datastores
+          - _out.added_datastores == []
+          - _out.removed_datastores == []
+    - name: Add and Remove vCLS Datastores
+      vmware.vmware.cluster_vcls:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        datastores_to_add: "{{ datastores_to_add }}"
+        datastores_to_remove: "{{ datastores_to_remove }}"
+      register: _out
+    - name: Check Output
+      ansible.builtin.assert:
+        that:
+          - _out is changed
+          - _out.allowed_datastores == datastores_to_add
+          - _out.added_datastores == datastores_to_add
+          - _out.removed_datastores == datastores_to_remove
+    - name: Add and Remove vCLS Datastores Again
+      vmware.vmware.cluster_vcls:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        datastores_to_add: "{{ datastores_to_add }}"
+        datastores_to_remove: "{{ datastores_to_remove }}"
+      register: _out
+    - name: Check Output
+      ansible.builtin.assert:
+        that:
+          - _out is not changed
+          - _out.allowed_datastores == datastores_to_add
+          - _out.added_datastores == []
+          - _out.removed_datastores == []
+
+  always:
+    - name: Destroy Test Cluster
+      vmware.vmware.cluster:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        port: "{{ vcenter_port }}"
+        validate_certs: false
+        cluster_name: "{{ test_cluster }}"
+        state: absent

--- a/tests/integration/targets/vmware_cluster_vcls/vars.yml
+++ b/tests/integration/targets/vmware_cluster_vcls/vars.yml
@@ -1,0 +1,9 @@
+vcenter_hostname: "127.0.0.1"
+vcenter_username: "user"
+vcenter_password: "pass"
+vcenter_port: 8989
+vcenter_datacenter: DC0
+test_cluster: DC0_C0
+allowed_datastores: [LocalDS_0]
+
+run_on_simulator: true

--- a/tests/unit/plugins/modules/test_cluster_vcls.py
+++ b/tests/unit/plugins/modules/test_cluster_vcls.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules import cluster_vcls
+
+from .common.utils import (
+    AnsibleExitJson, ModuleTestCase, set_module_args,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestClusterVcls(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        init_mock = mocker.patch.object(cluster_vcls.VMwareClusterVcls, "__init__")
+        init_mock.return_value = None
+
+        resolve_datastores_to_add_and_remove = mocker.patch.object(cluster_vcls.VMwareClusterVcls, "resolve_datastores_to_add_and_remove")
+        resolve_datastores_to_add_and_remove.return_value = ['ds1'], ['ds2'], ['ds1', 'ds3']
+
+        configure_vcls = mocker.patch.object(cluster_vcls.VMwareClusterVcls, "configure_vcls")
+        configure_vcls.return_value = {}
+
+    def test_gather(self, mocker):
+        self.__prepare(mocker)
+
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            datastores_to_add=['ds1'],
+            datastores_to_remove=['ds2'],
+        )
+
+        with pytest.raises(AnsibleExitJson) as c:
+            cluster_vcls.main()
+
+        assert c.value.args[0]["changed"] is True
+        assert c.value.args[0]["added_datastores"] == ['ds1']
+        assert c.value.args[0]["removed_datastores"] == ['ds2']


### PR DESCRIPTION
##### SUMMARY
This is a migration of the community.vmware.vmware_cluster_vcls module.

The inputs are backwards compatible. I added two inputs, `datastores_to_add` and `datastores_to_remove` to allow incremental modifications to the vCLS config. The legacy module only allowed absolute modifications; you needed to specify all allowed datastores every time.

The outputs that return any datastores added or removed by the module have changed key names to be more consistent with other output names in this collection. For example, `Added_AllowedDatastores` -> `added_datastores` 
Ive also added a new output to return the entire list of allowed datastores, `allowed_datastores`.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
cluster_vcl

##### Additional Information
Heres an example of the new output from the simulator tests:
```
{
    "added_datastores": [
        "LocalDS_0"
    ],
    "allowed_datastores": [
        "LocalDS_0"
    ],
    "changed": true,
    "invocation": {
        "module_args": {
            "allowed_datastores": [
                "LocalDS_0"
            ],
            "cluster": "DC0_C0",
            "datacenter": "DC0",
            "datastores_to_add": null,
            "datastores_to_remove": null,
            "hostname": "127.0.0.1",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 8989,
            "proxy_host": null,
            "proxy_port": null,
            "username": "user",
            "validate_certs": false
        }
    },
    "reconfig_task_result": {
        "completion_time": "2024-08-21T14:29:54.147149+00:00",
        "entity_name": "domain-c29",
        "error": null,
        "result": null,
        "state": "success"
    },
    "removed_datastores": []
}
```
