### PR TITLE
replace readme relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ System programmers can enable pipelines to setup, tear down and deploy VMs while
 
 ## Requirements
 
-The host running the tasks must have the python requirements described in [requirements.txt](./requirements.txt)
+The host running the tasks must have the python requirements described in [requirements.txt](https://github.com/ansible-collections/vmware.vmware/blob/main/requirements.txt)
 Once the collection is installed, you can install them into a python environment using pip: `pip install -r ~/.ansible/collections/ansible_collections/vmware/vmware/requirements.txt`
 
 ### Ansible version compatibility
@@ -75,8 +75,8 @@ ansible-galaxy collection install vmware.vmware:1.0.0
 
 All releases will meet the following test criteria.
 
-* 100% success for [Integration](./tests/integration) tests.
-* 100% success for [Unit](./tests/unit) tests.
+* 100% success for [Integration](https://github.com/ansible-collections/vmware.vmware/blob/main/tests/integration) tests.
+* 100% success for [Unit](https://github.com/ansible-collections/vmware.vmware/blob/main/tests/unit) tests.
 * 100% success for [Sanity](https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/index.html#all-sanity-tests) tests as part of [ansible-test](https://docs.ansible.com/ansible/latest/dev_guide/testing.html#run-sanity-tests).
 * 100% success for [ansible-lint](https://ansible.readthedocs.io/projects/lint/) allowing only false positives.
 
@@ -112,7 +112,7 @@ If a support case cannot be opened with Red Hat and the collection has been obta
 ## Release Notes and Roadmap
 
 A list of available releases can be found on the github [release page](https://github.com/ansible-collections/vmware.vmware/releases).
-A changelog may be found attached to the release, or in the [CHANGELOG.rst](CHANGELOG.rst)
+A changelog may be found attached to the release, or in the [CHANGELOG.rst](https://github.com/ansible-collections/vmware.vmware/blob/main/CHANGELOG.rst)
 
 Note, some collections release before an ansible-core version reaches End of Life (EOL), thus the version of ansible-core that is supported must be a version that is currently supported.
 For AAP users, to see the supported ansible-core versions, review the [AAP Life Cycle](https://access.redhat.com/support/policy/updates/ansible-automation-platform).
@@ -128,4 +128,4 @@ The `community.vmware` collection offers additional community supported function
 ## License Information
 
 GNU General Public License v3.0 or later
-See [LICENSE](LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/vmware.vmware/blob/main/LICENSE) to see the full text.

--- a/changelogs/fragments/98-fix-relative-links-in-readme.yml
+++ b/changelogs/fragments/98-fix-relative-links-in-readme.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - README - replace relative links with absolute links


### PR DESCRIPTION
##### SUMMARY
Replacing relative links in the README with absolute ones. The relative links do not work in Automation Hub/Galaxy

##### ISSUE TYPE
- Docs Pull Request