### PR TITLE
fix content_template library_id reference in delete

### DIFF
--- a/changelogs/fragments/92-fix-reference-in-content-template.yml
+++ b/changelogs/fragments/92-fix-reference-in-content-template.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - content_template - Fix bad reference of library variable that was refactored to library_id

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -181,7 +181,7 @@ class VmwareContentTemplate(VmwareRestClient):
         )
 
     def delete_template(self):
-        _template = self.get_library_item_ids(name=self.template, library_id=self.library)
+        _template = self.get_library_item_ids(name=self.template, library_id=self.library_id)
         if not _template:
             self.result['template_info'] = dict(
                 msg="Template '%s' doesn't exists." % self.template,

--- a/tests/integration/targets/vmware_content_template/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_template/tasks/main.yml
@@ -60,6 +60,20 @@
           - __res.template_info.msg == "Template '" + template_name + "'."
       when: not run_on_simulator
 
+    - name: Delete template from content library
+      vmware.vmware.content_template:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+        template: "{{ template_name }}"
+        library: "{{ library }}"
+        vm_name: "{{ vm }}"
+        host: "{{ template_host }}"
+        state: absent
+      when: not run_on_simulator
+
   always:
     - name: "Test teardown: Destroy VM guest {{ vm }}"
       community.vmware.vmware_guest:

--- a/tests/integration/targets/vmware_content_template/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_template/tasks/main.yml
@@ -74,6 +74,23 @@
         state: absent
       when: not run_on_simulator
 
+    - name: Check for deleted template
+      vmware.vmware.content_library_item_info:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+        library_name: "{{ library }}"
+        library_item_name: "{{ template_name }}"
+      register: __res
+      when: not run_on_simulator
+
+    - name: Verify Template Was Deleted
+      ansible.builtin.assert:
+        that: (__res.library_item_info | length) == 0
+        when: not run_on_simulator
+
   always:
     - name: "Test teardown: Destroy VM guest {{ vm }}"
       community.vmware.vmware_guest:

--- a/tests/integration/targets/vmware_content_template/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_template/tasks/main.yml
@@ -89,7 +89,7 @@
     - name: Verify Template Was Deleted
       ansible.builtin.assert:
         that: (__res.library_item_info | length) == 0
-        when: not run_on_simulator
+      when: not run_on_simulator
 
   always:
     - name: "Test teardown: Destroy VM guest {{ vm }}"


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/90

While refactoring the content_template module, one variable reference was missed. There are no tests for the spot that this issue occurred. I fixed the variable and added tests to cover this spot.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
content_template
