### PR TITLE
fix datastore cluster lookups

### DIFF
--- a/changelogs/fragments/151-fix-datastore-cluster-lookup.yml
+++ b/changelogs/fragments/151-fix-datastore-cluster-lookup.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix method to lookup datastore clusters by name or moid https://github.com/ansible-collections/vmware.vmware/issues/152

--- a/plugins/module_utils/_module_pyvmomi_base.py
+++ b/plugins/module_utils/_module_pyvmomi_base.py
@@ -253,7 +253,7 @@ class ModulePyvmomiBase(PyvmomiClient):
         """
         search_folder = None
         if datacenter and hasattr(datacenter, 'datastoreFolder'):
-            search_folder = datacenter.hostFolder
+            search_folder = datacenter.datastoreFolder
 
         data_store_cluster = self.get_objs_by_name_or_moid(
             [vim.StoragePod],

--- a/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
+++ b/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
@@ -9,6 +9,7 @@ from ...common.utils import set_module_args, fail_json, AnsibleFailJson
 from ...common.vmware_object_mocks import create_mock_vsphere_object
 from pyVmomi import vim
 import pytest
+from unittest.mock import ANY
 
 
 class TestModulePyvmomiBase():
@@ -140,6 +141,13 @@ class TestModulePyvmomiBase():
         mocker.patch.object(self.base, 'get_objs_by_name_or_moid', return_value=[])
         self.base.get_datastore_cluster_by_name_or_moid('foo', fail_on_missing=True)
         mock_fail.assert_called_once()
+
+        # test datacenter param
+        datacenter = mocker.Mock()
+        mocker.patch.object(self.base, 'get_objs_by_name_or_moid', return_value=[])
+        self.base.get_datastore_cluster_by_name_or_moid('foo', datacenter=datacenter)
+        self.base.get_objs_by_name_or_moid.assert_called_once_with(
+            ANY, ANY, return_all=ANY, search_root_folder=datacenter.datastoreFolder)
 
     def test_get_resource_pool_by_name_or_moid(self, mocker):
         self.__prepare(mocker)


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/152

When looking up a datastore cluster by name or moid, the wrong folder was used if a datacenter was provided. This fixes that issue

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
_module_pyvmomi_base
