### PR TITLE
ensure snapshot output when state is present

### DIFF
--- a/changelogs/fragments/166-fix-snapshot-outputs.yml
+++ b/changelogs/fragments/166-fix-snapshot-outputs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vm_snapshot - Make sure snapshot output is always included if state is present

--- a/tests/integration/targets/vmware_vm_snapshot/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_snapshot/tasks/main.yml
@@ -7,9 +7,9 @@
 
     - name: Create Virtual Machine From OVF Template
       vmware.vmware.deploy_content_library_ovf:
-        hostname: '{{ vcenter_hostname }}'
-        username: '{{ vcenter_username }}'
-        password: '{{ vcenter_password }}'
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
         validate_certs: false
         library_item_name: "{{ rhel9_content_library_ovf }}"
         vm_name: "{{ vm }}"
@@ -29,50 +29,9 @@
         snapshot_name: snap1
         description: snap1_description
         validate_certs: false
-      register: deploy
-    
-    - name: Gather some info from vm
-      vmware.vmware.guest_info:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        name: "{{ vm }}"
-        validate_certs: false
-      register: info
+      register: _create
 
-    - name: Verify snapshot taken
-      ansible.builtin.assert:
-        that:
-          - info.guests[0].snapshots[0].name == 'snap1'
-          - info.guests[0].snapshots[0].description == 'snap1_description'
-
-    - name: Remove a snapshot
-      vmware.vmware.vm_snapshot:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "/{{ vm_datacenter }}/vm/"
-        name: "{{ vm }}"
-        state: absent
-        snapshot_name: snap1
-        validate_certs: false
-
-    - name: Gather info from vm
-      vmware.vmware.guest_info:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        name: "{{ vm }}"
-        validate_certs: false
-      register: info
-      
-    - name: Verify snapshot removed
-      ansible.builtin.assert:
-        that:
-          - info.guests[0].snapshots == []
-
-    - name: Create a snapshot
+    - name: Create a snapshot - Idempotence
       vmware.vmware.vm_snapshot:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -84,8 +43,8 @@
         snapshot_name: snap1
         description: snap1_description
         validate_certs: false
-      register: deploy
-    
+      register: _create_idem
+
     - name: Gather some info from vm
       vmware.vmware.guest_info:
         hostname: "{{ vcenter_hostname }}"
@@ -95,11 +54,161 @@
         validate_certs: false
       register: info
 
-    - name: Verify snapshot taken
+    - name: Verify snapshot created
       ansible.builtin.assert:
         that:
