### PR TITLE
Feature/standardize pyvmomi method names

### DIFF
--- a/changelogs/fragments/86-standardize-pyvmomi-methods.yml
+++ b/changelogs/fragments/86-standardize-pyvmomi-methods.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - _vmware - standardize getter method names and return values

--- a/changelogs/fragments/86-standardize-pyvmomi-methods.yml
+++ b/changelogs/fragments/86-standardize-pyvmomi-methods.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - _vmware - standardize getter method names and return values

--- a/changelogs/fragments/88-standardize-pyvmomi-methods.yml
+++ b/changelogs/fragments/88-standardize-pyvmomi-methods.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - _vmware - standardize getter method names and documentation

--- a/plugins/module_utils/_vmware.py
+++ b/plugins/module_utils/_vmware.py
@@ -262,11 +262,12 @@ class PyVmomi(object):
             # for backwards-compat
             return None
 
-    def get_dvs_portgroup_by_name_or_moid(self, identifier, fail_on_missing=False):
+    def get_standard_portgroup_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
         Get a portgroup from type 'STANDARD_PORTGROUP' based on name or MOID
         Args:
             identifier: The name or the ID of the portgroup
+            fail_on_missing: If true, an error will be thrown if no networks are found
         Returns:
             The standard portgroup object
         """
@@ -280,6 +281,7 @@ class PyVmomi(object):
         Get a portgroup from type 'DISTRIBUTED_PORTGROUP' based on name or MOID
         Args:
             identifier: The name or the ID of the portgroup
+            fail_on_missing: If true, an error will be thrown if no networks are found
         Returns:
             The distributed portgroup object
         """
@@ -344,7 +346,7 @@ class PyVmomi(object):
 
     def get_folders_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
-            Get all folders with the given name. Names are not unique
+            Get all folders with the given name or MOID. Names are not unique
             in a given cluster, so multiple folder objects can be returned
             Args:
                 identifier: Name or MOID of the folder to search for
@@ -376,7 +378,7 @@ class PyVmomi(object):
 
     def get_datastore_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
-            Get the datastore matching the given name. Datastore names must be unique
+            Get the datastore matching the given name or MOID. Datastore names must be unique
             in a given cluster, so only one object is returned at most.
             Args:
                 identifier: Name or MOID of the datastore to search for
@@ -391,7 +393,7 @@ class PyVmomi(object):
 
     def get_resource_pool_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
-            Get the resource pool matching the given name. Pool names must be unique
+            Get the resource pool matching the given name or MOID. Pool names must be unique
             in a given cluster, so only one object is returned at most.
             Args:
                 identifier: Name or MOID of the pool to search for
@@ -443,7 +445,7 @@ class PyVmomi(object):
 
     def get_datacenter_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
-            Get the datacenter matching the given name. Datacenter names must be unique
+            Get the datacenter matching the given name or MOID. Datacenter names must be unique
             in a given vcenter, so only one object is returned at most.
             Args:
                 identifier: Name or MOID of the datacenter to search for
@@ -458,11 +460,13 @@ class PyVmomi(object):
 
     def get_cluster_by_name_or_moid(self, identifier, fail_on_missing=False, datacenter=None):
         """
-            Get the cluster matching the given name. Cluster names must be unique
+            Get the cluster matching the given name or MOID. Cluster names must be unique
             in a given vcenter, so only one object is returned at most.
             Args:
                 identifier: Name or MOID of the cluster to search for
                 fail_on_missing: If true, an error will be thrown if no clusters are found
+                datacenter: The datacenter object to use as a filter when searching for clusters. If
+                            not provided then all datacenters will be examined
             Returns:
                 cluster object or None
         """

--- a/plugins/module_utils/_vmware.py
+++ b/plugins/module_utils/_vmware.py
@@ -262,25 +262,31 @@ class PyVmomi(object):
             # for backwards-compat
             return None
 
-    def get_standard_portgroup(self, portgroup):
+    def get_dvs_portgroup_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
-        Get a portgroup from type 'STANDARD_PORTGROUP'
+        Get a portgroup from type 'STANDARD_PORTGROUP' based on name or MOID
         Args:
