### PR TITLE
fix integration test failures for folder_template_from_vm

### DIFF
--- a/changelogs/fragments/64-add-cluster-module.yaml
+++ b/changelogs/fragments/64-add-cluster-module.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - folder_template_from_vm - Use a more robust method when waiting for tasks to complete to improve accuracy (https://github.com/ansible-collections/vmware.vmware/pull/64).

--- a/plugins/modules/folder_template_from_vm.py
+++ b/plugins/modules/folder_template_from_vm.py
@@ -247,6 +247,7 @@ class VmwareFolderTemplate(PyVmomi):
 
         return template_location_spec
 
+
 def custom_validation(module):
     """
         This validation is too complex to be done with the provided ansible validation


### PR DESCRIPTION
##### SUMMARY
The `folder_template_from_vm` plugin was one of the first to be migrated from the community collection. It included a very simple method to wait for a running task in vmware. It looks like that method did not correctly evaluate the state of running tasks. This meant that running tasks would be marked as failures.

We now have a much better utility for waiting for running tasks. This change makes the plugin use that instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
folder_template_from_vm
