### PR TITLE
feature/update_module_bases

### DIFF
--- a/changelogs/fragments/95-use-client-utils-in-modules.yml
+++ b/changelogs/fragments/95-use-client-utils-in-modules.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - pyvmomi module base - refactor class to use the pyvmomi shared client util class as a base
+  - rest module base - refactor class to use the rest shared client util class as a base

--- a/plugins/modules/appliance_info.py
+++ b/plugins/modules/appliance_info.py
@@ -179,11 +179,11 @@ appliance:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import rest_compatible_argument_spec
 
 
-class VmwareApplianceInfo(VmwareRestClient):
+class VmwareApplianceInfo(ModuleRestBase):
     def __init__(self, module):
         super(VmwareApplianceInfo, self).__init__(module)
         self.module = module

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -92,8 +92,8 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     base_argument_spec
@@ -104,7 +104,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import
 )
 
 
-class VMwareCluster(PyVmomi):
+class VMwareCluster(ModulePyvmomiBase):
     def __init__(self, module):
         super(VMwareCluster, self).__init__(module)
         self.datacenter_obj = None

--- a/plugins/modules/cluster_dpm.py
+++ b/plugins/modules/cluster_dpm.py
@@ -109,8 +109,8 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     base_argument_spec
@@ -126,7 +126,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vmware_facts import
 from ansible.module_utils._text import to_native
 
 
-class VMwareCluster(PyVmomi):
+class VMwareCluster(ModulePyvmomiBase):
     def __init__(self, module):
         super(VMwareCluster, self).__init__(module)
 

--- a/plugins/modules/cluster_drs.py
+++ b/plugins/modules/cluster_drs.py
@@ -135,8 +135,8 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     base_argument_spec
@@ -154,7 +154,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vmware_type_utils i
 from ansible.module_utils._text import to_native
 
 
-class VMwareCluster(PyVmomi):
+class VMwareCluster(ModulePyvmomiBase):
     def __init__(self, module):
         super(VMwareCluster, self).__init__(module)
 

--- a/plugins/modules/cluster_drs_recommendations.py
+++ b/plugins/modules/cluster_drs_recommendations.py
@@ -95,8 +95,8 @@ except ImportError:
 
 from itertools import zip_longest
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     base_argument_spec
@@ -108,7 +108,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import
 from ansible.module_utils._text import to_native
 
 
-class VMwareCluster(PyVmomi):
+class VMwareCluster(ModulePyvmomiBase):
     def __init__(self, module):
         super(VMwareCluster, self).__init__(module)
         datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)

--- a/plugins/modules/cluster_info.py
+++ b/plugins/modules/cluster_info.py
@@ -156,25 +156,25 @@ try:
 except ImportError:
     pass
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     rest_compatible_argument_spec
 )
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_facts import (
     ClusterFacts,
     vmware_obj_to_json
 )
 
 
-class ClusterInfo(PyVmomi):
+class ClusterInfo(ModulePyvmomiBase):
     def __init__(self, module):
         super(ClusterInfo, self).__init__(module)
         self.rest_client = None
         if module.params['gather_tags']:
