### PR TITLE
fix deploy content modules when library name is not provided

### DIFF
--- a/plugins/module_utils/_module_deploy_content_library_base.py
+++ b/plugins/module_utils/_module_deploy_content_library_base.py
@@ -69,7 +69,7 @@ class VmwareContentDeploy(ModulePyvmomiBase):
 
         if self.params['library_id']:
             library_id = self.params['library_id']
-        else:
+        elif self.params['library_name']:
             library_ids = self.rest_base.get_content_library_ids(
                 name=self.params['library_name'],
                 fail_on_missing=True
@@ -80,6 +80,8 @@ class VmwareContentDeploy(ModulePyvmomiBase):
                     self.params['library_name']
                 ))
             library_id = library_ids[0]
+        else:
+            library_id = None
 
         item_ids = self.rest_base.get_library_item_ids(
             name=self.params['library_item_name'],


### PR DESCRIPTION
##### SUMMARY
Fixes issue where an error is thrown if the user does not provide the option library_name parameter
New functionality will mean all libraries are searched if the name is not provided

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
deploy_content_library_ovf
deploy_content_library_template
