### PR TITLE
Mm feature/migrate content library item info

### DIFF
--- a/changelogs/fragments/81-migrate-content-library-item-info.yml
+++ b/changelogs/fragments/81-migrate-content-library-item-info.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - content_library_item_info - Migrate content_library_item_info module from the vmware.vmware_rest collection to here

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -8,6 +8,7 @@ action_groups:
         - cluster_drs
         - cluster_drs_recommendations
         - cluster_vcls
+        - content_library_item_info
         - content_template
         - folder_template_from_vm
         - guest_info

--- a/plugins/module_utils/_vmware_rest_client.py
+++ b/plugins/module_utils/_vmware_rest_client.py
@@ -206,7 +206,7 @@ class VmwareRestClient(object):
             list(str), list of library IDs
         """
         if name or library_type:
-            find_spec = self.library_service.FindSpec(name=name, library_type=library_type)
+            find_spec = self.library_service.FindSpec(name=name, type=library_type)
             item_ids = self.library_service.find(spec=find_spec)
             if not item_ids and fail_on_missing:
                 self.module.fail_json(
@@ -241,25 +241,6 @@ class VmwareRestClient(object):
         else:
             item_ids = self.library_item_service.list()
         return item_ids
-
-    def get_library_item_id_from_content_library_name(self, name, content_library_name):
-        """
-        Returns the identifier of the library item with the given name in the specified
-        content library.
-        Args:
-            name (str): The name of item to look for
-            content_library_name (str): The name of the content library to search in
-        Returns:
-            str: The item ID or None if the item is not found
-        """
-        cl_item_id = self.get_content_library_ids(content_library_name)
-        if cl_item_id:
-            find_spec = self.library_item_service.FindSpec(name=name, library_id=cl_item_id[0])
-            item_ids = self.library_item_service.find(find_spec)
-            item_id = item_ids[0] if item_ids else None
-            return item_id
-        else:
-            return None
 
     def get_datacenter_by_name(self, datacenter_name):
         """

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -188,7 +188,7 @@ class ContentLibaryItemInfo(VmwareRestClient):
 
         return self.library_item_service.list(library_id=library_id)
 
-    def get_library_item_ids(self):
+    def get_relevant_library_item_ids_by_params(self):
         if ((self.params['library_item_id'] or self.params['library_item_name']) and
            (not self.params['library_id'] and not self.params['library_name'])):
             # User is searching for a library item in any library, we dont need to specify a
@@ -204,7 +204,7 @@ class ContentLibaryItemInfo(VmwareRestClient):
 
         return library_item_ids
 
-    def get_library_item_info(self, library_item_ids):
+    def get_relevant_library_item_info(self, library_item_ids):
         all_library_items_info = []
         for library_item_id in library_item_ids:
             all_library_items_info.append(self.library_item_service.get(library_item_id).to_dict())
@@ -230,8 +230,8 @@ def main():
     )
 
     library_item_info_module = ContentLibaryItemInfo(module)
-    library_item_ids = library_item_info_module.get_library_item_ids()
-    library_item_info = library_item_info_module.get_library_item_info(library_item_ids)
+    library_item_ids = library_item_info_module.get_relevant_library_item_ids_by_params()
+    library_item_info = library_item_info_module.get_relevant_library_item_info(library_item_ids)
     module.exit_json(library_item_info=library_item_info)
 
 

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -193,11 +193,12 @@ class ContentLibaryItemInfo(VmwareRestClient):
            (not self.params['library_id'] and not self.params['library_name'])):
             # User is searching for a library item in any library, we dont need to specify a
             # library ID and can save an API call or two
-            library_item_ids = self.__get_library_item_ids_by_search_param()
+            library_ids = [None]
+        else:
+            # User specified the library search params or is trying to gather all items, we need
+            # to lookup all of the library IDs first
+            library_ids = self.__get_library_ids_to_search()
 
