### PR TITLE
rename folder_template_from_vm module

### DIFF
--- a/changelogs/fragments/112-rename-folder-template-module.yml
+++ b/changelogs/fragments/112-rename-folder-template-module.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - folder_template - renamed folder_template_from_vm to folder_template, in order to match content_template module and
+    reduce confusion with the new deploy_folder_template module. Included a redirect until v3.0.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -16,7 +16,7 @@ action_groups:
         - deploy_content_library_template
         - esxi_maintenance_mode
         - folder
-        - folder_template_from_vm
+        - folder_template
         - guest_info
         - license_info
         - local_content_library
@@ -31,3 +31,8 @@ plugin_routing:
             deprecation:
                 removal_version: 2.0.0
                 warning_text: Use M(vmware.vmware.vm_list_group_by_clusters_info) instead.
+        folder_template:
+            redirect: vmware.vmware.folder_template
+            deprecation:
+                removal_version: 3.0.0
+                warning_text: Use M(vmware.vmware.folder_template) instead.

--- a/plugins/modules/folder_template.py
+++ b/plugins/modules/folder_template.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: folder_template_from_vm
+module: folder_template
 short_description: Create a template in a local VCenter folder from an existing VM
 description:
     - >-
@@ -115,7 +115,7 @@ EXAMPLES = r'''
     template_name: "my_template"
 
 - name: Create A New Template Using VM Name
-  vmware.vmware.folder_template_from_vm:
+  vmware.vmware.folder_template:
     hostname: "https://vcenter"
     username: "username"
     password: "password"
@@ -126,7 +126,7 @@ EXAMPLES = r'''
     template_folder: "nested/folder/path/templates"
 
 - name: Destroy A Template In A Folder
-  vmware.vmware.folder_template_from_vm:
+  vmware.vmware.folder_template:
     hostname: "https://vcenter"
     username: "username"
     password: "password"

--- a/tests/integration/targets/vmware_folder_template_from_vm/defaults/main.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/defaults/main.yml
@@ -4,7 +4,7 @@ template_folders:
   - "{{ tiny_prefix }}_folder_1"
   - "{{ tiny_prefix }}_folder_2"
 vm_folder: "{{ template_folders[0] }}"
-vm_name: "{{ tiny_prefix }}_folder_template_from_vm_test"
+vm_name: "{{ tiny_prefix }}_folder_template_test"
 vm_name_match: first
 template_name: "{{ vm_name }}_template"
 

--- a/tests/integration/targets/vmware_folder_template_from_vm/run.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/run.yml
@@ -21,7 +21,7 @@
 
     - name: Import vmware_folder_template role
       ansible.builtin.import_role:
-        name: vmware_folder_template_from_vm
+        name: vmware_folder_template
       tags:
         - integration-ci
         - eco-vcenter-ci

--- a/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
+++ b/tests/integration/targets/vmware_folder_template_from_vm/tasks/main.yml
@@ -27,7 +27,7 @@
         name: "{{ vm_name }}"
 
     - name: Create template from vm in vcenter folder
-      vmware.vmware.folder_template_from_vm:
+      vmware.vmware.folder_template:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -89,7 +89,7 @@
         name: "{{ vm_name }}"
 
     - name: Create templates from vm in vcenter folders
-      vmware.vmware.folder_template_from_vm:
+      vmware.vmware.folder_template:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -107,7 +107,7 @@
       loop: "{{ template_folders }}"
 
     - name: Destroy template
-      vmware.vmware.folder_template_from_vm:
+      vmware.vmware.folder_template:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"


### PR DESCRIPTION
##### SUMMARY
Renaming `folder_template_from_vm` to `folder_template` for two reasons:
1. the new name is more consistent with a similar module, `content_template`
2. this module manages the template's existence, and I think the new name better reflects that

I have another module coming that will deploy a vm from a folder template, which will be called `deploy_folder_template`

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
folder_template

##### ADDITIONAL INFORMATION
I think a major release is going to happen soon-ish so I set this module redirect to expire with version 3