### PR TITLE
fix license info test

### DIFF
--- a/tests/integration/targets/vmware_license_info/defaults/main.yml
+++ b/tests/integration/targets/vmware_license_info/defaults/main.yml
@@ -1,2 +1,1 @@
 run_on_simulator: false
-licenses_length: 5

--- a/tests/integration/targets/vmware_license_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_license_info/tasks/main.yml
@@ -17,4 +17,4 @@
   ansible.builtin.assert:
     that:
       - __res.changed == False
-      - __res.licenses | length == licenses_length
+      - __res.licenses | length > 1


### PR DESCRIPTION
##### SUMMARY
Fixes the license info test. Someone added a new license to the lab, so the old check is invalid. I think it makes sense to just check if more than one license is returned, since we know that should always be true and the exact number isnt as important

##### ISSUE TYPE
- Bugfix Pull Request

