### PR TITLE
Run sanity tests with ansible-core 2.18

### DIFF
--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -78,6 +78,7 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           - devel
         # - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.


### PR DESCRIPTION
Now that ansible-core 2.18 is out, we should (actually: have to) run the sanity tests with this release.