### PR TITLE
drop ansible 2.15 support

### DIFF
--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -74,7 +74,6 @@ jobs:
           # Add new versions announced in
           # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
           # consider dropping testing against EOL versions and versions you don't support.
-          - stable-2.15
           - stable-2.16
           - stable-2.17
           - stable-2.18

--- a/.github/workflows/ansible-unit.yml
+++ b/.github/workflows/ansible-unit.yml
@@ -56,9 +56,9 @@ jobs:
           # oldest versions of each that we support
           - { python: 3.13, ansible: stable-2.18 }
           - { python: 3.8, ansible: stable-2.18 }
-          - { python: 3.11, ansible: stable-2.15 }
-          - { python: 3.5, ansible: stable-2.15 }
-          - { python: 2.7, ansible: stable-2.15 }
+          - { python: 3.12, ansible: stable-2.16 }
+          - { python: 3.6, ansible: stable-2.16 }
+          - { python: 2.7, ansible: stable-2.16 }
 
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once the collection is installed, you can install them into a python environment
 
 ### Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15.0**.
+This collection has been tested against following Ansible versions: **>=2.16.0**.
 
 
 ## Installation

--- a/changelogs/fragments/146-drop-ansible-215.yml
+++ b/changelogs/fragments/146-drop-ansible-215.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - drop support for ansible 2.15 since it is EOL https://github.com/ansible-collections/vmware.vmware/issues/103

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 action_groups:
     vmware:
         - appliance_info


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/103

Drop support for ansible core 2.15 since it is EOL.

##### ISSUE TYPE
- Feature Pull Request
