### PR TITLE
add vm search params to content_template

### DIFF
--- a/changelogs/fragments/150-stadardize-vm-search-content-template.yml
+++ b/changelogs/fragments/150-stadardize-vm-search-content-template.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - content_template - Added more options to search for the source VM like uuid and moid. Also made argument validation more accurate

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -179,11 +179,12 @@ class VmwareContentTemplate(ModuleRestBase):
         self.library_id = self.get_content_library_ids(name=self.params.get('library'), fail_on_missing=True)[0]
         self.template_folder = self.params.get('template_folder')
 
-        pyvmomi = ModulePyvmomiBase(module)
-        self.vm = pyvmomi.get_vms_using_params(
-            vm_param='vm_name', uuid_param='vm_uuid', moid_param='vm_moid',
-            name_match_param='vm_name_match', folder_param='vm_folder', fail_on_missing=True
-        )[0]
+        if self.params['state'] == 'present':
+            pyvmomi = ModulePyvmomiBase(module)
+            self.vm = pyvmomi.get_vms_using_params(
+                vm_param='vm_name', uuid_param='vm_uuid', moid_param='vm_moid',
+                name_match_param='vm_name_match', folder_param='vm_folder', fail_on_missing=True
+            )[0]
 
     def create_template_from_vm(self):
         _template = self.get_library_item_ids(name=self.template_name, library_id=self.library_id)

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -182,7 +182,7 @@ class VmwareContentTemplate(ModuleRestBase):
         if self.params['state'] == 'present':
             pyvmomi = ModulePyvmomiBase(module)
             self.vm = pyvmomi.get_vms_using_params(
-                vm_param='vm_name', uuid_param='vm_uuid', moid_param='vm_moid',
+                name_param='vm_name', uuid_param='vm_uuid', moid_param='vm_moid',
                 name_match_param='vm_name_match', folder_param='vm_folder', fail_on_missing=True
             )[0]
 

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -39,13 +39,13 @@ options:
     vm_uuid:
         description:
             - UUID of the instance to manage if known, this is VMware's unique identifier.
-            - This is required if O(vm_moid) or O(vm_uuid) is not supplied.
+            - This is required if O(vm_moid) or O(vm_name) is not supplied.
             - A VM identifier is required when O(state) is present.
         type: str
     vm_moid:
         description:
             - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
-            - This is required if O(vm_moid) or O(vm_uuid) is not supplied.
+            - This is required if O(vm_name) or O(vm_uuid) is not supplied.
             - A VM identifier is required when O(state) is present.
         type: str
     use_instance_uuid:
@@ -94,12 +94,16 @@ options:
             - If not specified, the system will attempt to choose a suitable resource pool
               for the virtual machine template; if a resource pool cannot be
               chosen, the library item creation operation will fail.
+            - If O(cluster) and O(resource_pool) are both specified, O(resource_pool) must belong
+              to O(cluster).
+            - If O(host) and O(resource_pool) are both specified, O(resource_pool)
+              must belong to O(host).
         type: str
     cluster:
         description:
             - Cluster onto which the virtual machine template should be placed.
-            - If O(cluster) and O(resource_pool) are both specified,
-              O(resource_pool) must belong to O(cluster).
+            - If O(cluster) and O(resource_pool) are both specified, O(resource_pool) must belong
+              to O(cluster).
             - If O(cluster) and O(host) are both specified, O(host) must be a member of O(cluster).
             - This attribute was added in vSphere API 6.8.
         type: str

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -209,7 +209,7 @@ class VmwareContentTemplate(ModuleRestBase):
             name=self.template_name,
             placement=placement_spec,
             library=self.library_id,
-            source_vm=self.vm,
+            source_vm=self.vm._GetMoId(),
         )
         template_id = ''
         try:

--- a/tests/integration/targets/vmware_content_template/run.yml
+++ b/tests/integration/targets/vmware_content_template/run.yml
@@ -12,9 +12,9 @@
         file: vars.yml
       tags: integration-ci
 
-    - name: Prepare rest
+    - name: Setup VCenter simulator
       ansible.builtin.import_role:
-        name: prepare_rest
+        name: prepare_combined_vcenter_simulator
       tags: integration-ci
 
     - name: Import vmware_content_template role