-          - info.guests[0].snapshots[0].name == 'snap1'
-          - info.guests[0].snapshots[0].description == 'snap1_description'
+          - snapshot_info.name == 'snap1'
+          - snapshot_info.name == _create.snapshot.name
+          - snapshot_info.id == _create.snapshot.id
+          - snapshot_info.description == 'snap1_description'
+          - _create_idem is not changed
+      vars:
+        snapshot_info: "{{ info.guests[0].snapshots[0] }}"
+
+    - name: Rename Snapshot
+      vmware.vmware.vm_snapshot:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vm_datacenter }}"
+        folder: "/{{ vm_datacenter }}/vm/"
+        name: "{{ vm }}"
+        state: present
+        snapshot_name: snap1
+        description: snap1_description
+        validate_certs: false
+        new_snapshot_name: new_name1
+      register: _rename
+
+    - name: Gather some info from vm
+      vmware.vmware.guest_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: "{{ vm }}"
+        validate_certs: false
+      register: info
+
+    - name: Verify snapshot renamed
+      ansible.builtin.assert:
+        that:
+          - snapshot_info.name == 'new_name1'
+      vars:
+        snapshot_info: "{{ info.guests[0].snapshots[0] }}"
+
+    - name: Take a second snap with more options
+      vmware.vmware.vm_snapshot:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vm_datacenter }}"
+        folder: "/{{ vm_datacenter }}/vm/"
+        name: "{{ vm }}"
+        state: present
+        snapshot_name: snap02
+        quiesce: true
+        memory_dump: true
+        validate_certs: false
+
+    - name: Take even more snaps
+      vmware.vmware.vm_snapshot:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vm_datacenter }}"
+        folder: "/{{ vm_datacenter }}/vm/"
+        name: "{{ vm }}"
+        state: present
+        snapshot_name: snap0{{ item }}
+        validate_certs: false
+      loop:
+        - 3
+        - 4
+        - 5
+        - 6
+
+    - name: Gather some info from vm
+      vmware.vmware.guest_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: "{{ vm }}"
+        validate_certs: false
+      register: info
+
+    - name: Verify snapshot length
+      ansible.builtin.assert:
+        that:
+          - info.guests[0].snapshots | length == 6
+
+    - name: Remove a single snapshot
+      vmware.vmware.vm_snapshot:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vm_datacenter }}"
+        folder: "/{{ vm_datacenter }}/vm/"
+        name: "{{ vm }}"
+        state: absent
+        snapshot_name: snap06
+        validate_certs: false
+      register: _rm_single
+
+    - name: Remove a snapshot - Idemptoence
+      vmware.vmware.vm_snapshot:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vm_datacenter }}"
+        folder: "/{{ vm_datacenter }}/vm/"
+        name: "{{ vm }}"
+        state: absent
+        snapshot_name: snap06
+        validate_certs: false
+      register: _rm_single_idem
+
+    - name: Gather some info from vm
+      vmware.vmware.guest_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: "{{ vm }}"
+        validate_certs: false
+      register: info
+
+    - name: Verify snapshot length
+      ansible.builtin.assert:
+        that:
+          - info.guests[0].snapshots | length == 5
+          - _rm_single_idem is not changed
+
+    - name: Remove a snapshot and snapshot subtree
+      vmware.vmware.vm_snapshot:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ vm_datacenter }}"
+        folder: "/{{ vm_datacenter }}/vm/"
+        name: "{{ vm }}"
+        state: absent
+        remove_children: true
+        snapshot_name: snap04
+        validate_certs: false
+
+    - name: Gather some info from vm
+      vmware.vmware.guest_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: "{{ vm }}"
+        validate_certs: false
+      register: info
+
+    - name: Verify snapshot length
+      ansible.builtin.assert:
+        that:
+          - info.guests[0].snapshots | length == 3
+          - _rm_single_idem is not changed
 
     - name: Remove all snapshots of a VM
       vmware.vmware.vm_snapshot:
@@ -113,34 +222,6 @@
         remove_all: True
         validate_certs: false
 
-    - name: Gather info from vm
-      vmware.vmware.guest_info:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        name: "{{ vm }}"
-        validate_certs: false
-      register: info
-      
-    - name: Verify snapshot removed
-      ansible.builtin.assert:
-        that:
-          - info.guests[0].snapshots == []
-
-    - name: Create a snapshot
-      vmware.vmware.vm_snapshot:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "/{{ vm_datacenter }}/vm/"
-        name: "{{ vm }}"
-        state: present
-        snapshot_name: snap1
-        description: snap1_description
-        validate_certs: false
-      register: deploy
-    
     - name: Gather some info from vm
       vmware.vmware.guest_info:
         hostname: "{{ vcenter_hostname }}"
@@ -150,77 +231,10 @@
         validate_certs: false
       register: info
 
-    - name: Verify snapshot taken
+    - name: Verify all snapshots removed
       ansible.builtin.assert:
         that:
-          - info.guests[0].snapshots[0].name == 'snap1'
-          - info.guests[0].snapshots[0].description == 'snap1_description'
-
-    - name: Remove all snapshots of a VM using MoID
-      vmware.vmware.vm_snapshot:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        moid: "{{ deploy.vm.moid }}"
-        state: absent
-        remove_all: True
-        validate_certs: false
-
-    - name: Gather info from vm
-      vmware.vmware.guest_info:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        name: "{{ vm }}"
-        validate_certs: false
-      register: info
-      
-    - name: Verify snapshot removed
-      ansible.builtin.assert:
-        that:
-          - info.guests[0].snapshots == []
-
-    - name: Take snapshot of a VM using quiesce and memory flag on
-      vmware.vmware.vm_snapshot:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "/{{ vm_datacenter }}/vm/"
-        name: "{{ vm }}"
-        state: present
-        snapshot_name: dummy_vm_snap_0001
-        quiesce: true
-        memory_dump: true
-        validate_certs: false
-      register: deploy
-
-    - name: Gather info from vm
-      vmware.vmware.guest_info:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        name: "{{ vm }}"
-        validate_certs: false
-      register: info
-
-    - name: Verify snapshot taken
-      ansible.builtin.assert:
-        that:
-          - info.guests[0].snapshots[0]
-
-    - name: Remove a snapshot and snapshot subtree
-      vmware.vmware.vm_snapshot:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "/{{ vm_datacenter }}/vm/"
-        name: "{{ vm }}"
-        state: absent
-        remove_children: true
-        snapshot_name: dummy_vm_snap_0001
-        validate_certs: false
+          - info.guests[0].snapshots | length == 0
 
     - name: Create a snapshot
       vmware.vmware.vm_snapshot:
@@ -234,48 +248,7 @@
         snapshot_name: snap1
         description: snap1_description
         validate_certs: false
-      register: deploy
-
-    - name: Verify snapshot present
-      vmware.vmware.vm_snapshot:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "/{{ vm_datacenter }}/vm/"
-        name: "{{ vm }}"
-        state: present
-        snapshot_name: snap1
-        validate_certs: false
-
-    - name: Rename a snapshot
-      vmware.vmware.vm_snapshot:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "/{{ vm_datacenter }}/vm/"
-        name: "{{ vm }}"
-        state: present
-        snapshot_name: snap1
-        new_snapshot_name: im_renamed
-        description: im_redescribed
-        validate_certs: false
-
-    - name: Gather info from vm
-      vmware.vmware.guest_info:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        name: "{{ vm }}"
-        validate_certs: false
-      register: info
-
-    - name: Verify snapshot renamed
-      ansible.builtin.assert:
-        that:
-          - info.guests[0].snapshots[0].name == 'im_renamed'
-          - info.guests[0].snapshots[0].description == 'im_redescribed'
+      register: _create
 
     - name: Remove a snapshot with a snapshot id
       vmware.vmware.vm_snapshot:
@@ -285,11 +258,11 @@
         datacenter: "{{ vm_datacenter }}"
         folder: "/{{ vm_datacenter }}/vm/"
         name: "{{ vm }}"
-        snapshot_id: "{{ deploy.snapshot_result.id }}"
+        snapshot_id: "{{ _create.snapshot.id }}"
         state: absent
         validate_certs: false
 
-    - name: Gather info from vm
+    - name: Gather some info from vm
       vmware.vmware.guest_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -298,11 +271,10 @@
         validate_certs: false
       register: info
 
-    - name: Verify snapshot removed
+    - name: Verify all snapshots removed
       ansible.builtin.assert:
         that:
-          - info.guests[0].snapshots == []
-
+          - info.guests[0].snapshots | length == 0
 
   always:
     - name: "Test teardown: Destroy VM guest {{ vm }}"

--- a/tests/unit/plugins/modules/test_vm_snapshot.py
+++ b/tests/unit/plugins/modules/test_vm_snapshot.py
@@ -14,7 +14,9 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
 from ...common.utils import (
     AnsibleExitJson, ModuleTestCase, set_module_args,
 )