-        # User specified the library search params or is trying to gather all items, we need
-        # to lookup all of the library IDs first
-        library_ids = self.__get_library_ids_to_search()
         library_item_ids = []
         for library_id in library_ids:
             library_item_ids += self.__get_library_item_ids_by_search_param(library_id=library_id)

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Ansible Project
+# Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: content_library_item_info
+short_description: Gather info about content library items.
+description:
+    - Gather info about content library items, using optional search parameters to refine output.
+    - Content Library feature is introduced in vSphere 6.0 version.
+    - This module does not work with vSphere version older than 67U2.
+    - If neither O(library_item_id) nor O(library_item_name) are provided, all items in the relevant libraries will be returned.
+author:
+    - Ansible Cloud Team (@ansible-collections)
+requirements:
+    - vSphere Automation SDK
+options:
+    library_id:
+        description:
+            - The ID of the library to search within.
+            - Mutually exclusive with O(library_name)
+            - If neither O(library_id) nor O(library_name) are provided, all libraries will be considered relevant when searching.
+        type: str
+        required: false
+    library_name:
+        description:
+            - The name of the library to search within.
+            - Mutually exclusive with O(library_id)
+            - If neither O(library_id) nor O(library_name) are provided, all libraries will be considered relevant when searching.
+        type: str
+        required: false
+    library_item_id:
+        description:
+            - The ID of the library item for which to search.
+            - Mutually exclusive with O(library_item_name).
+            - If O(library_id) or O(library_name) are defined, only items in that library will be included in the results.
+            - If neither O(library_item_id) nor O(library_item_name) are provided, all items in the relevant libraries will be returned.
+        type: str
+        required: false
+    library_item_name:
+        description:
+            - The ID of the library item for which to search.
+            - Mutually exclusive with O(library_item_id).
+            - If O(library_id) or O(library_name) are defined, only items in that library will be included in the results.
+            - If neither O(library_item_id) nor O(library_item_name) are provided, all items in the relevant libraries will be returned.
+        type: str
+        required: false
+
+extends_documentation_fragment:
+    - vmware.vmware.vmware_rest_client.documentation
+'''
+
+EXAMPLES = r'''
+- name: Gather Info About All Library Items
+  vmware.vmware.content_library_item_info: {}
+
+- name: Gather Info About All Library Items In A Specific Library
+  vmware.vmware.content_library_item_info:
+    library_name: My Content Library
+
+- name: Gather Info About A Specific Library Item
+  vmware.vmware.content_library_item_info:
+    library_item_id: c453d380-d864-4437-8e9f-b36395e4e629
+
+# The returned info can be manipulated to extract attributes about the items
+# For example:
+- name: Gather Info About All Items
+  vmware.vmware.content_library_item_info: {}
+  register: _lib_items
+
+- name: Get ISO File Names
+  ansible.builtin.set_fact:
+    my_iso_files: >-
+      {{
+        _lib_items.library_item_info |
+        selectattr('type', 'equalto', 'iso') |
+        map(attribute='name')
+      }}
+'''
+
+RETURN = r'''
+library_item_info:
+  description: A list of dictionaries describing the library items found
+  returned: on success
+  type: list
+  sample: [
+        {
+            "cached": true,
+            "certificate_verification_info": {
+                "status": "NOT_AVAILABLE"
+            },
+            "content_version": "2",
+            "creation_time": "2024-04-04T06:48:07.026Z",
+            "description": "",
+            "id": "fa4d4b87-db09-4b8e-903c-4f30a84e13fb",
+            "last_modified_time": "2024-04-04T06:58:17.182Z",
+            "library_id": "5a74aeab-3333-2222-1111-000000000",
+            "metadata_version": "1",
+            "name": "Fedora-Workstation-Live-ppc64le-39-1.5",
+            "security_compliance": true,
+            "size": 2082617344,
+            "type": "iso",
+            "version": "1"
+        },
+        {
+            "cached": true,
+            "certificate_verification_info": {
+                "status": "NOT_AVAILABLE"
+            },
+            "content_version": "2",
+            "creation_time": "2024-08-27T05:49:38.112Z",
+            "description": "",
+            "id": "cb0fa396-2965-4e1e-bb2a-48bb8181b296",
+            "last_modified_time": "2024-08-27T06:19:55.288Z",
+            "library_id": "0d4ac97a-3333-2222-1111-000000000",
+            "metadata_version": "1",
+            "name": "CentOS-8.3.2011-x86_64-dvd1",
+            "security_compliance": true,
+            "size": 9264168960,
+            "type": "iso",
+            "version": "1"
+        },
+        {
+            "cached": true,
+            "certificate_verification_info": {
+                "status": "INTERNAL"
+            },
+            "content_version": "2",
+            "creation_time": "2024-08-27T07:45:31.191Z",
+            "description": "Windows Server 2022",
+            "id": "7130053e-2463-49c6-84af-2db9f8af1eba",
+            "last_modified_time": "2024-08-27T07:53:02.856Z",
+            "library_id": "2c29da9f-3333-2222-1111-000000000",
+            "metadata_version": "1",
+            "name": "windows_server_2022",
+            "security_compliance": true,
+            "size": 15945369630,
+            "type": "ovf",
+            "version": "1"
+        }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+
+
+class ContentLibaryItemInfo(VmwareRestClient):
+    def __init__(self, module):
+        super(ContentLibaryItemInfo, self).__init__(module)
+
+    def __get_library_ids_to_search(self):
+        """
+        Return a list of library IDs to search for library items, based on
+        search parameters.
+        If a library ID was supplied, use that.
+        If a library name was supplied, search using that name.
+        Otherwise, search with a name of None, which essentially means any name
+
+        Returns: list(str), list of IDs
+        """
+        if self.params['library_id']:
+            return [self.params['library_id']]
+
+        return self.get_content_library_ids(name=self.params['library_name'])
+
+    def __get_library_item_ids_by_search_param(self, library_id=None):
+        """
+        Return a list of library items that match the module search parameters.
+        If a library item was supplied, use that.
+        If a library ID and/or library item name was supplied, search using those params.
+        Otherwise, return all library item IDs
+        """
+        if self.params['library_item_id']:
+            return [self.params['library_item_id']]
+
+        if self.params['library_item_name']:
+            return self.get_library_item_ids(name=self.params['library_item_name'], library_id=library_id)
+
+        return self.library_item_service.list(library_id=library_id)
+
+    def get_library_item_ids(self):
+        if ((self.params['library_item_id'] or self.params['library_item_name']) and
+           (not self.params['library_id'] and not self.params['library_name'])):
+            # User is searching for a library item in any library, we dont need to specify a
+            # library ID and can save an API call or two
+            library_item_ids = self.__get_library_item_ids_by_search_param()
+
+        # User specified the library search params or is trying to gather all items, we need
+        # to lookup all of the library IDs first
+        library_ids = self.__get_library_ids_to_search()
+        library_item_ids = []
+        for library_id in library_ids:
+            library_item_ids += self.__get_library_item_ids_by_search_param(library_id=library_id)
+
+        return library_item_ids
+
+    def get_library_item_info(self, library_item_ids):
+        all_library_items_info = []
+        for library_item_id in library_item_ids:
+            all_library_items_info.append(self.library_item_service.get(library_item_id).to_dict())
+
+        return all_library_items_info
+
+
+def main():
+    argument_spec = VmwareRestClient.vmware_client_argument_spec()
+    argument_spec.update(
+        library_id=dict(type='str', required=False),
+        library_name=dict(type='str', required=False),
+        library_item_id=dict(type='str', required=False),
+        library_item_name=dict(type='str', required=False),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ('library_id', 'library_name'),
+            ('library_item_id', 'library_item_name')
+        ],
+    )
+
+    library_item_info_module = ContentLibaryItemInfo(module)
+    library_item_ids = library_item_info_module.get_library_item_ids()
+    library_item_info = library_item_info_module.get_library_item_info(library_item_ids)
+    module.exit_json(library_item_info=library_item_info)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -139,7 +139,7 @@ class VmwareContentTemplate(VmwareRestClient):
         self.vm_name = self.params.get('vm_name')
 
     def create_template_from_vm(self):