--- a/tests/integration/targets/vmware_content_template/vars.yml
+++ b/tests/integration/targets/vmware_content_template/vars.yml
@@ -1,7 +1,7 @@
 vcenter_hostname: "127.0.0.1"
 vcenter_username: "user"
 vcenter_password: "pass"
-vcenter_port: 1080
+vcenter_port: 9000
 
 mock_file: "vmware_content_template"
 

--- a/tests/integration/targets/vmware_content_template/vars.yml
+++ b/tests/integration/targets/vmware_content_template/vars.yml
@@ -6,7 +6,7 @@ vcenter_port: 9000
 mock_file: "vmware_content_template"
 
 run_on_simulator: true
-vm: test
+vm: DC0_H0_VM0
 template_host: 1.2.3.4.
 library: templates
 template_name: mytemplate

--- a/tests/unit/plugins/modules/test_content_template.py
+++ b/tests/unit/plugins/modules/test_content_template.py
@@ -1,0 +1,108 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.content_template import (
+    VmwareContentTemplate,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import PyvmomiClient
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import ModulePyvmomiBase
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import (
+    VmwareRestClient
+)
+from ...common.utils import (
+    AnsibleExitJson, ModuleTestCase, set_module_args,
+)
+from ...common.vmware_object_mocks import (
+    create_mock_vsphere_object,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestContentTemplate(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        self.mock_rest_client = mocker.Mock()
+        mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=self.mock_rest_client)
+
+        mocker.patch.object(VmwareContentTemplate, 'get_content_library_ids', return_value=[1])
+        mocker.patch.object(ModulePyvmomiBase, 'get_vms_using_params', return_value=[create_mock_vsphere_object()])
+
+        self.default_module_args = dict(
+            hostname="127.0.0.1",
+            username="administrator@local",
+            password="123456",
+            add_cluster=False,
+            template_name='bar',
+            library='bizz'
+        )
+
+    # def test_gather(self, mocker):
+    #     self.__prepare(mocker)
+
+    #     set_module_args(**self.default_module_args)
+
+    #     with pytest.raises(AnsibleExitJson) as c:
+    #         content_library_item_info.main()
+
+    def test_absent_no_template(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(VmwareContentTemplate, 'get_library_item_ids', return_value=[])
+
+        set_module_args(**self.default_module_args, **{'state': 'absent'})
+
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is False
+        self.mock_rest_client.content.library.Item.delete.assert_not_called()
+
+    def test_absent_template(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(VmwareContentTemplate, 'get_library_item_ids', return_value=[1])
+        set_module_args(**self.default_module_args, **{'state': 'absent'})
+
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is True
+        self.mock_rest_client.content.library.Item.delete.assert_called_once_with(1)
+
+    def test_present_template(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(VmwareContentTemplate, 'get_library_item_ids', return_value=[1])
+        set_module_args(**{
+            **self.default_module_args,
+            **{'state': 'present', 'vm_name': 'foo', 'add_cluster': True}
+        })
+
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is False
+        self.mock_rest_client.vcenter.vm_template.LibraryItems.create.assert_not_called()
+
+    def test_present_no_template(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(VmwareContentTemplate, 'get_library_item_ids', return_value=[])
+        mocker.patch.object(VmwareContentTemplate, 'get_host_by_name', return_value=1)
+        mocker.patch.object(VmwareContentTemplate, 'get_resource_pool_by_name', return_value=2)
+        mocker.patch.object(VmwareContentTemplate, 'get_cluster_by_name', return_value=3)
+        mocker.patch.object(VmwareContentTemplate, 'get_folder_by_name', return_value=4)
+        set_module_args(**{
+            **self.default_module_args,
+            **{'state': 'present', 'vm_name': 'foo', 'add_cluster': True}
+        })
+
+        with pytest.raises(AnsibleExitJson) as c:
+            module_main()
+
+        assert c.value.args[0]["changed"] is True
+        self.mock_rest_client.vcenter.vm_template.LibraryItems.create.assert_called_once()


### PR DESCRIPTION
##### SUMMARY
Adds standard VM search params to the content_template module (uuid, moid, name_match etc).
Also makes the module arg validation more accurate

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
content_template

##### ADDITIONAL INFORMATION
All of the changes are backwards compatible