### PR TITLE
missed adding host filtering to vm inventory

### DIFF
--- a/plugins/inventory/vms.py
+++ b/plugins/inventory/vms.py
@@ -279,6 +279,8 @@ class InventoryModule(VmwareInventoryBase):
         return hostvars
 
     def __update_inventory(self, vm):
+        if self.host_should_be_filtered_out(vm):
+            return
         self.add_host_to_inventory(vm)
         self.add_host_to_groups_based_on_path(vm)
         self.set_host_variables_from_host_properties(vm)


### PR DESCRIPTION
##### SUMMARY
The VM inventory is missing the actual method call to filter hosts out. This adds that in. There is another changelog that already captures this addition

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vms inventory