### PR TITLE
move unit tests to ansible-test gha

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           path: ansible_collections/vmware/vmware
 
-      - name: Run
-        run: |
-          make units
-        working-directory: ansible_collections/vmware/vmware
+      # - name: Run
+      #   run: |
+      #     make units
+      #   working-directory: ansible_collections/vmware/vmware

--- a/.github/workflows/ansible-unit.yml
+++ b/.github/workflows/ansible-unit.yml
@@ -1,0 +1,102 @@
+# README FIRST
+# 1. Subscribe to https://github.com/ansible-collections/news-for-maintainers
+#    (click the Watch button on the homepage > Custom > Issues)
+#    and keep this matrix up to date in accordance to related announcements.
+#    Timely add new ansible-core versions and consider dropping support
+#    and testing against its EOL versions.
+# 2. If your collection repository is under the ansible-collections org,
+#    please keep in mind that the number of GHA jobs is limited
+#    and shared across all the collections in the org.
+#    So, focusing on good test coverage of your collection,
+#    please avoid testing against unnecessary entities such as
+#    ansible-core EOL versions your collection does not support
+#    or ansible-core versions that are not EOL yet but not supported by the collection.
+# 3. If you don't have unit or integration tests, remove corresponding sections.
+# 4. If your collection depends on other collections ensure they are installed,
+#    add them to the "test-deps" input.
+# 5. For the comprehensive list of the inputs supported by the
+#    ansible-community/ansible-test-gh-action GitHub Action, see
+#    https://github.com/marketplace/actions/ansible-test.
+# 6. If you want to prevent merging PRs that do not pass all tests,
+#    make sure to add the "check" job to your repository branch
+#    protection once this workflow is added.
+#    It is also possible to tweak which jobs are allowed to fail. See
+#    https://github.com/marketplace/actions/alls-green#gotchas for more detail.
+# 7. If you need help please ask in #community:ansible.com on Matrix
+#    or in bridged #ansible-community on the Libera.Chat IRC channel.
+#    See https://docs.ansible.com/ansible/devel/community/communication.html
+#    for details.
+# 8. If your collection is [going to get] included in the Ansible package,
+#    it has to adhere to Python compatibility and CI testing requirements described in
+#    https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_requirements.html.
+
+name: Units
+on:
+  # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
+  # Run CI once per day (at 06:00 UTC)
+  # This ensures that even if there haven't been commits that we are still
+  # testing against latest version of ansible-test for each ansible-core
+  # version
+  schedule:
+    - cron: "0 6 * * *"
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number || github.sha
+    }}
+  cancel-in-progress: true
+
+jobs:
+  units:
+    name: Units (Ⓐ${{ matrix.versions.ansible }} - ${{ matrix.versions.python }})
+    strategy:
+      matrix:
+        versions:
+          # It's important that Sanity is tested against all stable-X.Y branches
+          # Testing against `devel` may fail as new tests are added.
+          # An alternative to `devel` is the `milestone` branch with
+          # gets synchronized with `devel` every few weeks and therefore
+          # tends to be a more stable target. Be aware that it is not updated
+          # around creation of a new stable branch, this might cause a problem
+          # that two different versions of ansible-test use the same sanity test
+          # ignore.txt file.
+          # Add new versions announced in
+          # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
+          # consider dropping testing against EOL versions and versions you don't support.
+          - { python: 3.13, ansible: stable-2.18 }
+          - { python: 3.8, ansible: stable-2.18 }
+          - { python: 3.11, ansible: stable-2.15 }
+          - { python: 3.5, ansible: stable-2.15 }
+          - { python: 2.7, ansible: stable-2.15 }
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Perform unit testing
+        # See the documentation for the following GitHub action on
+        # https://github.com/ansible-community/ansible-test-gh-action/blob/main/README.md
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: ${{ matrix.versions.ansible }}
+          testing-type: units
+          target-python-version: ${{ matrix.versions.python }}
+          pull-request-change-detection: false
+
+  # This job does nothing and is only used for the branch protection
+  # or multi-stage CI jobs, like making sure that all tests pass before
+  # a publishing job is started.
+  check:
+    if: always()
+    needs:
+      - units
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
##### SUMMARY
The code coverage for our repo comes from the ansible sanity tests, which use a community GH action to upload the results and do all the other code coverage stuff.

So this PR is trying to use the same GH action to upload the unit test code coverage, which is actually what we want to use

##### ISSUE TYPE
- Docs Pull Request