-            portgroup: The name or the ID of the portgroup
+            identifier: The name or the ID of the portgroup
         Returns:
             The standard portgroup object
         """
-        return self.get_objs_by_name_or_moid([vim.Network], portgroup)
+        pg = self.get_objs_by_name_or_moid([vim.Network], identifier)
+        if not pg and fail_on_missing:
+            self.module.fail_json("Unable to find standard portgroup with name or MOID %s" % identifier)
+        return pg
 
-    def get_dvs_portgroup(self, portgroup):
+    def get_dvs_portgroup_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
-        Get a portgroup from type 'DISTRIBUTED_PORTGROUP'
+        Get a portgroup from type 'DISTRIBUTED_PORTGROUP' based on name or MOID
         Args:
-            portgroup: The name or the ID of the portgroup
+            identifier: The name or the ID of the portgroup
         Returns:
             The distributed portgroup object
         """
-        return self.get_objs_by_name_or_moid([vim.dvs.DistributedVirtualPortgroup], portgroup)
+        pg = self.get_objs_by_name_or_moid([vim.dvs.DistributedVirtualPortgroup], identifier)
+        if not pg and fail_on_missing:
+            self.module.fail_json("Unable to find distributed portgroup with name or MOID %s" % identifier)
+        return pg
 
     def get_vm_using_params(
             self, name_param='name', uuid_param='uuid', moid_param='moid', fail_on_missing=False,
@@ -336,19 +342,19 @@ class PyVmomi(object):
 
         return vms
 
-    def get_folder_by_name(self, folder_name, fail_on_missing=False):
+    def get_folders_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
             Get all folders with the given name. Names are not unique
             in a given cluster, so multiple folder objects can be returned
             Args:
-                folder_name: Name of the folder to search for
+                identifier: Name or MOID of the folder to search for
                 fail_on_missing: If true, an error will be thrown if no folders are found
             Returns:
                 list(folder object) or None
         """
-        folder = self.get_objs_by_name_or_moid([vim.Folder], folder_name, return_all=True)
+        folder = self.get_objs_by_name_or_moid([vim.Folder], identifier, return_all=True)
         if not folder and fail_on_missing:
-            self.module.fail_json("Unable to find folder with name %s" % folder_name)
+            self.module.fail_json("Unable to find folder with name or MOID %s" % identifier)
         return folder
 
     def get_folder_by_absolute_path(self, folder_path, fail_on_missing=False):
@@ -368,39 +374,39 @@ class PyVmomi(object):
             self.module.fail_json("Unable to find folder with absolute path %s" % folder_path)
         return folder
 
-    def get_datastore_by_name(self, ds_name, fail_on_missing=False):
+    def get_datastore_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
             Get the datastore matching the given name. Datastore names must be unique
             in a given cluster, so only one object is returned at most.
             Args:
-                ds_name: Name of the datastore to search for
+                identifier: Name or MOID of the datastore to search for
                 fail_on_missing: If true, an error will be thrown if no datastores are found
             Returns:
                 datastore object or None
         """
-        ds = self.get_objs_by_name_or_moid([vim.Datastore], ds_name)
+        ds = self.get_objs_by_name_or_moid([vim.Datastore], identifier)
         if not ds and fail_on_missing:
-            self.module.fail_json("Unable to find datastore with name %s" % ds_name)
+            self.module.fail_json("Unable to find datastore with name or MOID %s" % identifier)
         return ds
 
-    def get_resource_pool_by_name(self, pool_name, fail_on_missing=False):
+    def get_resource_pool_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
             Get the resource pool matching the given name. Pool names must be unique
             in a given cluster, so only one object is returned at most.
             Args:
-                pool_name: Name of the pool to search for
+                identifier: Name or MOID of the pool to search for
                 fail_on_missing: If true, an error will be thrown if no pools are found
             Returns:
                 resource pool object or None
         """
-        pool = self.get_objs_by_name_or_moid([vim.ResourcePool], pool_name)
+        pool = self.get_objs_by_name_or_moid([vim.ResourcePool], identifier)
         if not pool and fail_on_missing:
-            self.module.fail_json("Unable to find resource pool with name %s" % pool_name)
+            self.module.fail_json("Unable to find resource pool with name %s" % identifier)
         return pool
 
-    def list_all_objs_by_type(self, vimtype, folder=None, recurse=True):
+    def get_all_objs_by_type(self, vimtype, folder=None, recurse=True):
         """
-            Returns a dictionary of all objects matching a given VMWare type.
+            Returns a list of all objects matching a given VMWare type.
             You can also limit the search by folder and recurse if desired
             Args:
                 vimtype: The type of object to search for
@@ -408,48 +414,54 @@ class PyVmomi(object):
                         none is provided, the datacenter root will be used
                 recurse: If true, the search will recurse through the folder structure
             Returns:
-                dicttionary of {obj: str}. The keys are the object while the values are the
-                object name
+                list of objs
         """
         if not folder:
             folder = self.content.rootFolder
 
-        obj = {}
+        objs = []
         container = self.content.viewManager.CreateContainerView(folder, vimtype, recurse)
         for managed_object_ref in container.view:
             try:
-                obj.update({managed_object_ref: managed_object_ref.name})
+                objs += [managed_object_ref]
             except vmodl.fault.ManagedObjectNotFound:
                 pass
-        return obj
+        return objs
 
     def get_all_vms(self, folder=None, recurse=True):
         """
-        Get all virtual machines.
+            Get all virtual machines in a folder. Can recurse through folder tree if needed. If no folder
+            is provided, then the datacenter root folder is used
+            Args:
+                folder: vim.Folder, the folder object to use as a base for the search. If
+                        none is provided, the datacenter root will be used
+                recurse: If true, the search will recurse through the folder structure
+            Returns:
+                list of vim.VirtualMachine
         """
-        return self.list_all_objs_by_type([vim.VirtualMachine], folder=folder, recurse=recurse)
+        return self.get_all_objs_by_type([vim.VirtualMachine], folder=folder, recurse=recurse)
 
-    def get_datacenter_by_name(self, dc_name, fail_on_missing=False):
+    def get_datacenter_by_name_or_moid(self, identifier, fail_on_missing=False):
         """
             Get the datacenter matching the given name. Datacenter names must be unique
             in a given vcenter, so only one object is returned at most.
             Args:
-                dc_name: Name of the datacenter to search for
+                identifier: Name or MOID of the datacenter to search for
                 fail_on_missing: If true, an error will be thrown if no datacenters are found
             Returns:
                 datacenter object or None
         """
-        ds = self.get_objs_by_name_or_moid([vim.Datacenter], dc_name)
+        ds = self.get_objs_by_name_or_moid([vim.Datacenter], identifier)
         if not ds and fail_on_missing:
-            self.module.fail_json("Unable to find datacenter with name %s" % dc_name)
+            self.module.fail_json("Unable to find datacenter with name or MOID %s" % identifier)
         return ds
 
-    def get_cluster_by_name(self, cluster_name, fail_on_missing=False, datacenter=None):
+    def get_cluster_by_name_or_moid(self, identifier, fail_on_missing=False, datacenter=None):
         """
             Get the cluster matching the given name. Cluster names must be unique
             in a given vcenter, so only one object is returned at most.
             Args:
-                cluster_name: Name of the cluster to search for
+                identifier: Name or MOID of the cluster to search for
                 fail_on_missing: If true, an error will be thrown if no clusters are found
             Returns:
                 cluster object or None
@@ -460,12 +472,12 @@ class PyVmomi(object):
 
         cluster = self.get_objs_by_name_or_moid(
             [vim.ClusterComputeResource],
-            cluster_name,
+            identifier,
             return_all=False,
             search_root_folder=search_folder
         )
 
         if not cluster and fail_on_missing:
-            self.module.fail_json("Unable to find cluster with name %s" % cluster_name)
+            self.module.fail_json("Unable to find cluster with name or MOID %s" % identifier)
 
         return cluster

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -152,9 +152,9 @@ class VMwareCluster(PyVmomi):
         Checks if cluster exists and compares that to the desired state.
         Returns: True if cluster state matches desired state, False otherwise
         """
-        self.datacenter_obj = self.get_datacenter_by_name(self.params['datacenter'], fail_on_missing=True)
-        self.cluster_obj = self.get_cluster_by_name(
-            cluster_name=self.params['cluster'],
+        self.datacenter_obj = self.get_datacenter_by_name_or_moid(self.params['datacenter'], fail_on_missing=True)
+        self.cluster_obj = self.get_cluster_by_name_or_moid(
+            identifier=self.params['cluster'],
             datacenter=self.datacenter_obj,
             fail_on_missing=False
         )

--- a/plugins/modules/cluster_dpm.py
+++ b/plugins/modules/cluster_dpm.py
@@ -128,8 +128,8 @@ class VMwareCluster(PyVmomi):
     def __init__(self, module):
         super(VMwareCluster, self).__init__(module)
 
-        datacenter = self.get_datacenter_by_name(self.params.get('datacenter'), fail_on_missing=True)
-        self.cluster = self.get_cluster_by_name(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
+        datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
+        self.cluster = self.get_cluster_by_name_or_moid(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
 
     @property
     def automation_level(self):

--- a/plugins/modules/cluster_drs.py
+++ b/plugins/modules/cluster_drs.py
@@ -156,8 +156,8 @@ class VMwareCluster(PyVmomi):
     def __init__(self, module):
         super(VMwareCluster, self).__init__(module)
 
-        datacenter = self.get_datacenter_by_name(self.params.get('datacenter'), fail_on_missing=True)
-        self.cluster = self.get_cluster_by_name(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
+        datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
+        self.cluster = self.get_cluster_by_name_or_moid(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
 
         self.enable_drs = self.params.get('enable')
         self.drs_enable_vm_behavior_overrides = self.params.get('drs_enable_vm_behavior_overrides')

--- a/plugins/modules/cluster_drs_recommendations.py
+++ b/plugins/modules/cluster_drs_recommendations.py
@@ -109,8 +109,8 @@ from ansible.module_utils._text import to_native
 class VMwareCluster(PyVmomi):
     def __init__(self, module):
         super(VMwareCluster, self).__init__(module)
-        datacenter = self.get_datacenter_by_name(self.params.get('datacenter'), fail_on_missing=True)
-        self.cluster = self.get_cluster_by_name(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
+        datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
+        self.cluster = self.get_cluster_by_name_or_moid(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
 
     def get_recommendations(self):
         """

--- a/plugins/modules/cluster_info.py
+++ b/plugins/modules/cluster_info.py
@@ -177,19 +177,19 @@ class ClusterInfo(PyVmomi):
         """
         datacenter, search_folder = None, None
         if self.params.get('datacenter'):
-            datacenter = self.get_datacenter_by_name(self.params.get('datacenter'), fail_on_missing=False)
+            datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=False)
             search_folder = datacenter.hostFolder
 
         if self.params.get('cluster'):
-            _cluster = self.get_cluster_by_name(self.params.get('cluster'), fail_on_missing=False, datacenter=datacenter)
+            _cluster = self.get_cluster_by_name_or_moid(self.params.get('cluster'), fail_on_missing=False, datacenter=datacenter)
             return [_cluster] if _cluster else []
         else:
-            _clusters = self.list_all_objs_by_type(
+            _clusters = self.get_all_objs_by_type(
                 [vim.ClusterComputeResource],
                 folder=search_folder,
                 recurse=False
             )
-            return _clusters.keys()
+            return _clusters
 
     def gather_info_for_clusters(self):
         """

--- a/plugins/modules/cluster_vcls.py
+++ b/plugins/modules/cluster_vcls.py
@@ -150,11 +150,11 @@ class VMwareClusterVcls(PyVmomi):
     def __init__(self, module):
         super(VMwareClusterVcls, self).__init__(module)
         if module.params.get('datacenter'):
-            datacenter = self.get_datacenter_by_name(module.params['datacenter'], fail_on_missing=True)
+            datacenter = self.get_datacenter_by_name_or_moid(module.params['datacenter'], fail_on_missing=True)
         else:
             datacenter = None
 
-        self.cluster = self.get_cluster_by_name(module.params['cluster'], datacenter=datacenter, fail_on_missing=True)
+        self.cluster = self.get_cluster_by_name_or_moid(module.params['cluster'], datacenter=datacenter, fail_on_missing=True)
 
     def get_current_configured_datastores(self):
         """
@@ -198,7 +198,7 @@ class VMwareClusterVcls(PyVmomi):
         Adds a datastore to the potential new vCLS spec. Causes a failure if the datastore does not exist.
         """
         allowed_datastore_spec = vim.cluster.DatastoreUpdateSpec()
-        allowed_datastore_spec.datastore = self.get_datastore_by_name(ds_name, fail_on_missing=True)
+        allowed_datastore_spec.datastore = self.get_datastore_by_name_or_moid(ds_name, fail_on_missing=True)
         allowed_datastore_spec.operation = 'add'
         cluster_config_spec.systemVMsConfig.allowedDatastores.append(allowed_datastore_spec)
 
@@ -207,7 +207,7 @@ class VMwareClusterVcls(PyVmomi):
         Removes a datastore from the potential new vCLS spec
         """
         allowed_datastore_spec = vim.cluster.DatastoreUpdateSpec()
-        allowed_datastore_spec.removeKey = self.get_datastore_by_name(ds_name, fail_on_missing=False)
+        allowed_datastore_spec.removeKey = self.get_datastore_by_name_or_moid(ds_name, fail_on_missing=False)
         allowed_datastore_spec.operation = 'remove'
         cluster_config_spec.systemVMsConfig.allowedDatastores.append(allowed_datastore_spec)
 

--- a/plugins/modules/folder_template_from_vm.py
+++ b/plugins/modules/folder_template_from_vm.py
@@ -236,12 +236,12 @@ class VmwareFolderTemplate(PyVmomi):
     def __create_template_location_spec(self):
         template_location_spec = vim.vm.RelocateSpec()
         if self.params.get("datastore"):
-            template_location_spec.datastore = self.get_datastore_by_name(
+            template_location_spec.datastore = self.get_datastore_by_name_or_moid(
                 self.params.get("datastore"),
                 fail_on_missing=True)
 
         if self.params.get("resource_pool"):
-            template_location_spec.pool = self.get_resource_pool_by_name(
+            template_location_spec.pool = self.get_resource_pool_by_name_or_moid(
                 self.params.get("resource_pool"),
                 fail_on_missing=True)
 

--- a/plugins/modules/vm_portgroup_info.py
+++ b/plugins/modules/vm_portgroup_info.py
@@ -77,7 +77,7 @@ class PortgroupInfo(PyVmomi):
         self.vms = self.params['vm_names']
 
     def get_dvs_portgroup_detailed(self, pg_id):
-        dvs_pg = self.get_dvs_portgroup(pg_id)
+        dvs_pg = self.get_dvs_portgroup_by_name_or_moid(pg_id)
         pg = {'portgroup_name': dvs_pg.name, 'vswitch_name': dvs_pg.config.distributedVirtualSwitch.name,
               'type': 'DISTRIBUTED_PORTGROUP', 'port_id': pg_id,
               'port_binding': vmware_network.get_dvs_port_allocation(dvs_pg.config.type),
@@ -98,7 +98,7 @@ class PortgroupInfo(PyVmomi):
         return pg
 
     def get_standard_portgroup_detailed(self, pg_id):
-        pg = self.get_standard_portgroup(pg_id)
+        pg = self.get_standard_portgroup_by_name_or_moid(pg_id)
         pg_name = str(pg.summary.name)
         ret_pg = vmware_network.get_standard_portgroup_vlan_vswitch(pg, pg_name)
         ret_pg['port_id'] = pg_id


### PR DESCRIPTION
##### SUMMARY
This is preparing the pymomi module utils to be made public. There are two main changes in this PR, all relating to module_utils/_vmware

1. Standardize the get_<something>_by_name_or_moid methods. These methods are all very similar but some slightly differ just because they were written at different times. This change updates the names to be both descriptive and similar to one another, updates documentation for the methods to be similar to one another, and adds an optional parameter to throw a standard error if the search comes back empty

2. `list_all_objs_by_type` doesnt match the get_ method name pattern we have and needlessly return a dict. Updated the name to be `get_all....` and changed the return value to a list, like the other methods

There should be no change in functionality.

I am not able to update the rest utils yet. I think i see some possible bugs with the current methods and I want to confirm and fix those first

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_utils/_vmware
