### PR TITLE
Mm feature/migrate drs recommendations

### DIFF
--- a/changelogs/fragments/72-fix-drs-recommendation-task-results.yml
+++ b/changelogs/fragments/72-fix-drs-recommendation-task-results.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cluster_drs_recommendations - Fix issue where no task object is returned when applying DRS recommendations. Lookup the latest task instead


### PR DESCRIPTION
##### SUMMARY
When applying DRS recommendations, nothing is returned by the ApplyRecommendation method. This change adds a step to lookup the latest task associated with the VM targeted by the recommendation and monitors that task to determine if the recommendation succeeded.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_drs_recommendations