-from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import RunningTaskMonitor
+from ...common.vmware_object_mocks import (
+    MockVsphereTask
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -27,29 +29,27 @@ class TestVmSnapshot(ModuleTestCase):
         self.content_mock = mocker.MagicMock()
         mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), self.content_mock))
         self.vm_mock = mocker.MagicMock()
+        mocker.patch.object(VmSnapshotModule, 'get_vms_using_params', return_value=([self.vm_mock]))
         self.vm_mock.configure_mock(
             **{
-                "RemoveAllSnapshots.return_value": type('', (object,), {"info": type('', (object,), {"state": "success"})()})(),
-                "CreateSnapshot.return_value": type('', (object,), {"info": type('', (object,), {"state": "success"})()})()
+                "RemoveAllSnapshots_Task.return_value": MockVsphereTask(),
+                "CreateSnapshot_Task.return_value": MockVsphereTask()
             }
         )
-        self.snap_object_mock = mocker.MagicMock()
-        self.snap_object_mock.configure_mock(
-            **{
-                "RenameSnapshot.return_value": type('', (object,), {"info": type('', (object,), {"state": "success"})()})(),
-                "RemoveSnapshot_Task.return_value": type('', (object,), {"info": type('', (object,), {"state": "success"})()})(),
-                "RevertToSnapshot_Task.return_value": type('', (object,), {"info": type('', (object,), {"state": "success"})()})()
-            }
-        )
-        self.external_snap_object_mock = mocker.MagicMock()
-        self.external_snap_object_mock.configure_mock(
-            **{
-                "snapshot.return_value": self.snap_object_mock
-            }
-        )
-        mocker.patch.object(VmSnapshotModule, 'get_vms_using_params', return_value=([self.vm_mock]))
-        mocker.patch.object(VmSnapshotModule, 'get_snapshot_by_identifier_recursively', return_value=(self.external_snap_object_mock))
-        mocker.patch.object(RunningTaskMonitor, 'wait_for_completion', return_value=(True, True))
+
+        self.snap1_mock = mocker.MagicMock()
+        self.snap1_mock.name = 'snap1'
+        self.snap1_mock.snapshot.RenameSnapshot.return_value = MockVsphereTask()
+        self.snap1_mock.snapshot.RemoveSnapshot_Task.return_value = MockVsphereTask()
+
+        self.snap2_mock = mocker.MagicMock()
+        self.snap2_mock.name = 'snap2'
+
+        self.snap3_mock = mocker.MagicMock()
+        self.snap3_mock.name = 'snap2'
+
+        self.snap3_mock.childSnapshotList = [self.snap2_mock]
+        self.snap2_mock.childSnapshotList = [self.snap1_mock]
 
     def test_take_snapshot(self, mocker):
         self.__prepare(mocker)
@@ -69,8 +69,6 @@ class TestVmSnapshot(ModuleTestCase):
         )
 
         self.vm_mock.snapshot = None
-        mocker.patch.object(VmSnapshotModule, 'get_snapshot_by_identifier_recursively', return_value=None)
-
         with pytest.raises(AnsibleExitJson) as c:
             module_main()
 
@@ -94,6 +92,8 @@ class TestVmSnapshot(ModuleTestCase):
             add_cluster=False
         )
 
+        self.vm_mock.snapshot = self.snap3_mock
+        self.snap3_mock.rootSnapshotList = [self.snap3_mock]
         with pytest.raises(AnsibleExitJson) as c:
             module_main()
 
@@ -115,6 +115,8 @@ class TestVmSnapshot(ModuleTestCase):
             add_cluster=False
         )
 
+        self.vm_mock.snapshot = self.snap3_mock
+        self.snap3_mock.rootSnapshotList = [self.snap3_mock]
         with pytest.raises(AnsibleExitJson) as c:
             module_main()
 


### PR DESCRIPTION
##### SUMMARY
This fixes an issue where the snapshot details were not included in every output. While testing I also found that removing snapshots when there are large snapshot trees did not work. I fixed that as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vm_snapshot

