### PR TITLE
fix dpm automation level option

### DIFF
--- a/changelogs/fragments/75-fix-dpm-automation-level-terms.yml
+++ b/changelogs/fragments/75-fix-dpm-automation-level-terms.yml
@@ -1,0 +1,3 @@
+---
+minor_change:
+  - cluster_dpm - Change automation level option from 'automated' to 'automatic' so it matches the vCenter UI

--- a/changelogs/fragments/75-fix-dpm-automation-level-terms.yml
+++ b/changelogs/fragments/75-fix-dpm-automation-level-terms.yml
@@ -1,3 +1,3 @@
 ---
-minor_change:
+minor_changes:
   - cluster_dpm - Change automation level option from 'automated' to 'automatic' so it matches the vCenter UI


### PR DESCRIPTION
##### SUMMARY
The automation level option for dpm_cluster did not match the options that are used in the UI. This is because the API uses a different word (automated vs automatic).

This change modifies the module options to match what the user sees in the vcenter UI and docs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_dpm
