### PR TITLE
fix bug where inputs were silently ignored

### DIFF
--- a/changelogs/fragments/83-fix-content-library-item-info-args.yml
+++ b/changelogs/fragments/83-fix-content-library-item-info-args.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - content_library_item_info - Library name and ID are ignored if item ID is provided so updated docs and arg parse rules to reflect this

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -42,6 +42,7 @@ options:
         description:
             - The ID of the library item for which to search.
             - Mutually exclusive with O(library_item_name).
+            - Also mutually exclusive with O(library_id), and O(library_name) since item IDs are unique within a vCenter.
             - If O(library_id) or O(library_name) are defined, only items in that library will be included in the results.
             - If neither O(library_item_id) nor O(library_item_name) are provided, all items in the relevant libraries will be returned.
         type: str
@@ -226,7 +227,9 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[
             ('library_id', 'library_name'),
-            ('library_item_id', 'library_item_name')
+            ('library_item_id', 'library_item_name'),
+            ('library_item_id', 'library_id'),
+            ('library_item_id', 'library_name')
         ],
     )
 


### PR DESCRIPTION
##### SUMMARY
The library item name and id are ignored if library item id is provided. This is because the library item id is unique within a vcenter. This pr updates the documentation to reflect that and will stop the user from performing a nonsensical query

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
content_library_item_info

