### PR TITLE
Bugfix/add longer esxi wait

### DIFF
--- a/changelogs/fragments/142-add-longer-wait-to-esxi-tests.yml
+++ b/changelogs/fragments/142-add-longer-wait-to-esxi-tests.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - test - Add a longer wait period to ESXi tests, since DHCP can take awhile

--- a/changelogs/fragments/142-add-longer-wait-to-esxi-tests.yml
+++ b/changelogs/fragments/142-add-longer-wait-to-esxi-tests.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+trivial:
   - test - Add a longer wait period to ESXi tests, since DHCP can take awhile

--- a/tests/integration/targets/vmware_esxi_connection/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_connection/tasks/eco-vcenter.yml
@@ -69,7 +69,9 @@
         validate_certs: false
         name: "{{ test_esxi_hostname }}"
       register: _esxi_info
-      until: _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4
+      until: >-
+        _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4 and
+        not _esxi_info.guests[0].ipv4.startswith('169.254')
       retries: 60
       delay: 5
 

--- a/tests/integration/targets/vmware_esxi_connection/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_connection/tasks/eco-vcenter.yml
@@ -70,7 +70,7 @@
         name: "{{ test_esxi_hostname }}"
       register: _esxi_info
       until: _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4
-      retries: 15
+      retries: 60
       delay: 5
 
     - name: Pause for 15 seconds to ensure host is ready

--- a/tests/integration/targets/vmware_esxi_host/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_host/tasks/eco-vcenter.yml
@@ -82,7 +82,9 @@
         validate_certs: false
         name: "{{ test_esxi_hostname }}"
       register: _esxi_info
-      until: _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4
+      until: >-
+        _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4 and
+        not _esxi_info.guests[0].ipv4.startswith('169.254')
       retries: 60
       delay: 5
 

--- a/tests/integration/targets/vmware_esxi_host/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_host/tasks/eco-vcenter.yml
@@ -83,7 +83,7 @@
         name: "{{ test_esxi_hostname }}"
       register: _esxi_info
       until: _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4
-      retries: 15
+      retries: 60
       delay: 5
 
     - name: Pause for 15 seconds to ensure host is ready

--- a/tests/integration/targets/vmware_esxi_maintenance_mode/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_maintenance_mode/tasks/eco-vcenter.yml
@@ -69,7 +69,9 @@
         validate_certs: false
         name: "{{ test_esxi_hostname }}"
       register: _esxi_info
-      until: _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4
+      until: >-
+        _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4 and
+        not _esxi_info.guests[0].ipv4.startswith('169.254')
       retries: 60
       delay: 5
 

--- a/tests/integration/targets/vmware_esxi_maintenance_mode/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_maintenance_mode/tasks/eco-vcenter.yml
@@ -70,7 +70,7 @@
         name: "{{ test_esxi_hostname }}"
       register: _esxi_info
       until: _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4
-      retries: 15
+      retries: 60
       delay: 5
 
     - name: Pause for 15 seconds to ensure host is ready


### PR DESCRIPTION
##### SUMMARY
Adds a longer wait time to ESXi tests. The DHCP process in the test lab can take longer than the original wait time, so this should help more tests pass.

##### ISSUE TYPE
- Bugfix Pull Request

