### PR TITLE
fix missing lib error message

### DIFF
--- a/changelogs/fragments/101-fix-missing-lib-error.yml
+++ b/changelogs/fragments/101-fix-missing-lib-error.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - client utils - Fixed error message when required library could not be imported

--- a/plugins/module_utils/clients/_errors.py
+++ b/plugins/module_utils/clients/_errors.py
@@ -11,4 +11,4 @@ class MissingLibError(Exception):
         self.exception = exception
         self.library = library
         self.url = url
-        super().__init__(msg=missing_required_lib(self.library, url=self.url))
+        super().__init__(missing_required_lib(self.library, url=self.url))


### PR DESCRIPTION
##### SUMMARY
I noticed that the error message shown when you dont have pyvmomi or the rest sdk installed was not displaying correctly. This change fixes that

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pyvmomi and rest client utils

##### ADDITIONAL INFORMATION
Before the fix, the error was:
`MissingLibError() takes no keyword arguments`

Now its
`Failed to import the required Python library (pyvmomi) on mikemorency's Python /usr/bin/python3. Please read the module documentation and install it in the appropriate location. If the required
library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter`