-        template = self.get_library_item_from_content_library_name(self.template, self.library)
+        template = self.get_library_item_id_from_content_library_name(self.template, self.library)
         if template:
             self.result['template_info'] = dict(
                 msg="Template '%s' already exists." % self.template,
@@ -156,7 +156,7 @@ class VmwareContentTemplate(VmwareRestClient):
         create_spec = LibraryItems.CreateSpec(
             name=self.template,
             placement=placement_spec,
-            library=self.get_library_by_name(self.library),
+            library=self.get_content_library_ids(name=self.library, fail_on_missing=True)[0],
             source_vm=self.get_vm_obj_by_name(self.vm_name),
         )
         template_id = ''
@@ -179,7 +179,7 @@ class VmwareContentTemplate(VmwareRestClient):
         )
 
     def delete_template(self):
-        template = self.get_library_item_from_content_library_name(self.template, self.library)
+        template = self.get_library_item_id_from_content_library_name(self.template, self.library)
         if template is None:
             self.result['template_info'] = dict(
                 msg="Template '%s' doesn't exists." % self.template,

--- a/tests/integration/targets/vmware_content_library_item_info/defaults/main.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/defaults/main.yml
@@ -1,0 +1,2 @@
+run_on_simulator: false
+library: ISO

--- a/tests/integration/targets/vmware_content_library_item_info/defaults/main.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/defaults/main.yml
@@ -1,2 +1,2 @@
 run_on_simulator: false
-library: ISO
+library_name: ISO

--- a/tests/integration/targets/vmware_content_library_item_info/run.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/run.yml
@@ -2,11 +2,6 @@
   gather_facts: no
 
   tasks:
-    - name: Import simulator vars
-      ansible.builtin.include_vars:
-        file: vars.yml
-      tags: integration-ci
-
     - name: Import eco-vcenter credentials
       ansible.builtin.include_vars:
         file: ../../integration_config.yml
@@ -16,5 +11,4 @@
       ansible.builtin.import_role:
         name: vmware_content_library_item_info
       tags:
-        - integration-ci
         - eco-vcenter-ci

--- a/tests/integration/targets/vmware_content_library_item_info/run.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/run.yml
@@ -1,0 +1,15 @@
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import vmware_content_library_item_info role
+      ansible.builtin.import_role:
+        name: vmware_content_library_item_info
+      tags:
+        - integration-ci
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_content_library_item_info/run.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/run.yml
@@ -2,6 +2,11 @@
   gather_facts: no
 
   tasks:
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
     - name: Import eco-vcenter credentials
       ansible.builtin.include_vars:
         file: ../../integration_config.yml

--- a/tests/integration/targets/vmware_content_library_item_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Test On Eco Datacenter
+  when: not run_on_simulator
+  block:
+    - name: Import common vars
+      ansible.builtin.include_vars:
+        file: ../group_vars.yml
+
+    - name: Gather Library Info
+      vmware.vmware.content_library_item_info:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+        library_name: "{{ library_name }}"
+      register: __res
+
+    - name: Assert values
+      ansible.builtin.assert:
+        that:
+          - __res.changed == False
+          - (__res.library_item_info | length) > 0
+
+    - name: Gather Fake Library Info
+      vmware.vmware.content_library_item_info:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+        library_item_name: should_not_exist
+      register: __res
+
+    - name: Assert values
+      ansible.builtin.assert:
+        that:
+          - __res.changed == False
+          - (__res.library_item_info | length) == 0

--- a/tests/integration/targets/vmware_content_library_item_info/vars.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/vars.yml
@@ -1,0 +1,6 @@
+vcenter_hostname: "127.0.0.1"
+vcenter_username: "user"
+vcenter_password: "pass"
+vcenter_port: 1080
+
+run_on_simulator: true

--- a/tests/integration/targets/vmware_content_library_item_info/vars.yml
+++ b/tests/integration/targets/vmware_content_library_item_info/vars.yml
@@ -1,6 +1,0 @@
-vcenter_hostname: "127.0.0.1"
-vcenter_username: "user"
-vcenter_password: "pass"
-vcenter_port: 1080
-
-run_on_simulator: true

--- a/tests/unit/plugins/modules/test_content_library_item_info.py
+++ b/tests/unit/plugins/modules/test_content_library_item_info.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules import content_library_item_info
+
+from .common.utils import (
+    AnsibleExitJson, ModuleTestCase, set_module_args,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestGuestInfo(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        init_mock = mocker.patch.object(content_library_item_info.ContentLibaryItemInfo, "__init__")
+        init_mock.return_value = None
+
+        library_item_ids = mocker.patch.object(content_library_item_info.ContentLibaryItemInfo, "get_library_item_ids")
+        library_item_ids.return_value = []
+
+    def test_gather(self, mocker):
+        self.__prepare(mocker)
+
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=False,
+        )
+
+        with pytest.raises(AnsibleExitJson) as c:
+            content_library_item_info.main()
+
+        assert c.value.args[0]["changed"] is False

--- a/tests/unit/plugins/modules/test_content_library_item_info.py
+++ b/tests/unit/plugins/modules/test_content_library_item_info.py
@@ -21,7 +21,7 @@ class TestGuestInfo(ModuleTestCase):
         init_mock = mocker.patch.object(content_library_item_info.ContentLibaryItemInfo, "__init__")
         init_mock.return_value = None
 
-        library_item_ids = mocker.patch.object(content_library_item_info.ContentLibaryItemInfo, "get_library_item_ids")
+        library_item_ids = mocker.patch.object(content_library_item_info.ContentLibaryItemInfo, "get_relevant_library_item_ids_by_params")
         library_item_ids.return_value = []
 
     def test_gather(self, mocker):
@@ -32,10 +32,6 @@ class TestGuestInfo(ModuleTestCase):
             username="administrator@local",
             password="123456",
             add_cluster=False,
-            library_id=None,
-            library_name=None,
-            library_item_id=None,
-            library_item_name=None,
         )
 
         with pytest.raises(AnsibleExitJson) as c:

--- a/tests/unit/plugins/modules/test_content_library_item_info.py
+++ b/tests/unit/plugins/modules/test_content_library_item_info.py
@@ -32,6 +32,10 @@ class TestGuestInfo(ModuleTestCase):
             username="administrator@local",
             password="123456",
             add_cluster=False,
+            library_id=None,
+            library_name=None,
+            library_item_id=None,
+            library_item_name=None,
         )
 
         with pytest.raises(AnsibleExitJson) as c:


### PR DESCRIPTION
##### SUMMARY
This is migrating the content_library_item_info from the vmware_rest collection to here. The auto-generated module in the rest collection does not work due to an issue with the OpenAPI spec, so its easier to add the functionality to this collection instead.

I also consolidated some of the content library shared methods in the rest api module_util

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
content_library_item_info
