### PR TITLE
add warnings and errors for duplicate hosts in inventorys

### DIFF
--- a/changelogs/fragments/153-warn-on-duplicate-names-in-inven.yml
+++ b/changelogs/fragments/153-warn-on-duplicate-names-in-inven.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Warn the user when more than one host has the same name in the inventory plugins. Throw an error if strict is true

--- a/plugins/inventory/esxi_hosts.py
+++ b/plugins/inventory/esxi_hosts.py
@@ -70,6 +70,8 @@ search_paths:
   - /DC3
 
 # Set custom inventory hostnames based on attributes
+# If more than one host has the same name, only the first host is shown in the inventory and a warning is thrown.
+# If strict is true, this warning is considered a fatal error.
 hostnames:
   - "'ESXi - ' + name + ' - ' + management_ip"
   - "'ESXi - ' + name"
@@ -240,31 +242,18 @@ class InventoryModule(VmwareInventoryBase):
                 self.add_tags_to_object_properties(esxi_host)
 
             self.set_inventory_hostname(esxi_host)
-            if esxi_host.inventory_hostname not in hostvars:
-                hostvars[esxi_host.inventory_hostname] = esxi_host.properties
-                self.__update_inventory(esxi_host)
+            self.add_host_object_from_vcenter_to_inventory(new_host=esxi_host, hostvars=hostvars)
 
         return hostvars
 
-    def __update_inventory(self, esxi_host):
-        if self.host_should_be_filtered_out(esxi_host):
-            return
-        self.add_host_to_inventory(esxi_host)
-        self.add_host_to_groups_based_on_path(esxi_host)
-        self.set_host_variables_from_host_properties(esxi_host)
-
-    def add_host_to_inventory(self, esxi_host: EsxiInventoryHost):
+    def set_default_ansible_host_var(self, vmware_host_object):
         """
-        Add the host to the inventory and any groups that the user wants to create based on inventory
-        parameters like groups or keyed groups.
+            Sets the default ansible_host var. This is usually an IP that is dependent on the object type.
+            This is a default because the user can override this via compose
+            Args:
+              vmware_host_object: EsxiInventoryHost, The host object that should be used
         """
-        strict = self.get_option("strict")
-        self.inventory.add_host(esxi_host.inventory_hostname)
-        self.inventory.set_variable(esxi_host.inventory_hostname, "ansible_host", esxi_host.management_ip)
-
-        self._set_composite_vars(
-            self.get_option("compose"), esxi_host.properties, esxi_host.inventory_hostname, strict=strict)
-        self._add_host_to_composed_groups(
-            self.get_option("groups"), esxi_host.properties, esxi_host.inventory_hostname, strict=strict)
-        self._add_host_to_keyed_groups(
-            self.get_option("keyed_groups"), esxi_host.properties, esxi_host.inventory_hostname, strict=strict)
+        self.inventory.set_variable(
+            vmware_host_object.inventory_hostname, "ansible_host",
+            vmware_host_object.management_ip
+        )

--- a/plugins/inventory/vms.py
+++ b/plugins/inventory/vms.py
@@ -80,6 +80,8 @@ search_paths:
 filter_expressions:
   - 'summary.runtime.powerState == "poweredOff"'
 # Set custom inventory hostnames based on attributes
+# If more than one host has the same name, only the first host is shown in the inventory and a warning is thrown.
+# If strict is true, this warning is considered a fatal error.
 hostnames:
   - "'VM - ' + name + ' - ' + guest.ipAddress"
   - "'VM - ' + name + ' - ' + config.instanceUuid"
@@ -272,31 +274,18 @@ class InventoryModule(VmwareInventoryBase):
                 self.add_tags_to_object_properties(vm)
 
             self.set_inventory_hostname(vm)
-            if vm.inventory_hostname not in hostvars:
-                hostvars[vm.inventory_hostname] = vm.properties
-                self.__update_inventory(vm)
+            self.add_host_object_from_vcenter_to_inventory(new_host=vm, hostvars=hostvars)
 
         return hostvars
 
-    def __update_inventory(self, vm):
-        if self.host_should_be_filtered_out(vm):
-            return
-        self.add_host_to_inventory(vm)
-        self.add_host_to_groups_based_on_path(vm)
-        self.set_host_variables_from_host_properties(vm)
-
-    def add_host_to_inventory(self, vm: VmInventoryHost):
+    def set_default_ansible_host_var(self, vmware_host_object):
         """
-        Add the host to the inventory and any groups that the user wants to create based on inventory
-        parameters like groups or keyed groups.
+            Sets the default ansible_host var. This is usually an IP that is dependent on the object type.
+            This is a default because the user can override this via compose
+            Args:
+              vmware_host_object: EsxiInventoryHost, The host object that should be used
         """
