### PR TITLE
Migrate/vmware host

### DIFF
--- a/changelogs/fragments/111-migrate-vmware_host.yml
+++ b/changelogs/fragments/111-migrate-vmware_host.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - esxi_host - migrate the vmware_host module from community to here
+  - esxi_connection - migrate the vmware_host module from community to here

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -14,6 +14,8 @@ action_groups:
         - content_template
         - deploy_content_library_ovf
         - deploy_content_library_template
+        - esxi_connection
+        - esxi_host
         - esxi_maintenance_mode
         - folder
         - folder_template_from_vm

--- a/plugins/modules/esxi_connection.py
+++ b/plugins/modules/esxi_connection.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: esxi_connection
+short_description: Manage VMware ESXi host connection status in vCenter
+description:
+    - Manage VMware ESXi host connection status in vCenter. Disconnecting hosts temporarily
+      disables monitoring for the host and its VMs. However they will still show up in vCenter.
+    - This module does not manage the addition, removal, or placement of hosts in vCenter.
+      That functionality is in vmware.vmware.esxi_host
+    - The community.vmware.vmware_host module allows you to add a host in a disconnected state.
+      The host must have been added in a connected state for you to reconnect it using this module.
+      You can remove the host and add it back using the vmware.vmware.esxi_host to get it in the proper state.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+seealso:
+    - module: vmware.vmware.esxi_host
+
+options:
+    datacenter:
+        description:
+            - The name of the datacenter.
+        type: str
+        required: true
+        aliases: [datacenter_name]
+    esxi_host_name:
+        description:
+            - ESXi hostname to manage.
+        required: true
+        type: str
+        aliases: [name]
+    state:
+        description:
+            - Sets the connection status of the host in vCenter
+        default: connected
+        choices: ['connected', 'disconnected']
+        type: str
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+'''
+
+EXAMPLES = r'''
+- name: Connect Host
+  vmware.vmware.esxi_connection:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ vcenter_datacenter }}"
+    esxi_host_name: 10.10.10.10
+    state: connected
+
+- name: Disconnect Host
+  vmware.vmware.esxi_connection:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ vcenter_datacenter }}"
+    esxi_host_name: 10.10.10.10
+    state: disconnected
+'''
+
+RETURN = r'''
+host:
+    description:
+        - Identifying information about the managed host
+    returned: Always
+    type: dict
+    sample: {
+        "host": {
+            "moid": "host-111111",
+            "name": "10.10.10.10"
+        },
+    }
+result:
+    description:
+        - Information about the vCenter task, if something changed
+    returned: On change
+    type: dict
+    sample: {
+        "result": {
+            "completion_time": "2024-07-29T15:27:37.041577+00:00",
+            "entity_name": "test-5fb1_my_esxi_host",
+            "error": null,
+            "state": "success"
+        }
+    }
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
+    base_argument_spec
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import (
+    TaskError,
+    RunningTaskMonitor
+)
+
+
+class VmwareHostConnection(ModulePyvmomiBase):
+    def __init__(self, module):
+        super().__init__(module)
+        self.datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
+        self.host = self.get_esxi_host_by_name_or_moid(identifier=self.params['esxi_host_name'], fail_on_missing=True)
+
+    def reconnect_host(self):
+        reconnect_spec = vim.HostSystem.ReconnectSpec()
+        reconnect_spec.syncState = True
+        try:
+            task = self.host.ReconnectHost_Task(reconnectSpec=reconnect_spec)
+            _, task_result = RunningTaskMonitor(task).wait_for_completion()   # pylint: disable=disallowed-name
+        except vim.fault.InvalidLogin:
+            self.module.fail_json(msg=(
+                'Failed to connect host due to invalid username or password. If these values are correct, you '
+                'can try removing and adding the host in a connected state, using the vmware.vmware.esxi_host module.'
+            ))
+        except (vmodl.RuntimeFault, vmodl.MethodFault)as vmodl_fault:
+            self.module.fail_json(msg=to_native(vmodl_fault.msg))
+        except TaskError as task_e:
+            self.module.fail_json(msg=to_native(task_e))
+        except Exception as generic_exc:
+            self.module.fail_json(msg=(
+                "Failed to reconnect host %s due to exception %s" %
+                (self.params['esxi_host_name'], to_native(generic_exc))
+            ))
+
+        return task_result
+
+    def disconnect_host(self):
+        try:
+            task = self.host.DisconnectHost_Task()
+            _, task_result = RunningTaskMonitor(task).wait_for_completion()   # pylint: disable=disallowed-name
+        except (vmodl.RuntimeFault, vmodl.MethodFault)as vmodl_fault:
+            self.module.fail_json(msg=to_native(vmodl_fault.msg))
+        except TaskError as task_e:
+            self.module.fail_json(msg=to_native(task_e))
+        except Exception as generic_exc:
+            self.module.fail_json(msg=(
+                "Failed to disconnect host %s due to exception %s" %
+                (self.params['esxi_host_name'], to_native(generic_exc))
+            ))
+        return task_result
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **base_argument_spec(), **dict(
+                datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
+                state=dict(type='str', default='connected', choices=['connected', 'disconnected']),
+                esxi_host_name=dict(type='str', required=True, aliases=['name']),
+            )
+        },
+        supports_check_mode=True
+    )
+
+    vmware_host_connection = VmwareHostConnection(module)
+    result = dict(changed=False, host=dict(
+        name=vmware_host_connection.host.name,
+        moid=vmware_host_connection.host._GetMoId()
+    ))
+    if module.params['state'] == vmware_host_connection.host.runtime.connectionState:
+        module.exit_json(**result)
+
+    result['changed'] = True
+    if module.check_mode:
+        module.exit_json(**result)
+
+    if module.params['state'] == 'disconnected':
+        vmware_host_connection.disconnect_host()
+    else:
+        vmware_host_connection.reconnect_host()
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/esxi_host.py
+++ b/plugins/modules/esxi_host.py
@@ -1,0 +1,418 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: esxi_host
+short_description: Manage VMware ESXi host status in vCenter
+description:
+    - Manage VMware ESXi host status in vCenter, including cluster or folder membership.
+    - The host must be in maintenance mode to remove it or update its placement.
+    - This module does not manage the connection status of hosts in vCenter. That functionality
+      is in vmware.vmware.esxi_connection
+    - The host must be in maintenance mode if it is already registered with vCenter but should
+      be moved to a new cluster or folder.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+seealso:
+    - module: vmware.vmware.esxi_connection
+
+options:
+    cluster:
+        description:
+            - The name of the cluster to be managed.
+            - One of O(cluster) or O(folder) is required when O(state) is V(present).
+            - Since ESXi names are unique in a datacenter, this option is not used when O(state) is V(absent).
+        type: str
+        required: false
+        aliases: [cluster_name]
+    datacenter:
+        description:
+            - The name of the datacenter.
+        type: str
+        required: true
+        aliases: [datacenter_name]
+    folder:
+        description:
+            - Name of the folder under which host to add.
+            - One of O(cluster) or O(folder) is required when O(state) is V(present)
+            - Since ESXi names are unique in a datacenter, this option is not used when O(state) is V(absent).
+        type: str
+    esxi_host_name:
+        description:
+            - ESXi hostname to manage.
+        required: true
+        type: str
+    esxi_username:
+        description:
+            - The username to use when authenticating to the ESXi host.
+            - Required when O(state) is V(present).
+        type: str
+    esxi_password:
+        description:
+            - The password to use when authenticating to the ESXi host.
+            - Required when O(state) is V(present).
+        type: str
+    esxi_port:
+        description:
+            - The port on which the ESXi host's SSL certificate can be seen.
+            - This is used when fetching the SSL thumbprint, and is not used if
+              O(ssl_thumbprint) is provided.
+        type: int
+        default: 443
+    state:
+        description:
+            - If set to V(present), make sure the host is registered in vCenter in the desired folder or cluster.
+            - If set to V(absent), remove the host from vCenter if it exists.
+            - If set to V(absent), the host must either be disconnected or be in maintenance mode before it can be
+              removed.
+        default: present
+        choices: ['present', 'absent']
+        type: str
+    ssl_thumbprint:
+        description:
+            - Specify the host system's SSL certificate thumbprint.
+            - You can run the following command on the host to get the thumbprint -
+              'openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha1 -noout'
+            - If this is not set, the module will attempt to fetch the thumbprint from the host itself.
+              This essentially skips the host certificate verification, since whatever host is presented will be trusted.
+            - This option is only used when state is present.
+            - If O(proxy_host) is set, the proxy is used when fetching the SSL thumbprint.
+        type: str
+    force_add:
+        description:
+            - Forces the ESXi host to be added to the vCenter server, even if it is already being managed by another server.
+            - The host must be in maintenance mode even if this option is enabled.
+        type: bool
+        default: False
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+'''
+
+EXAMPLES = r'''
+- name: Make Sure Host Is In A Cluster
+  vmware.vmware.esxi_host:
+    datacenter: DC01
+    cluster: MyCluster
+    esxi_host_name: 1.1.1.1
+    esxi_username: root
+    esxi_password: mypassword!
+    state: present
+
+
+- name: Make Sure Host Is In A Folder (Standalone Host)
+  vmware.vmware.esxi_host:
+    datacenter: DC01
+    folder: my/host/folder   # or DC01/host/my/host/folder
+    esxi_host_name: 1.1.1.1
+    esxi_username: root
+    esxi_password: mypassword!
+    state: present
+
+
+- name: Remove Host From Cluster
+  vmware.vmware.esxi_host:
+    datacenter: DC01
+    esxi_host_name: 1.1.1.1
+    state: absent
+'''
+
+RETURN = r'''
+host:
+    description:
+        - Identifying information about the host
+        - If the state is absent and the host does not exist, only the name is returned
+    returned: On success
+    type: dict
+    sample: {
+        "host": {
+            "moid": "host-111111",
+            "name": "10.10.10.10"
+        },
+    }
+result:
+    description:
+        - Information about the vCenter task, if something changed
+    returned: On change
+    type: dict
+    sample: {
+        "result": {
+            "completion_time": "2024-07-29T15:27:37.041577+00:00",
+            "entity_name": "test-5fb1_my_esxi_host",
+            "error": null,
+            "state": "success"
+        }
+    }
+'''
+
+import ssl
+import socket
+import hashlib
+
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_argument_spec import (
+    base_argument_spec
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_tasks import (
+    TaskError,
+    RunningTaskMonitor
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vmware_folder_paths import (
+    format_folder_path_as_host_fq_path
+)
+
+
+class VmwareHost(ModulePyvmomiBase):
+    def __init__(self, module):
+        super().__init__(module)
+        self.datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
+        self.cluster = None
+        self.folder = None
+        if self.params['cluster']:
+            self.cluster = self.get_cluster_by_name_or_moid(self.params.get('cluster'), fail_on_missing=True, datacenter=self.datacenter)
+        elif self.params['folder']:
+            if self.params['folder'].startswith(self.params['datacenter']) or self.params['folder'].startswith('/' + self.params['datacenter']):
+                path = self.params['folder']
+            else:
+                path = format_folder_path_as_host_fq_path(self.params['folder'], self.params['datacenter'])
+            self.folder = self.get_folder_by_absolute_path(folder_path=path, fail_on_missing=True)
+
+        self.host = self.get_esxi_host_by_name_or_moid(identifier=self.params['esxi_host_name'])
+
+    def __host_parent_type_is_folder(self):
+        """
+            Checks if the host is in a cluster or folder. Returns true if its in a folder.
+            Technically, the parent of a host in a folder is a ComputeResource. Clusters are
+            also a type of ComputeResource, so we need to check for the cluster type specifically.
+        """
+        if isinstance(self.host.parent, vim.ClusterComputeResource):
+            # the parent is a cluster
+            return False
+        else:
+            return True
+
+    def __run_and_wait_for_task(self, task, error_msg, state_msg):
+        """
+            Helper method to run and wait for an arbitrary vCenter task
+        """
+        try:
+            _, task_result = RunningTaskMonitor(task).wait_for_completion()   # pylint: disable=disallowed-name
+        except (vmodl.RuntimeFault)as vmodl_fault:
+            self.module.fail_json(msg=to_native(vmodl_fault.msg))
+        except TaskError as task_e:
+            self.module.fail_json(msg="ESXi task failed to complete due to: %s" % to_native(task_e))
+        except Exception as generic_exc:
+            self.module.fail_json(msg="%s due to exception %s" % (error_msg, to_native(generic_exc)))
+
+        return task_result
+
+    def create_host_connect_spec(self):
+        """
+            Function to create a host connection spec based on user params
+            Returns:
+                host connection specification
+        """
+        # Get the thumbprint of the SSL certificate
+        ssl_thumbprint = self.params['ssl_thumbprint']
+        if not ssl_thumbprint:
+            ssl_thumbprint = self.get_host_ssl_thumbprint()
+
+        host_connect_spec = vim.host.ConnectSpec()
+        host_connect_spec.sslThumbprint = ssl_thumbprint
+        host_connect_spec.hostName = self.params['esxi_host_name']
+        host_connect_spec.userName = self.params['esxi_username']
+        host_connect_spec.password = self.params['esxi_password']
+        host_connect_spec.force = self.params['force_add']
+        return host_connect_spec
+
+    def validate_host_state(func):   # pylint: disable=no-self-argument
+        """
+            Decorator function to perform a state check on a host before moving or removing it. Both of
+            these changes require that the host is in maintenance mode, or in some state other than connected.
+        """
+        def wrapper(self):
+            try:
+                if not self.host.runtime.inMaintenanceMode and self.host.runtime.connectionState == 'connected':
+                    self.module.fail_json(msg='Host is not in valid state to be moved or removed. It must either be in maintenance mode or disconnected.')
+            except AttributeError:
+                pass
+            func(self)
+        return wrapper
+
+    def add_host(self):
+        host_connect_spec = self.create_host_connect_spec()
+        _kwargs = {'spec': host_connect_spec, 'license': None}
+        if self.folder:
+            task = self.folder.AddStandaloneHost(**_kwargs, addConnected=True, compResSpec=None)
+        else:
+            task = self.cluster.AddHost_Task(**_kwargs, asConnected=True, resourcePool=None)
+
+        task_result = self.__run_and_wait_for_task(
+            task=task,
+            error_msg="Failed to add host %s" % self.params['esxi_host_name'],
+            state_msg="Host %s is not in a valid state to be added. Try using the force_add parameter." % self.params['esxi_host_name']
+        )
+        self.host = task_result['result']
+        del task_result['result']
+
+        return task_result
+
+    @validate_host_state
+    def remove_host(self):
+        if self.__host_parent_type_is_folder():
+            task = self.host.parent.Destroy_Task()
+        else:
+            task = self.host.Destroy_Task()
+        return self.__run_and_wait_for_task(
+            task=task,
+            error_msg="Failed to remove host %s" % self.params['esxi_host_name'],
+            state_msg="Host %s is not in a valid state to be remove. It must either be disconnected or in maintenance mode." % self.params['esxi_host_name']
+        )
+
+    @validate_host_state
+    def move_host(self):
+        """
+            Move the host to a new folder or cluster
+        """
+        if self.folder:
+            if self.__host_parent_type_is_folder():
+                task = self.folder.MoveIntoFolder_Task([self.host.parent])
+            else:
+                task = self.folder.MoveIntoFolder_Task([self.host])
+        else:
+            task = self.cluster.MoveHostInto_Task(host=self.host, resourcePool=None)
+
+        return self.__run_and_wait_for_task(
+            task=task,
+            error_msg="Failed to move host %s" % self.params['esxi_host_name'],
+            state_msg="Host %s is not in a valid state to be moved. It must be in maintenance mode." % self.params['esxi_host_name']
+        )
+
+    def host_needs_to_be_moved(self):
+        """
+            Returns true if the host is in the wrong cluster or folder, when compared to the inputs
+            the user provided.
+            Note that a standalone host (one in a folder) has a ComputeResource as a parent, and the
+            parent of that is the folder.
+            Returns:
+                True if host needs to be moved
+        """
+        if self.cluster:
+            if self.host.parent._GetMoId() == self.cluster._GetMoId():
+                return False
+
+        if self.folder:
+            if self.host.parent.parent._GetMoId() == self.folder._GetMoId():
+                return False
+
+        return True
+
+    def get_host_ssl_thumbprint(self):
+        """
+            Connect to the UI provided by the host and parse the SSL thumbprint
+            from it
+            Returns:
+                str, the thumbprint presented by the host
+        """
+        host_fqdn = self.params['esxi_host_name']
+        host_port = self.params['esxi_port']
+        if self.params['proxy_host']:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            sock.connect((self.params['proxy_host'], self.params['proxy_port']))
+            command = "CONNECT %s:%d HTTP/1.0\r\n\r\n" % (host_fqdn, host_port)
+            sock.send(command.encode())
+            buf = sock.recv(8192).decode()
+            if buf.split()[1] != '200':
+                self.module.fail_json(msg="Failed to connect to the proxy")
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            der_cert_bin = ctx.wrap_socket(sock, server_hostname=host_fqdn).getpeercert(True)
+            sock.close()
+        else:
+            try:
+                pem = ssl.get_server_certificate((host_fqdn, host_port))
+            except Exception:
+                self.module.fail_json(msg=f"Cannot connect to host to fetch thumbprint: {host_fqdn}")
+            der_cert_bin = ssl.PEM_cert_to_DER_cert(pem)
+
+        if der_cert_bin:
+            string = str(hashlib.sha1(der_cert_bin).hexdigest())
+            return ':'.join(a + b for a, b in zip(string[::2], string[1::2]))
+        else:
+            self.module.fail_json(msg=f"Unable to fetch SSL thumbprint for host: {host_fqdn}")
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **base_argument_spec(), **dict(
+                cluster=dict(type='str', required=False, aliases=['cluster_name']),
+                datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
+                folder=dict(type='str', required=False),
+                state=dict(type='str', default='present', choices=['absent', 'present']),
+
+                esxi_host_name=dict(type='str', required=True),
+                esxi_username=dict(type='str', required=False),
+                esxi_password=dict(type='str', required=False, no_log=True),
+                esxi_port=dict(type='int', default=443),
+                ssl_thumbprint=dict(type='str', required=False),
+                force_add=dict(type='bool', default=False),
+            )
+        },
+        supports_check_mode=True,
+        required_if=[
+            ('state', 'present', ('cluster', 'folder'), True),
+            ('state', 'present', ('esxi_username', 'esxi_password'), True),
+        ],
+        mutually_exclusive=[
+            ('cluster', 'folder')
+        ]
+    )
+
+    result = dict(changed=False, host=dict(name=module.params['esxi_host_name']))
+
+    vmware_host = VmwareHost(module)
+
+    if module.params['state'] == 'present':
+        if not vmware_host.host:
+            result['changed'] = True
+            result['result'] = vmware_host.add_host()
+        elif vmware_host.host_needs_to_be_moved():
+            result['changed'] = True
+            result['result'] = vmware_host.move_host()
+        result['host']['moid'] = vmware_host.host._GetMoId()
+
+    elif module.params['state'] == 'absent':
+        if vmware_host.host:
+            result['changed'] = True
+            result['host']['moid'] = vmware_host.host._GetMoId()
+            result['result'] = vmware_host.remove_host()
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/esxi_host.py
+++ b/plugins/modules/esxi_host.py
@@ -212,7 +212,7 @@ class VmwareHost(ModulePyvmomiBase):
         else:
             return True
 
-    def __run_and_wait_for_task(self, task, error_msg, state_msg):
+    def __run_and_wait_for_task(self, task, error_msg):
         """
             Helper method to run and wait for an arbitrary vCenter task
         """
@@ -270,8 +270,7 @@ class VmwareHost(ModulePyvmomiBase):
 
         task_result = self.__run_and_wait_for_task(
             task=task,
-            error_msg="Failed to add host %s" % self.params['esxi_host_name'],
-            state_msg="Host %s is not in a valid state to be added. Try using the force_add parameter." % self.params['esxi_host_name']
+            error_msg="Failed to add host %s" % self.params['esxi_host_name']
         )
         self.host = task_result['result']
         del task_result['result']
@@ -286,8 +285,7 @@ class VmwareHost(ModulePyvmomiBase):
             task = self.host.Destroy_Task()
         return self.__run_and_wait_for_task(
             task=task,
-            error_msg="Failed to remove host %s" % self.params['esxi_host_name'],
-            state_msg="Host %s is not in a valid state to be remove. It must either be disconnected or in maintenance mode." % self.params['esxi_host_name']
+            error_msg="Failed to remove host %s" % self.params['esxi_host_name']
         )
 
     @validate_host_state
@@ -305,8 +303,7 @@ class VmwareHost(ModulePyvmomiBase):
 
         return self.__run_and_wait_for_task(
             task=task,
-            error_msg="Failed to move host %s" % self.params['esxi_host_name'],
-            state_msg="Host %s is not in a valid state to be moved. It must be in maintenance mode." % self.params['esxi_host_name']
+            error_msg="Failed to move host %s" % self.params['esxi_host_name']
         )
 
     def host_needs_to_be_moved(self):

--- a/tests/integration/targets/vmware_esxi_connection/defaults/main.yml
+++ b/tests/integration/targets/vmware_esxi_connection/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+test_esxi_hostname: "{{ tiny_prefix }}_esxi_connection"
+test_resource_pool: "{{ tiny_prefix }}_esxi_connection_rp"
+test_cluster: Eco-Cluster
+test_esxi_username: root
+test_esxi_password: "!#%135qEt"
+run_on_simulator: false

--- a/tests/integration/targets/vmware_esxi_connection/run.yml
+++ b/tests/integration/targets/vmware_esxi_connection/run.yml
@@ -1,0 +1,14 @@
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import vmware_esxi_connection role
+      ansible.builtin.import_role:
+        name: vmware_esxi_connection
+      tags:
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_esxi_connection/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_connection/tasks/eco-vcenter.yml
@@ -78,105 +78,91 @@
         seconds: 15
 
     - name: Join Hosts To Cluster
-      community.vmware.vmware_host:
+      vmware.vmware.esxi_host:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
-        cluster: "{{ vcenter_cluster_name }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
-        esxi_username: root
-        esxi_password: "!#%135qEt"
+        cluster: "{{ test_cluster }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        esxi_username: "{{ test_esxi_username }}"
+        esxi_password: "{{ test_esxi_password }}"
         state: present
 
-    - name: Disable Maintenance Mode For Host That Is Not In Maintenance Mode
-      vmware.vmware.esxi_maintenance_mode:
-        validate_certs: false
+    - name: Disconnect Host
+      vmware.vmware.esxi_connection:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        enable_maintenance_mode: False
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _set
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        state: disconnected
 
-    - name: Check Task Output
+    - name: Connect Host
+      vmware.vmware.esxi_connection:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        state: connected
+      register: _conn
+
+    - name: Connect Host - Idempotence
+      vmware.vmware.esxi_connection:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        state: connected
+      register: _conn_idem
+
+    - name: Disconnect Host
+      vmware.vmware.esxi_connection:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        state: disconnected
+      register: _disconn
+
+    - name: Disconnect Host - Idempotence
+      vmware.vmware.esxi_connection:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        state: disconnected
+      register: _disconn_idem
+
+    - name: Check Output
       ansible.builtin.assert:
         that:
-          - _set is not changed
-
-    - name: Enable Maintenance Mode For Host That Is Not In Maintenance Mode
-      vmware.vmware.esxi_maintenance_mode:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        enable_maintenance_mode: true
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _set
-
-    - name: Gather Info about ESXi Host
-      community.vmware.vmware_host_facts:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _host_info
-
-    - name: Check Task Output
-      ansible.builtin.assert:
-        that:
-          - _set is changed
-          - _set.result.state == 'success'
-          - _host_info.ansible_facts.ansible_in_maintenance_mode
-
-    - name: Disable Maintenance Mode For Host That Is In Maintenance Mode
-      vmware.vmware.esxi_maintenance_mode:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        enable_maintenance_mode: false
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _set
-
-    - name: Gather Info about ESXi Host
-      community.vmware.vmware_host_facts:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _host_info
-
-    - name: Check Task Output
-      ansible.builtin.assert:
-        that:
-          - _set is changed
-          - _set.result.state == 'success'
-          - not _host_info.ansible_facts.ansible_in_maintenance_mode
-
-    - name: Enable Maintenance Mode Before Cleanup
-      vmware.vmware.esxi_maintenance_mode:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        enable_maintenance_mode: true
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
+          - _conn is changed
+          - _conn_idem is not changed
+          - _disconn is changed
+          - _disconn_idem is not changed
 
   always:
-    - name: Disconnect Host From vCenter
-      community.vmware.vmware_host:
-        validate_certs: false
+    - name: Remove Host From vCenter
+      vmware.vmware.esxi_host:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        cluster: "{{ vcenter_cluster_name }}"
+        validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 | default(test_esxi_hostname) }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
         state: absent
+      when: _esxi_info.guests[0] is defined
     - name: "Test cleanup: Delete Virtual ESXi Host"
       community.vmware.vmware_guest:
         validate_certs: false

--- a/tests/integration/targets/vmware_esxi_connection/tasks/main.yml
+++ b/tests/integration/targets/vmware_esxi_connection/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Test On VCenter
+  ansible.builtin.include_tasks: eco-vcenter.yml
+  when: not run_on_simulator

--- a/tests/integration/targets/vmware_esxi_host/defaults/main.yml
+++ b/tests/integration/targets/vmware_esxi_host/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+test_esxi_hostname: "{{ tiny_prefix }}_esxi_host"
+test_resource_pool: "{{ tiny_prefix }}_esxi_host_rp"
+test_cluster: Eco-Cluster
+test_esxi_username: root
+test_esxi_password: "!#%135qEt"
+test_folder_1: "{{ tiny_prefix }}_esxi_host_folder_1"
+test_folder_2: "{{ tiny_prefix }}_esxi_host_folder_2"
+run_on_simulator: false

--- a/tests/integration/targets/vmware_esxi_host/run.yml
+++ b/tests/integration/targets/vmware_esxi_host/run.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+    - name: Import vmware_esxi_host role
+      ansible.builtin.import_role:
+        name: vmware_esxi_host
+      tags:
+        - eco-vcenter-ci

--- a/tests/integration/targets/vmware_esxi_host/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_host/tasks/eco-vcenter.yml
@@ -15,6 +15,19 @@
 
 - name: Test
   block:
+    - name: Create a test folders
+      vmware.vmware.folder:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        relative_path: "{{ item }}"
+        folder_type: host
+        datacenter: "{{ vcenter_datacenter }}"
+      loop:
+        - "{{ test_folder_1 }}"
+        - "{{ test_folder_2 }}"
+
     - name: Create a test resource pool
       vmware.vmware_rest.vcenter_resourcepool:
         vcenter_hostname: "{{ vcenter_hostname }}"
@@ -78,105 +91,84 @@
         seconds: 15
 
     - name: Join Hosts To Cluster
-      community.vmware.vmware_host:
+      vmware.vmware.esxi_host:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
-        cluster: "{{ vcenter_cluster_name }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
-        esxi_username: root
-        esxi_password: "!#%135qEt"
+        cluster: "{{ test_cluster }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        esxi_username: "{{ test_esxi_username }}"
+        esxi_password: "{{ test_esxi_password }}"
         state: present
 
-    - name: Disable Maintenance Mode For Host That Is Not In Maintenance Mode
+    - name: Put Host In Maintenance Mode
       vmware.vmware.esxi_maintenance_mode:
-        validate_certs: false
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        enable_maintenance_mode: False
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _set
-
-    - name: Check Task Output
-      ansible.builtin.assert:
-        that:
-          - _set is not changed
-
-    - name: Enable Maintenance Mode For Host That Is Not In Maintenance Mode
-      vmware.vmware.esxi_maintenance_mode:
         validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
+        esxi_host_name: "{{ test_esxi_ip | default(_esxi_info.guests[0].ipv4) }}"
         enable_maintenance_mode: true
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _set
 
-    - name: Gather Info about ESXi Host
-      community.vmware.vmware_host_facts:
-        validate_certs: false
+    - name: Move Host To Folder
+      vmware.vmware.esxi_host:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _host_info
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        folder: "{{ test_folder_1 }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        esxi_username: "{{ test_esxi_username }}"
+        esxi_password: "{{ test_esxi_password }}"
+      register: _f1
 
-    - name: Check Task Output
+    - name: Move Host To Another Folder
+      vmware.vmware.esxi_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        folder: "{{ test_folder_2 }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        esxi_username: "{{ test_esxi_username }}"
+        esxi_password: "{{ test_esxi_password }}"
+      register: _f2
+
+    - name: Move Host To Cluster
+      vmware.vmware.esxi_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
+        esxi_username: "{{ test_esxi_username }}"
+        esxi_password: "{{ test_esxi_password }}"
+      register: _c2
+
+    - name: Check Output
       ansible.builtin.assert:
         that:
-          - _set is changed
-          - _set.result.state == 'success'
-          - _host_info.ansible_facts.ansible_in_maintenance_mode
-
-    - name: Disable Maintenance Mode For Host That Is In Maintenance Mode
-      vmware.vmware.esxi_maintenance_mode:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        enable_maintenance_mode: false
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _set
-
-    - name: Gather Info about ESXi Host
-      community.vmware.vmware_host_facts:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
-      register: _host_info
-
-    - name: Check Task Output
-      ansible.builtin.assert:
-        that:
-          - _set is changed
-          - _set.result.state == 'success'
-          - not _host_info.ansible_facts.ansible_in_maintenance_mode
-
-    - name: Enable Maintenance Mode Before Cleanup
-      vmware.vmware.esxi_maintenance_mode:
-        validate_certs: false
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        enable_maintenance_mode: true
-        name: "{{ _esxi_info.guests[0].ipv4 }}"
+          - _f1 is changed
+          - _f2 is changed
+          - _c2 is changed
 
   always:
-    - name: Disconnect Host From vCenter
-      community.vmware.vmware_host:
-        validate_certs: false
+    - name: Remove Host From vCenter
+      vmware.vmware.esxi_host:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        cluster: "{{ vcenter_cluster_name }}"
+        validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
-        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 | default(test_esxi_hostname) }}"
+        esxi_host_name: "{{ _esxi_info.guests[0].ipv4 }}"
         state: absent
+      when: _esxi_info.guests[0] is defined
     - name: "Test cleanup: Delete Virtual ESXi Host"
       community.vmware.vmware_guest:
         validate_certs: false
@@ -189,6 +181,19 @@
         state: absent
         name: "{{ test_esxi_hostname }}"
         force: true
+    - name: Delete test folders
+      vmware.vmware.folder:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        relative_path: "{{ item }}"
+        folder_type: host
+        datacenter: "{{ vcenter_datacenter }}"
+        state: absent
+      loop:
+        - "{{ test_folder_1 }}"
+        - "{{ test_folder_2 }}"
     - name: "Test cleanup: Delete Resource Pool"
       vmware.vmware_rest.vcenter_resourcepool:
         vcenter_hostname: "{{ vcenter_hostname }}"

--- a/tests/integration/targets/vmware_esxi_host/tasks/main.yml
+++ b/tests/integration/targets/vmware_esxi_host/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Test On VCenter
+  ansible.builtin.include_tasks: eco-vcenter.yml
+  when: not run_on_simulator

--- a/tests/unit/plugins/modules/common/vmware_object_mocks.py
+++ b/tests/unit/plugins/modules/common/vmware_object_mocks.py
@@ -2,6 +2,18 @@ from unittest import mock
 from pyVmomi import vim
 
 
+def create_mock_vsphere_object(name="test", moid="1"):
+    """
+        Creates a mock object and populates basic properties and functions
+        to make it act like a vSphere object.
+    """
+    obj = mock.Mock()
+    obj.name = name
+    obj._moid = moid
+    obj._GetMoId.return_value = obj._moid
+    return obj
+
+
 class MockVsphereTask():
     def __init__(self):
         self.info = mock.Mock()
@@ -19,7 +31,7 @@ class MockClusterConfiguration():
         self.drsConfig = None
 
 
-class MockVmwareObject():
+class MockVmwareObject(mock.Mock):
     def __init__(self, name="test", moid="1"):
         super().__init__()
         self.name = name

--- a/tests/unit/plugins/modules/test_esxi_connection.py
+++ b/tests/unit/plugins/modules/test_esxi_connection.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.esxi_connection import (
+    VmwareHostConnection,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients._pyvmomi import (
+    PyvmomiClient
+)
+from .common.utils import (
+    AnsibleExitJson, ModuleTestCase, set_module_args,
+)
+from .common.vmware_object_mocks import (
+    MockEsxiHost
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestEsxiConnection(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        self.test_esxi = MockEsxiHost(name="test")
+        self.mock_cluster = mocker.Mock()
+
+        mocker.patch.object(VmwareHostConnection, 'get_datacenter_by_name_or_moid')
+        mocker.patch.object(VmwareHostConnection, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
+
+    def test_no_change(self, mocker):
+        self.__prepare(mocker)
+        self.test_esxi.runtime.connectionState = 'connected'
+
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=False,
+            datacenter="",
+            esxi_host_name=self.test_esxi.name,
+            state="connected"
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is False
+
+        self.test_esxi.runtime.connectionState = 'disconnected'
+
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=False,
+            datacenter="",
+            esxi_host_name=self.test_esxi.name,
+            state="disconnected"
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is False

--- a/tests/unit/plugins/modules/test_esxi_host.py
+++ b/tests/unit/plugins/modules/test_esxi_host.py
@@ -15,7 +15,8 @@ from .common.utils import (
     AnsibleExitJson, ModuleTestCase, set_module_args,
 )
 from .common.vmware_object_mocks import (
-    MockEsxiHost
+    create_mock_vsphere_object,
+    MockVsphereTask
 )
 
 pytestmark = pytest.mark.skipif(
@@ -27,12 +28,15 @@ class TestEsxiHost(ModuleTestCase):
 
     def __prepare(self, mocker):
         mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
-        self.test_esxi = MockEsxiHost(name="test")
+        self.test_esxi = create_mock_vsphere_object()
         self.test_esxi.runtime.inMaintenanceMode = True
         self.mock_cluster = mocker.Mock()
+        self.mock_folder = mocker.Mock()
+        self.mock_folder._GetMoId.return_value = '1'
 
         mocker.patch.object(VmwareHost, 'get_datacenter_by_name_or_moid')
         mocker.patch.object(VmwareHost, 'get_cluster_by_name_or_moid', return_value=self.mock_cluster)
+        mocker.patch.object(VmwareHost, 'get_folder_by_absolute_path', return_value=self.mock_folder)
 
     def test_no_change(self, mocker):
         self.__prepare(mocker)
@@ -45,6 +49,24 @@ class TestEsxiHost(ModuleTestCase):
             password="123456",
             add_cluster=True,
             datacenter='foo',
+            esxi_host_name=self.test_esxi.name,
+            esxi_username="foo",
+            esxi_password="foo"
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is False
+
+        self.test_esxi.parent.parent = self.mock_folder
+        mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=False,
+            datacenter='foo',
+            folder='bar',
             esxi_host_name=self.test_esxi.name,
             esxi_username="foo",
             esxi_password="foo"
@@ -69,3 +91,72 @@ class TestEsxiHost(ModuleTestCase):
             module_main()
 
         assert c.value.args[0]["changed"] is False
+
+    def test_state_present(self, mocker):
+        self.__prepare(mocker)
+
+        self.test_esxi.parent = self.mock_folder
+        self.mock_folder.AddStandaloneHost.return_value = MockVsphereTask()
+        self.mock_folder.AddStandaloneHost.return_value.info.result = self.test_esxi
+        mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=None)
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=False,
+            datacenter='foo',
+            folder="foo/vm/bar",
+            esxi_host_name=self.test_esxi.name,
+            ssl_thumbprint='fdsfadf',
+            esxi_username="foo",
+            esxi_password="foo"
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is True
+
+    def test_state_present_move(self, mocker):
+        self.__prepare(mocker)
+
+        self.test_esxi.parent = self.mock_folder
+        self.mock_cluster.MoveHostInto_Task.return_value = MockVsphereTask()
+        mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=True,
+            datacenter='foo',
+            esxi_host_name=self.test_esxi.name,
+            ssl_thumbprint='fdsfadf',
+            esxi_username="foo",
+            esxi_password="foo"
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is True
+
+    def test_state_absent(self, mocker):
+        self.__prepare(mocker)
+
+        self.test_esxi.parent = self.mock_folder
+        self.mock_folder.Destroy_Task.return_value = MockVsphereTask()
+        mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=False,
+            datacenter='foo',
+            folder="foo/vm/bar",
+            esxi_host_name=self.test_esxi.name,
+            state='absent',
+            esxi_username="foo",
+            esxi_password="foo"
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is True

--- a/tests/unit/plugins/modules/test_esxi_host.py
+++ b/tests/unit/plugins/modules/test_esxi_host.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.esxi_host import (
+    VmwareHost,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients._pyvmomi import (
+    PyvmomiClient
+)
+from .common.utils import (
+    AnsibleExitJson, ModuleTestCase, set_module_args,
+)
+from .common.vmware_object_mocks import (
+    MockEsxiHost
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestEsxiHost(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        self.test_esxi = MockEsxiHost(name="test")
+        self.test_esxi.runtime.inMaintenanceMode = True
+        self.mock_cluster = mocker.Mock()
+
+        mocker.patch.object(VmwareHost, 'get_datacenter_by_name_or_moid')
+        mocker.patch.object(VmwareHost, 'get_cluster_by_name_or_moid', return_value=self.mock_cluster)
+
+    def test_no_change(self, mocker):
+        self.__prepare(mocker)
+
+        self.test_esxi.parent = self.mock_cluster
+        mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=True,
+            datacenter='foo',
+            esxi_host_name=self.test_esxi.name,
+            esxi_username="foo",
+            esxi_password="foo"
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is False
+
+        mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=None)
+
+        set_module_args(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=True,
+            datacenter='foo',
+            esxi_host_name=self.test_esxi.name,
+            state='absent'
+        )
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is False


### PR DESCRIPTION
##### SUMMARY
Migrating the vmware_host functionality from community to this repo.
I split the module into two, one to manage if the host is added or removed from vcenter and one to manage if the host is connected or disconnected from vcenter (disconnecting is considered a temporary state while removing is more permenant).

I think having these two functions together made the module a bit more complicated than it needed to be.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
esxi_host
esxi_connection