### PR TITLE
Mm bugfix/drs threshold backwards

### DIFF
--- a/changelogs/fragments/73-fix_drs_backwards_vmotion_rate.yml
+++ b/changelogs/fragments/73-fix_drs_backwards_vmotion_rate.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cluster_drs - fixed backwards vMotion rate (input 1 set rate to 5 in vCenter) (https://github.com/ansible-collections/vmware.vmware/issues/68)

--- a/plugins/modules/cluster_drs.py
+++ b/plugins/modules/cluster_drs.py
@@ -158,7 +158,6 @@ class VMwareCluster(PyVmomi):
         self.cluster = self.get_cluster_by_name(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
 
         self.enable_drs = self.params.get('enable')
-        self.drs_vmotion_rate = self.params.get('drs_vmotion_rate')
         self.drs_enable_vm_behavior_overrides = self.params.get('drs_enable_vm_behavior_overrides')
         self.drs_default_vm_behavior = self.params.get('drs_default_vm_behavior')
         self.predictive_drs = self.params.get('predictive_drs')
@@ -167,6 +166,16 @@ class VMwareCluster(PyVmomi):
             self.params.get('advanced_settings'),
             self.cluster.configurationEx.drsConfig.option
         )
+
+    @property
+    def drs_vmotion_rate(self):
+        """
+        When applying or reading this rate from the vCenter config, the values are reversed. So
+        for example, vCenter thinks 1 is the most aggressive when docs/UI say 5 is most aggressive.
+        We present the scale seen in the docs/UI to the user and then adjust the value here to ensure
+        vCenter behaves as intended.
+        """
+        return 6 - self.params.get('drs_vmotion_rate')
 
     def check_drs_config_diff(self):
         """

--- a/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -49,6 +49,21 @@
         advanced_settings: "{{ drs_advanced_settings }}"
         predictive_drs: "{{ drs_predictive_drs }}"
       register: _out
+    - name: Set DRS Settings In Test Cluster Again - Idempotence
+      vmware.vmware.cluster_drs:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        port: "{{ vcenter_port }}"
+        drs_enable_vm_behavior_overrides: "{{ drs_enable_vm_behavior_overrides}}"
+        drs_default_vm_behavior: "{{ drs_default_vm_behavior }}"
+        drs_vmotion_rate: "{{ drs_vmotion_rate }}"
+        advanced_settings: "{{ drs_advanced_settings }}"
+        predictive_drs: "{{ drs_predictive_drs }}"
+      register: _idempotence_check
     - name: Gather Cluster Settings
       community.vmware.vmware_cluster_info:
         validate_certs: false
@@ -59,12 +74,16 @@
         cluster_name: "{{ test_cluster }}"
         port: "{{ vcenter_port }}"
       register: _cluster_info
+    # drs vmotion rate reported by vcenter api is backwards. So 1 is actually 5 in the UI
+    # and 5 is actually 1 in the UI. When we migrate cluster_info there is a ticket to fix the output
+    # so the number we return to the user makes sense, but for now we will fix it here with (6 - <user_input>)
     - name: Check DRS Settings Were Applied
       ansible.builtin.assert:
         that:
+          - _idempotence_check is not changed
           - _config.drs_default_vm_behavior == drs_default_vm_behavior
           - _config.drs_enable_vm_behavior_overrides == drs_enable_vm_behavior_overrides
-          - _config.drs_vmotion_rate == drs_vmotion_rate
+          - _config.drs_vmotion_rate == (6 - drs_vmotion_rate)
           - _config.enabled_drs == drs_enable
       vars:
         _config: "{{ _cluster_info.clusters[test_cluster] }}"


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/68

When setting the DRS vmotion rate, the user input value gets reversed by the vCenter API (so 1 becomes 5 and 5 becomes 1). This is confusing because the UI and documentation do not indicate this in anyway.
This fix makes the module reverse the numbers in code, so if a user chooses a rate of 1, we change it to 5 in code before inputting it in the API. It will display as 1 in the UI which is what the user wanted in the first place.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_drs

##### ADDITIONAL INFORMATION
The `community.vmware.vcenter_cluster_info` module reports back what the API says. This means that if the user sets the DRS rate to 2, the cluster info module will say the DRS rate is 4. Obviously this is confusing, so when the info module is migrated to this repo, we should fix that as well. I left a note in our tests (which use that module) and made a jira ticket to follow up.
