### PR TITLE
test functools cache

### DIFF
--- a/plugins/module_utils/_vmware.py
+++ b/plugins/module_utils/_vmware.py
@@ -13,6 +13,7 @@ __metaclass__ = type
 import atexit
 import ssl
 import traceback
+from functools import lru_cache
 
 REQUESTS_IMP_ERR = None
 try:
@@ -80,6 +81,7 @@ def vmware_argument_spec():
     )
 
 
+@lru_cache
 def connect_to_api(module, disconnect_atexit=True, return_si=False, hostname=None, username=None, password=None,
                    port=None, validate_certs=None,
                    httpProxyHost=None, httpProxyPort=None):


### PR DESCRIPTION
SUMMARY

Testing functools caches to see if tests are executed faster. If it works it should cache the result of the certain functions, like the ones we use to authenticate to vcenter
Based on https://docs.python.org/3/library/functools.html#functools.lru_cache

Related to https://forum.ansible.com/t/10551