-            self.rest_client = VmwareRestClient(module)
+            self.rest_client = ModuleRestBase(module)
 
     def get_clusters(self):
         """

--- a/plugins/modules/cluster_vcls.py
+++ b/plugins/modules/cluster_vcls.py
@@ -136,8 +136,8 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     base_argument_spec
@@ -148,7 +148,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import
 )
 
 
-class VMwareClusterVcls(PyVmomi):
+class VMwareClusterVcls(ModulePyvmomiBase):
     def __init__(self, module):
         super(VMwareClusterVcls, self).__init__(module)
         if module.params.get('datacenter'):

--- a/plugins/modules/content_library_item_info.py
+++ b/plugins/modules/content_library_item_info.py
@@ -153,11 +153,11 @@ library_item_info:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import rest_compatible_argument_spec
 
 
-class ContentLibaryItemInfo(VmwareRestClient):
+class ContentLibaryItemInfo(ModuleRestBase):
     def __init__(self, module):
         super(ContentLibaryItemInfo, self).__init__(module)
 

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -108,7 +108,7 @@ template_info:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import rest_compatible_argument_spec
 from ansible.module_utils._text import to_native
 
@@ -121,7 +121,7 @@ except ImportError:
     pass
 
 
-class VmwareContentTemplate(VmwareRestClient):
+class VmwareContentTemplate(ModuleRestBase):
     def __init__(self, module):
         """Constructor."""
         super(VmwareContentTemplate, self).__init__(module)

--- a/plugins/modules/folder_template_from_vm.py
+++ b/plugins/modules/folder_template_from_vm.py
@@ -143,8 +143,8 @@ RETURN = r'''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     base_argument_spec
@@ -161,7 +161,7 @@ except ImportError:
     HAS_PYVMOMI = False
 
 
-class VmwareFolderTemplate(PyVmomi):
+class VmwareFolderTemplate(ModulePyvmomiBase):
     def __init__(self, module):
         super(VmwareFolderTemplate, self).__init__(module)
         if not self.is_vcenter():

--- a/plugins/modules/guest_info.py
+++ b/plugins/modules/guest_info.py
@@ -171,8 +171,8 @@ guests:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import PyVmomi
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import ModulePyvmomiBase
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import rest_compatible_argument_spec
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_facts import (
     VmFacts,
@@ -181,10 +181,10 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vmware_facts import
 )
 
 
-class VmwareGuestInfo(VmwareRestClient):
+class VmwareGuestInfo(ModuleRestBase):
     def __init__(self, module):
         super(VmwareGuestInfo, self).__init__(module)
-        self.pyvmomi = PyVmomi(module)
+        self.pyvmomi = ModulePyvmomiBase(module)
         self.vm_svc = self.api_client.vcenter.vm
 
     def _get_env(self, vm):

--- a/plugins/modules/license_info.py
+++ b/plugins/modules/license_info.py
@@ -44,15 +44,15 @@ licenses:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import (
-    PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
     base_argument_spec
 )
 
 
-class VcenterLicenseMgr(PyVmomi):
+class VcenterLicenseMgr(ModulePyvmomiBase):
     def __init__(self, module):
         super(VcenterLicenseMgr, self).__init__(module)
 

--- a/plugins/modules/vcsa_settings.py
+++ b/plugins/modules/vcsa_settings.py
@@ -242,11 +242,11 @@ vcsa_settings:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import rest_compatible_argument_spec
 
 
-class VmwareVcsaSettings(VmwareRestClient):
+class VmwareVcsaSettings(ModuleRestBase):
     def __init__(self, module):
         super(VmwareVcsaSettings, self).__init__(module)
         self.api_system = self.api_client.appliance.system

--- a/plugins/modules/vm_list_group_by_clusters_info.py
+++ b/plugins/modules/vm_list_group_by_clusters_info.py
@@ -115,11 +115,11 @@ vm_list_group_by_clusters_info:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import rest_compatible_argument_spec
 
 
-class VmwareVMList(VmwareRestClient):
+class VmwareVMList(ModuleRestBase):
     def __init__(self, module):
         super(VmwareVMList, self).__init__(module)
         self.module = module

--- a/plugins/modules/vm_portgroup_info.py
+++ b/plugins/modules/vm_portgroup_info.py
@@ -66,16 +66,16 @@ vm_portgroup_info:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware import PyVmomi
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import ModulePyvmomiBase
 from ansible_collections.vmware.vmware.plugins.module_utils import _vmware_network as vmware_network
-from ansible_collections.vmware.vmware.plugins.module_utils._vmware_rest_client import VmwareRestClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
 from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import rest_compatible_argument_spec
 
 
-class PortgroupInfo(PyVmomi):
+class PortgroupInfo(ModulePyvmomiBase):
     def __init__(self, module):
         super(PortgroupInfo, self).__init__(module)
-        self.vmware_client = VmwareRestClient(module)
+        self.vmware_client = ModuleRestBase(module)
         self.vms = self.params['vm_names']
 
     def get_dvs_portgroup_detailed(self, pg_id):

--- a/tests/unit/plugins/modules/common/utils.py
+++ b/tests/unit/plugins/modules/common/utils.py
@@ -6,7 +6,6 @@ import json
 
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from ansible_collections.vmware.vmware.plugins.module_utils import _vmware
 
 import mock
 
@@ -27,13 +26,6 @@ def set_module_args(add_cluster=True, **args):
 
     args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
     basic._ANSIBLE_ARGS = to_bytes(args)
-
-
-def mock_pyvmomi(mocker):
-    connect_to_api = mocker.patch.object(_vmware, "connect_to_api")
-    _content = type('', (), {})()
-    _content.customFieldsManager = False
-    connect_to_api.return_value = None, _content
 
 
 class DummyDatacenter:

--- a/tests/unit/plugins/modules/common/vmware_object_mocks.py
+++ b/tests/unit/plugins/modules/common/vmware_object_mocks.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+
 class MockClusterConfiguration():
     def __init__(self):
         self.dasConfig = None
@@ -5,16 +8,23 @@ class MockClusterConfiguration():
         self.drsConfig = None
 
 
-class MockCluster():
-    def __init__(self, name="test"):
+class MockVmwareObject():
+    def __init__(self, name="test", moid="1"):
+        self.name = name
+        self._moId = moid
+
+    def _GetMoId(self):
+        return self._moId
+
+
+class MockCluster(MockVmwareObject):
+    def __init__(self, name="test", moid="1"):
+        super().__init__(name=name, moid=moid)
         self.configurationEx = MockClusterConfiguration()
         self.host = []
 
-        self.name = name
-        self._moId = "1"
-
-        self.parent = type('', (), {})()
-        self.parent.parent = type('', (), {})()
+        self.parent = mock.Mock()
+        self.parent.parent = mock.Mock()
         self.parent.parent.name = "dc"
 
     def GetResourceUsage(self):

--- a/tests/unit/plugins/modules/test_utils_module_pyvmomi_base.py
+++ b/tests/unit/plugins/modules/test_utils_module_pyvmomi_base.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import ModulePyvmomiBase
+from ansible_collections.vmware.vmware.plugins.module_utils.clients._pyvmomi import (
+    PyvmomiClient
+)
+from .common.utils import set_module_args
+from .common.vmware_object_mocks import MockCluster
+
+
+class TestModulePyvmomiBase():
+
+    def __prepare(self, mocker):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        set_module_args()
+        self.base = ModulePyvmomiBase(
+            module=mocker.Mock()
+        )
+
+    def test_is_vcenter(self, mocker):
+        self.__prepare(mocker)
+        self.base.content.about.apiType = 'VirtualCenter'
+        assert self.base.is_vcenter() is True
+        self.base.content.about.apiType = 'HostAgent'
+        assert self.base.is_vcenter() is False
+
+    def test_get_objs_by_name_or_moid(self, mocker):
+        self.__prepare(mocker)
+        mock_view = mocker.Mock()
+        mock_view.view = [MockCluster('test1'), MockCluster('test2')]
+        mocker.patch.object(
+            self.base.content.viewManager , 'CreateContainerView',
+            return_value=mock_view
+        )
+        assert self.base.get_objs_by_name_or_moid('vimtype', 'test1')

--- a/tests/unit/plugins/modules/test_utils_module_rest_base.py
+++ b/tests/unit/plugins/modules/test_utils_module_rest_base.py
@@ -34,4 +34,3 @@ class TestModuleRestBase():
         mocker.patch.object(self.base.library_service, 'find', return_value=['1'])
 
         assert self.base.get_content_library_ids(name='foo') == ['1']
-

--- a/tests/unit/plugins/modules/test_utils_module_rest_base.py
+++ b/tests/unit/plugins/modules/test_utils_module_rest_base.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
+from ansible_collections.vmware.vmware.plugins.module_utils.clients._rest import (
+    VmwareRestClient
+)
+from .common.utils import set_module_args
+
+
+class TestModuleRestBase():
+
+    def __prepare(self, mocker):
+        mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=mocker.Mock())
+        set_module_args()
+        self.base = ModuleRestBase(
+            module=mocker.Mock()
+        )
+
+    def test_get_vm_by_name(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(self.base.api_client.vcenter.VM, 'list', return_value=['vm_id'])
+        assert self.base.get_vm_by_name('foo') == 'vm_id'
+
+        mocker.patch.object(self.base.api_client.vcenter.VM, 'list', return_value=[])
+        assert self.base.get_vm_by_name('foo') is None
+
+    def test_get_content_library_ids(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(self.base.library_service, 'list', return_value=['1', '2', '3'])
+        assert self.base.get_content_library_ids() == ['1', '2', '3']
+
+        mocker.patch.object(self.base.library_service, 'FindSpec')
+        mocker.patch.object(self.base.library_service, 'find', return_value=['1'])
+
+        assert self.base.get_content_library_ids(name='foo') == ['1']
+


### PR DESCRIPTION
##### SUMMARY
This change updates the modules to use the new client pyvmomi/rest classes that were created with the last release. By using these client classes, a lot of code that was in the original module base classes can be removed.

The code that is in the client classes is shared by plugins and modules. Theres still a lot of methods that are used by modules only and include module specific logic. Those methods are staying in the module base classes

I also added some unit tests to cover the basic. I think ill open another PR to add tests to cover most/all methods in these classes.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pvmomi module base class - _vmware.py
rest  module base class - _vmware_rest.py