-        strict = self.get_option("strict")
-        self.inventory.add_host(vm.inventory_hostname)
-        self.inventory.set_variable(vm.inventory_hostname, "ansible_host", vm.guest_ip)
-
-        self._set_composite_vars(
-            self.get_option("compose"), vm.properties, vm.inventory_hostname, strict=strict)
-        self._add_host_to_composed_groups(
-            self.get_option("groups"), vm.properties, vm.inventory_hostname, strict=strict)
-        self._add_host_to_keyed_groups(
-            self.get_option("keyed_groups"), vm.properties, vm.inventory_hostname, strict=strict)
+        self.inventory.set_variable(
+            vmware_host_object.inventory_hostname, "ansible_host",
+            vmware_host_object.guest_ip
+        )

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -13,7 +13,7 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cachea
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
+from ansible.utils.display import Display
 
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import PyvmomiClient
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import VmwareRestClient
@@ -24,6 +24,9 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vmware_facts import
     vmware_obj_to_json,
     flatten_dict
 )
+
+
+DISPLAY = Display()
 
 
 class VmwareInventoryHost(ABC):
@@ -345,3 +348,62 @@ class VmwareInventoryBase(BaseInventoryPlugin, Constructable, Cacheable):
                     )
 
         return False
+
+    def _handle_duplicate_host(self, existing_host_vars, new_host):
+        """
+            Handles the instance where two hosts have the same inventory hostname. If the user has strict set to true, this
+            should be an error. Otherwise it is just a warning.
+            Args:
+                existing_host_vars: dict, The host properties of the existing host (for example, hostvars[inventory_hostname])
+                new_host: VmwareInventoryHost, The host object that was going to be added, but is a duplicate hostname of another
+        """
+        if self.get_option('strict'):
+            raise AnsibleError(
+                "Host %s has the same inventory hostname (%s) as %s. This is a fatal issue since strict is true." %
+                (existing_host_vars['moid'], new_host.inventory_hostname, new_host.object._GetMoId())
+            )
+        else:
+            DISPLAY.warning(
+                "Host %s has the same inventory hostname (%s) as %s. Only the first host, %s, will be included since strict is false." %
+                (existing_host_vars['moid'], new_host.inventory_hostname, new_host.object._GetMoId(), existing_host_vars['moid'])
+            )
+
+    def add_host_object_from_vcenter_to_inventory(self, new_host, hostvars):
+        """
+            Add a new host to the inventory and populate host vars based on object properties.
+            If the host should be filtered out or if a host with the same name already exists, this method will handle that
+            and simply return without processing the host.
+            Args:
+                new_host: VmwareInventoryHost, The new host to add to the inventory
+                hostvars: dict, The hostvars dict that should be updated with the new host's properties
+        """
+        if new_host.inventory_hostname in hostvars:
+            self._handle_duplicate_host(hostvars[new_host.inventory_hostname], new_host)
+            return
+
+        if self.host_should_be_filtered_out(new_host):
+            return
+
+        hostvars[new_host.inventory_hostname] = new_host.properties
+        self.inventory.add_host(new_host.inventory_hostname)
+        self.set_default_ansible_host_var(new_host)
+
+        _strict = self.get_option("strict")
+        self._set_composite_vars(
+            self.get_option("compose"), new_host.properties, new_host.inventory_hostname, strict=_strict)
+        self._add_host_to_composed_groups(
+            self.get_option("groups"), new_host.properties, new_host.inventory_hostname, strict=_strict)
+        self._add_host_to_keyed_groups(
+            self.get_option("keyed_groups"), new_host.properties, new_host.inventory_hostname, strict=_strict)
+
+        self.add_host_to_groups_based_on_path(new_host)
+        self.set_host_variables_from_host_properties(new_host)
+
+    def set_default_ansible_host_var(self, vmware_host_object):
+        """
+            Sets the default ansible_host var. This is usually an IP that is dependent on the object type.
+            This is a default because the user can override this via compose
+            Args:
+              vmware_host_object: The host object that should be used. The type will be dependent on the plugin type.
+        """
+        raise NotImplementedError('ansible_host should be defined in the inventory plugin class.')


### PR DESCRIPTION
##### SUMMARY
Adds a warning/error if more than one host has the same inventory hostname in the inventory plugins.
Also moved a bunch of duplicate code from the esxi/vms plugins to the base plugin class

Previously, the plugins would just silently skip the duplicate hosts

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vm and esxi inventory plugins
