### PR TITLE
include moid in inven output

### DIFF
--- a/changelogs/fragments/135-add-moid-to-inven-out.yml
+++ b/changelogs/fragments/135-add-moid-to-inven-out.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - vms inventory - include moid property in output always
+  - esxi_hosts inventory - include moid property in output always

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -67,6 +67,7 @@ class VmwareInventoryHost(ABC):
     def get_properties_from_pyvmomi(self, properties_to_gather, pyvmomi_client):
         properties = vmware_obj_to_json(self.object, properties_to_gather)
         properties['path'] = self.path
+        properties['moid'] = self.object._GetMoId()
 
         # Custom values
         if hasattr(self.object, "customValue"):


### PR DESCRIPTION
##### SUMMARY
Always include the moid in the inventory plugin output. The MOID is used by other modules and reporting. Its also the only consistent unique identifier across all objects. We should always return it

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vms inventory
esxi_hosts inventory
