### PR TITLE
Drop ubuntu-20.04 from GitHub workflow

### DIFF
--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -81,15 +81,7 @@ jobs:
           - stable-2.18
           - devel
         # - milestone
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       # Run sanity tests inside a Docker container.
       # The docker container has all the pinned dependencies that are


### PR DESCRIPTION
##### SUMMARY
Since the collection neither supports nor tests with those outdated ansible (core) versions, I think we should drop ubuntu-20.04 from GitHub workflow.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
.github/workflows/ansible-sanity.yml

##### ADDITIONAL INFORMATION
https://forum.ansible.com/t/40187
ansible-collections/community.vmware#2312