### PR TITLE
fix required param issue for vm inven

### DIFF
--- a/changelogs/fragments/158-add-missing-props-to-inven.yml
+++ b/changelogs/fragments/158-add-missing-props-to-inven.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - vms inventory - Fixed issue where a user could accidentally not collect a required parameter, config.guestId

--- a/plugins/inventory/esxi_hosts.py
+++ b/plugins/inventory/esxi_hosts.py
@@ -202,8 +202,13 @@ class InventoryModule(VmwareInventoryBase):
         if "name" not in properties_param:
             properties_param.append("name")
 
+        # needed to filter out disconnected or unreachable hosts in self.populate_from_vcenter
         if "summary.runtime.connectionState" not in properties_param:
             properties_param.append("summary.runtime.connectionState")
+
+        # needed by keyed_groups default
+        if "summary.runtime.powerState" not in properties_param:
+            properties_param.append("summary.runtime.powerState")
 
         return properties_param
 

--- a/plugins/inventory/vms.py
+++ b/plugins/inventory/vms.py
@@ -237,6 +237,11 @@ class InventoryModule(VmwareInventoryBase):
         if "name" not in properties_param:
             properties_param.append("name")
 
+        # needed by keyed_groups default value
+        if "config.guestId" not in properties_param:
+            properties_param.append("config.guestId")
+
+        # needed by keyed_groups default value
         if "summary.runtime.powerState" not in properties_param:
             properties_param.append("summary.runtime.powerState")
 


### PR DESCRIPTION
##### SUMMARY
When a user has the default keyed_groups values for the vm inventory, it is easy to accidentally not collect required config properties. Although we do warn users about making sure the required props are collected if they change settings, this seems like an easy issue to fall into without really understanding why.

This change makes sure that we collect the parameters that are required for the default keyed_groups

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vms inven

##### ADDITIONAL INFORMATION
Also added some comments to help indicate why we make sure certain props are collected