### PR TITLE
Drop unnecessary changelog entries

### DIFF
--- a/changelogs/fragments/74-fix-drs-recommendation-task-results.yml
+++ b/changelogs/fragments/74-fix-drs-recommendation-task-results.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - cluster_drs_recommendations - Fix issue where no task object is returned when applying DRS recommendations. Lookup the latest task instead

--- a/changelogs/fragments/75-fix-dpm-automation-level-terms.yml
+++ b/changelogs/fragments/75-fix-dpm-automation-level-terms.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - cluster_dpm - Change automation level option from 'automated' to 'automatic' so it matches the vCenter UI


### PR DESCRIPTION
##### SUMMARY
Those changelog fragments will turn up in the changelog. I wonder if this is really helpful. I mean, it's not really a change compared to the last version, is it? Those modules haven't been part of this release. This might confuse some people.

I don't have a strong opinion on this. Just merge this PR or close it if you want to keep those (future) changelog entries. Personally, I think there hasn't been a change compared to 1.5.0 so there shouldn't be any entries in the changelog, either.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
cluster_drs_recommendations
cluster_dpm

##### ADDITIONAL INFORMATION
#70
#71
#73
#74
#75

cc @mikemorency