### PR TITLE
migrate cluster_drs_recommendations module

### DIFF
--- a/changelogs/fragments/70-migrate-cluster-drs-recommendations.yml
+++ b/changelogs/fragments/70-migrate-cluster-drs-recommendations.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - cluster_drs_recommendations - Migrated module from community.vmware to apply any DRS recommendations the vCenter cluster may have

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -5,6 +5,7 @@ action_groups:
         - appliance_info
         - cluster
         - cluster_drs
+        - cluster_drs_recommendations
         - cluster_vcls
         - content_template
         - folder_template_from_vm

--- a/plugins/modules/cluster_drs_recommendations.py
+++ b/plugins/modules/cluster_drs_recommendations.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: cluster_drs_recommendations
+short_description: Apply Distributed Resource Scheduler (DRS) recommendations on VMware vSphere clusters
+description:
+    - Applies DRS recommendations on VMware vSphere clusters.
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    cluster:
+        description:
+            - The name of the cluster to be managed.
+        type: str
+        required: true
+        aliases: [ cluster_name ]
+    datacenter:
+        description:
+            - The name of the datacenter.
+        type: str
+        required: true
+        aliases: [ datacenter_name ]
+
+extends_documentation_fragment:
+    - vmware.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Apply DRS Recommendations for Cluster
+  vmware.vmware.cluster_drs_recommendations:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: datacenter
+    cluster_name: cluster
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+applied_recommendations:
+    description:
+        - List of dictionaries describing the applied recommendations
+        - Each entry has a description, which is a string saying where servers were moved
+        - Each entry has a task_result, which is a dictionary describing the vCenter task
+    returned: always
+    type: list
+    sample: [
+        {
+            "description": "server1 move from host1 to host2.",
+            "task_result": {
+                "completion_time": "2024-07-29T15:27:37.041577+00:00",
+                "entity_name": "test-5fb1_cluster_drs_test",
+                "error": null,
+                "result": null,
+                "state": "success"
+            }
+        },
+        {
+            "description": "server2 move from host1 to host2.",
+            "task_result": {
+                "completion_time": "2024-07-29T15:27:37.041577+00:00",
+                "entity_name": "test-5fb1_cluster_drs_test",
+                "error": null,
+                "result": null,
+                "state": "success"
+            }
+        }
+    ]
+'''
+
+try:
+    from pyVmomi import vmodl
+except ImportError:
+    pass
+
+from itertools import zip_longest
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
+    PyVmomi,
+    vmware_argument_spec
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import (
+    TaskError,
+    RunningTaskMonitor
+)
+from ansible.module_utils._text import to_native
+
+
+class VMwareCluster(PyVmomi):
+    def __init__(self, module):
+        super(VMwareCluster, self).__init__(module)
+        datacenter = self.get_datacenter_by_name(self.params.get('datacenter'), fail_on_missing=True)
+        self.cluster = self.get_cluster_by_name(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
+
+    def get_recommendations(self):
+        """
+        Refreshes the clusters current DRS recommendation list and returns them.
+        Returns:
+            list
+        """
+        self.cluster.RefreshRecommendation()
+        return self.cluster.recommendation
+
+    def apply_recommendations(self):
+        """
+        Applies any DRS recommendations that the cluster may have pending. Waits for all tasks to finish and returns
+        information about the applied recommendation and tasks.
+        Returns:
+          list(dict())
+          Example: [{description: str, task_result: dict}]
+        """
+        applied_recommendation_descriptions = []
+        applied_recommendation_tasks = []
+        for recommendation in self.cluster.recommendation:
+            applied_recommendation_descriptions.append(
+                "%s move from %s to %s." % (
+                    recommendation.action[0].target.name,
+                    recommendation.action[0].drsMigration.source.name,
+                    recommendation.action[0].drsMigration.destination.name
+                )
+            )
+
+            if not self.module.check_mode:
+                applied_recommendation_tasks.append(self.cluster.ApplyRecommendation(recommendation.key))
+
+        task_results = self.__wait_for_recommendation_task_results(applied_recommendation_tasks)
+        combined_results = zip_longest(applied_recommendation_descriptions, task_results, fillvalue=dict())
+        return [dict(zip(['description', 'task_results'], res)) for res in combined_results]
+
+    def __wait_for_recommendation_task_results(self, recommendation_tasks):
+        """
+        Waits for all tasks in a list of tasks to finish, then returns the task output
+        Args:
+            recommendation_tasks: list of vcenter task objects
+        Returns:
+          list(dict)
+        """
+        task_results = []
+        for task in recommendation_tasks:
+            try:
+                _, task_result = RunningTaskMonitor(task).wait_for_completion()   # pylint: disable=disallowed-name
+            except (vmodl.RuntimeFault, vmodl.MethodFault)as vmodl_fault:
+                self.module.fail_json(msg=to_native(vmodl_fault.msg))
+            except TaskError as task_e:
+                self.module.fail_json(msg=to_native(task_e))
+            except Exception as generic_exc:
+                self.module.fail_json(msg="Failed to apply DRS recommendation due to exception %s" % to_native(generic_exc))
+            task_results.append(task_result)
+
+        return task_results
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **vmware_argument_spec(), **dict(
+                cluster=dict(type='str', required=True, aliases=['cluster_name']),
+                datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
+            )
+        },
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        applied_recommendations=[]
+    )
+
+    cluster_drs = VMwareCluster(module)
+    recommendations = cluster_drs.get_recommendations()
+    if recommendations:
+        result['changed'] = True
+        result['applied_recommendations'] = cluster_drs.apply_recommendations()
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vmware_cluster_drs_recommendations/defaults/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs_recommendations/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+test_cluster: "{{ tiny_prefix }}_cluster_drs_recommendations_test"
+run_on_simulator: false

--- a/tests/integration/targets/vmware_cluster_drs_recommendations/run.yml
+++ b/tests/integration/targets/vmware_cluster_drs_recommendations/run.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.general
+
+  tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import vmware_cluster_drs_recommendations role
+      ansible.builtin.import_role:
+        name: vmware_cluster_drs_recommendations
+      tags:
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_cluster_drs_recommendations/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs_recommendations/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+# The simulator doesn't support the RefreshRecommendations method that the drs recommendations
+# module uses, so there's no simulator tests
+- name: Test On VCenter
+  when: not run_on_simulator
+  block:
+    - name: Import common vars
+      ansible.builtin.include_vars:
+        file: ../group_vars.yml
+    - name: Create Test Cluster
+      vmware.vmware.cluster:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        validate_certs: false
+        port: "{{ vcenter_port }}"
+        cluster_name: "{{ test_cluster }}"
+    - name: Enable DRS Settings In Test Cluster
+      vmware.vmware.cluster_drs:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        enable: true
+    - name: Apply Recommendations
+      vmware.vmware.cluster_drs_recommendations:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+  always:
+    - name: Destroy Test Cluster
+      vmware.vmware.cluster:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        port: "{{ vcenter_port }}"
+        validate_certs: false
+        cluster_name: "{{ test_cluster }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
This migrates the cluster_drs_recommendations module from the community.vmware collection

The inputs have not changed.
The outputs have changed from the original module. This version reports a description of the applied recommendations as well as details about the vcenter task associated with the change

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
cluster_drs_recommendations

