### PR TITLE
make pyvmomi client inputs explicit

### DIFF
--- a/changelogs/fragments/132-add-explicit-client-params.yml
+++ b/changelogs/fragments/132-add-explicit-client-params.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - clients/_pyvmomi - adds explicit init params instead of using dict
+  - clients/_rest - adds explicit init params instead of using dict

--- a/changelogs/fragments/132-add-explicit-client-params.yml
+++ b/changelogs/fragments/132-add-explicit-client-params.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - clients/_pyvmomi - adds explicit init params instead of using dict

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -98,15 +98,15 @@ class VmwareInventoryBase(BaseInventoryPlugin, Constructable, Cacheable):
         username, password = self.get_credentials_from_options()
 
         try:
-            self.pyvmomi_client = PyvmomiClient({
-                'hostname': self.get_option("hostname"),
-                'username': username,
-                'password': password,
-                'port': self.get_option("port"),
-                'validate_certs': self.get_option("validate_certs"),
-                'http_proxy_host': self.get_option("proxy_host"),
-                'http_proxy_port': self.get_option("proxy_port")
-            })
+            self.pyvmomi_client = PyvmomiClient(
+                hostname=self.get_option("hostname"),
+                username=username,
+                password=password,
+                port=self.get_option("port"),
+                validate_certs=self.get_option("validate_certs"),
+                http_proxy_host=self.get_option("proxy_host"),
+                http_proxy_port=self.get_option("proxy_port")
+            )
         except Exception as e:
             raise AnsibleParserError(message=to_native(e))
 

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -120,16 +120,16 @@ class VmwareInventoryBase(BaseInventoryPlugin, Constructable, Cacheable):
         username, password = self.get_credentials_from_options()
 
         try:
-            self.rest_client = VmwareRestClient({
-                'hostname': self.get_option("hostname"),
-                'username': username,
-                'password': password,
-                'port': self.get_option("port"),
-                'validate_certs': self.get_option("validate_certs"),
-                'http_proxy_host': self.get_option("proxy_host"),
-                'http_proxy_port': self.get_option("proxy_port"),
-                'http_proxy_protocol': self.get_option("proxy_protocol")
-            })
+            self.rest_client = VmwareRestClient(
+                hostname=self.get_option("hostname"),
+                username=username,
+                password=password,
+                port=self.get_option("port"),
+                validate_certs=self.get_option("validate_certs"),
+                http_proxy_host=self.get_option("proxy_host"),
+                http_proxy_port=self.get_option("proxy_port"),
+                http_proxy_protocol=self.get_option("proxy_protocol")
+            )
         except Exception as e:
             raise AnsibleParserError(message=to_native(e))
 

--- a/plugins/module_utils/_module_pyvmomi_base.py
+++ b/plugins/module_utils/_module_pyvmomi_base.py
@@ -20,7 +20,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients._pyvmomi imp
 
 class ModulePyvmomiBase(PyvmomiClient):
     def __init__(self, module):
-        super().__init__(module.params)
+        super().__init__(**module.params)
         self.module = module
         self.params = module.params
 

--- a/plugins/module_utils/_module_rest_base.py
+++ b/plugins/module_utils/_module_rest_base.py
@@ -26,7 +26,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients._rest import
 
 class ModuleRestBase(VmwareRestClient):
     def __init__(self, module):
-        super().__init__(connection_params=module.params)
+        super().__init__(**module.params)
         self.module = module
         self.params = module.params
 

--- a/plugins/module_utils/clients/_rest.py
+++ b/plugins/module_utils/clients/_rest.py
@@ -45,9 +45,9 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients._errors impo
 
 class VmwareRestClient():
     def __init__(
-            self, hostname, username, password, port=443, validate_certs=True,
-            http_proxy_host=None, http_proxy_port=None, http_proxy_protocol=None, **_
-        ):
+        self, hostname, username, password, port=443, validate_certs=True,
+        http_proxy_host=None, http_proxy_port=None, http_proxy_protocol=None, **_
+    ):
         self.check_requirements()
         self.hostname = hostname
         self.username = username

