### PR TITLE
Add cluster to action group

### DIFF
--- a/changelogs/fragments/63-add-cluster-module-to-action_groups.yaml
+++ b/changelogs/fragments/63-add-cluster-module-to-action_groups.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - cluster - Add cluster module to action group (https://github.com/ansible-collections/vmware.vmware/pull/63).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -3,6 +3,7 @@ requires_ansible: '>=2.15.0'
 action_groups:
   vmware:
     - appliance_info
+    - cluster
     - cluster_drs
     - content_template
     - folder_template_from_vm


### PR DESCRIPTION
##### SUMMARY
This is a follow-up to both #59 and #60 to add the `cluster` module to the `action_group`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cluster
meta/runtime.yml

##### ADDITIONAL INFORMATION
Since there hasn't been a release containing this module yet, I made this a trivial change. I don't think this needs to show up in the changelog. Let me know if you think otherwise and I'll change it.