--- a/tests/unit/plugins/module_utils/clients/test_pyvmomi.py
+++ b/tests/unit/plugins/module_utils/clients/test_pyvmomi.py
@@ -30,11 +30,9 @@ class TestPyvmomiClient():
 
     def __prepare_client(self):
         return PyvmomiClient(
-            {
-                'hostname': 'a',
-                'username': 'a',
-                'password': 'a',
-            }
+            hostname='a',
+            username='a',
+            password='a'
         )
 
     def test_class_init(self, mocker):
@@ -49,16 +47,16 @@ class TestPyvmomiClient():
             'http_proxy_port': 443
         }
 
-        PyvmomiClient(init_args)
+        PyvmomiClient(**init_args)
 
         with pytest.raises(ApiAccessError):
-            PyvmomiClient({**init_args, **{'hostname': ''}})
+            PyvmomiClient(**{**init_args, **{'hostname': ''}})
 
         with pytest.raises(ApiAccessError):
-            PyvmomiClient({**init_args, **{'username': ''}})
+            PyvmomiClient(**{**init_args, **{'username': ''}})
 
         with pytest.raises(ApiAccessError):
-            PyvmomiClient({**init_args, **{'password': ''}})
+            PyvmomiClient(**{**init_args, **{'password': ''}})
 
     def test_get_all_objs_by_type(self, mocker):
         self.__prepare(mocker)

--- a/tests/unit/plugins/module_utils/clients/test_rest.py
+++ b/tests/unit/plugins/module_utils/clients/test_rest.py
@@ -10,11 +10,9 @@ class TestRestClient():
         client_mock = mocker.patch('ansible_collections.vmware.vmware.plugins.module_utils.clients._rest.create_vsphere_client')
         client_mock.return_value = mocker.Mock()
         self.client = VmwareRestClient(
-            {
-                'hostname': 'a',
-                'username': 'a',
-                'password': 'a',
-            }
+            hostname='a',
+            username='a',
+            password='a',
         )
 
     def test_get_tags_by_moid(self, mocker):

--- a/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
+++ b/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
@@ -14,9 +14,9 @@ class TestModulePyvmomiBase():
     def __prepare(self, mocker):
         mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
         set_module_args()
-        self.base = ModulePyvmomiBase(
-            module=mocker.Mock()
-        )
+        module=mocker.Mock()
+        module.params = {"hostname": "a", "username": "b", "password": "c"}
+        self.base = ModulePyvmomiBase(module=module)
 
     def test_is_vcenter(self, mocker):
         self.__prepare(mocker)

--- a/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
+++ b/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
@@ -14,7 +14,7 @@ class TestModulePyvmomiBase():
     def __prepare(self, mocker):
         mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
         set_module_args()
-        module=mocker.Mock()
+        module = mocker.Mock()
         module.params = {"hostname": "a", "username": "b", "password": "c"}
         self.base = ModulePyvmomiBase(module=module)
 

--- a/tests/unit/plugins/module_utils/test_module_rest_base.py
+++ b/tests/unit/plugins/module_utils/test_module_rest_base.py
@@ -13,9 +13,9 @@ class TestModuleRestBase():
     def __prepare(self, mocker):
         mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=mocker.Mock())
         set_module_args()
-        self.base = ModuleRestBase(
-            module=mocker.Mock()
-        )
+        module = mocker.Mock()
+        module.params = {"hostname": "a", "username": "b", "password": "c"}
+        self.base = ModuleRestBase(module=module)
 
     def test_get_vm_by_name(self, mocker):
         self.__prepare(mocker)


### PR DESCRIPTION
##### SUMMARY
Testing the recommendation from https://github.com/ansible-collections/vmware.vmware/issues/133 and making client parameters explicit instead of relying on a dict

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
client/_pyvmomi

