### PR TITLE
add ansible 2.19 support

### DIFF
--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -77,6 +77,7 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
+          - stable-2.19
           - devel
         # - milestone
     runs-on: ubuntu-latest

--- a/.github/workflows/ansible-unit.yml
+++ b/.github/workflows/ansible-unit.yml
@@ -54,8 +54,8 @@ jobs:
         versions:
           # Testing all ansible and python versions is impractical. Only test the newest and
           # oldest versions of each that we support
-          - { python: 3.13, ansible: stable-2.18 }
-          - { python: 3.8, ansible: stable-2.18 }
+          - { python: 3.13, ansible: stable-2.19 }
+          - { python: 3.8, ansible: stable-2.19 }
           - { python: 3.12, ansible: stable-2.16 }
           - { python: 3.6, ansible: stable-2.16 }
           - { python: 2.7, ansible: stable-2.16 }

--- a/.github/workflows/eco-vcenter-ci.yaml
+++ b/.github/workflows/eco-vcenter-ci.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
+          pip install --pre ansible==2.19
           make eco-vcenter-ci
         working-directory: ansible_collections/vmware/vmware
         env:

--- a/.github/workflows/eco-vcenter-ci.yaml
+++ b/.github/workflows/eco-vcenter-ci.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install --pre ansible==2.19
+          pip install --pre ansible-core>=2.19
           make eco-vcenter-ci
         working-directory: ansible_collections/vmware/vmware
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Collection: vmware.vmware
 
- This repo hosts the `vmware.vmware` Ansible Collection.
+This repo hosts the `vmware.vmware` Ansible Collection.
 
 The **vmware.vmware** collection is part of the **Red Hat Ansible Certified Content for VMware** offering that brings Ansible automation to VMware. This collection brings forward the possibility to manage vSphere resources and automate operator tasks.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Collection: vmware.vmware
 
-This repo hosts the `vmware.vmware` Ansible Collection.
+ This repo hosts the `vmware.vmware` Ansible Collection.
 
 The **vmware.vmware** collection is part of the **Red Hat Ansible Certified Content for VMware** offering that brings Ansible automation to VMware. This collection brings forward the possibility to manage vSphere resources and automate operator tasks.
 

--- a/tests/unit/common/utils.py
+++ b/tests/unit/common/utils.py
@@ -5,23 +5,40 @@ __metaclass__ = type
 import json
 import contextlib
 import mock
+import pytest
 
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 
 
+def run_module(module_entry, module_args=None, expect_success=True):
+    """
+        Run the (mock) module and expect Ansible to exit without an error
+    """
+    raises = AnsibleExitJson if expect_success else AnsibleFailJson
+
+    if module_args is None:
+        module_args = {}
+
+    with pytest.raises(raises) as c, set_module_args(module_args):
+        module_entry()
+
+    return c.value.args[0]
+
+
 @contextlib.contextmanager
-def set_module_args(add_cluster=True, **args):
+def set_module_args(args=None):
     """
     Context manager that sets module arguments for AnsibleModule
     """
+    if args is None:
+        args = {}
+
     if '_ansible_remote_tmp' not in args:
         args['_ansible_remote_tmp'] = '/tmp'
     if '_ansible_keep_remote_files' not in args:
         args['_ansible_keep_remote_files'] = False
 
-    if add_cluster and 'cluster_name' not in args:
-        args["cluster_name"] = "mycluster"
     if 'hostname' not in args:
         args["hostname"] = "127.0.0.1"
     if 'username' not in args:

--- a/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
+++ b/tests/unit/plugins/module_utils/test_module_pyvmomi_base.py
@@ -16,11 +16,11 @@ class TestModulePyvmomiBase():
 
     def __prepare(self, mocker):
         mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
-        set_module_args()
-        module = mocker.Mock()
-        module.fail_json = fail_json
-        module.params = {"hostname": "a", "username": "b", "password": "c"}
-        self.base = ModulePyvmomiBase(module=module)
+        with set_module_args():
+            module = mocker.Mock()
+            module.fail_json = fail_json
+            module.params = {"hostname": "a", "username": "b", "password": "c"}
+            self.base = ModulePyvmomiBase(module=module)
 
     def test_is_vcenter(self, mocker):
         self.__prepare(mocker)

--- a/tests/unit/plugins/module_utils/test_module_rest_base.py
+++ b/tests/unit/plugins/module_utils/test_module_rest_base.py
@@ -12,10 +12,10 @@ class TestModuleRestBase():
 
     def __prepare(self, mocker):
         mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=mocker.Mock())
-        set_module_args()
-        module = mocker.Mock()
-        module.params = {"hostname": "a", "username": "b", "password": "c"}
-        self.base = ModuleRestBase(module=module)
+        with set_module_args():
+            module = mocker.Mock()
+            module.params = {"hostname": "a", "username": "b", "password": "c"}
+            self.base = ModuleRestBase(module=module)
 
     def test_get_vm_by_name(self, mocker):
         self.__prepare(mocker)

--- a/tests/unit/plugins/modules/test_appliance_info.py
+++ b/tests/unit/plugins/modules/test_appliance_info.py
@@ -7,7 +7,7 @@ import pytest
 from ansible_collections.vmware.vmware.plugins.modules import appliance_info
 
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -27,14 +27,9 @@ class TestApplianceInfo(ModuleTestCase):
     def test_gather(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        result = run_module(
+            module_entry=appliance_info.main,
+            module_args={}
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            appliance_info.main()
-
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False

--- a/tests/unit/plugins/modules/test_cluster.py
+++ b/tests/unit/plugins/modules/test_cluster.py
@@ -7,7 +7,7 @@ import pytest
 from ansible_collections.vmware.vmware.plugins.modules import cluster
 
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -33,16 +33,11 @@ class TestCluster(ModuleTestCase):
     def test_cluster(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="test",
             name="test"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            cluster.main()
-
-        assert c.value.args[0]["changed"] is True
-        assert c.value.args[0]["cluster"] == {"name": "test", "moid": "11111"}
+        result = run_module(module_entry=cluster.main, module_args=module_args)
+        assert result["changed"] is True
+        assert result["cluster"] == {"name": "test", "moid": "11111"}

--- a/tests/unit/plugins/modules/test_cluster_ha.py
+++ b/tests/unit/plugins/modules/test_cluster_ha.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     MockCluster
@@ -36,11 +36,7 @@ class TestClusterHa(ModuleTestCase):
     def test_bare_enable(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter="foo",
             cluster=self.test_cluster.name
         )
@@ -49,25 +45,17 @@ class TestClusterHa(ModuleTestCase):
         ha_config.enabled = True
         ha_config.defaultVmSettings.isolationResponse = 'none'
         ha_config.defaultVmSettings.vmComponentProtectionSettings.vmStorageProtectionForPDL = 'warning'
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
 
         ha_config.enabled = False
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
 
     def test_bare_disable(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter="foo",
             cluster=self.test_cluster.name,
             enable=False
@@ -75,13 +63,9 @@ class TestClusterHa(ModuleTestCase):
 
         ha_config = self.test_cluster.configurationEx.dasConfig
         ha_config.enabled = True
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
 
         ha_config.enabled = False
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False

--- a/tests/unit/plugins/modules/test_cluster_info.py
+++ b/tests/unit/plugins/modules/test_cluster_info.py
@@ -13,7 +13,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
 )
 
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import MockCluster
 
@@ -36,11 +36,5 @@ class TestClusterInfo(ModuleTestCase):
     def test_gather(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            add_cluster=True,
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args={'cluster': 'foo'})
+        assert result["changed"] is False

--- a/tests/unit/plugins/modules/test_cluster_vcls.py
+++ b/tests/unit/plugins/modules/test_cluster_vcls.py
@@ -13,7 +13,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     create_mock_vsphere_object,
@@ -42,72 +42,45 @@ class TestClusterVcls(ModuleTestCase):
 
         ds_to_add = ['ds1']
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
+            cluster='foo',
             datastores_to_add=ds_to_add
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
-        assert set(c.value.args[0]["added_datastores"]) == set(ds_to_add)
-        assert len(c.value.args[0]["removed_datastores"]) == 0
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert set(result["added_datastores"]) == set(ds_to_add)
+        assert len(result["removed_datastores"]) == 0
 
         self.test_cluster.configurationEx.systemVMsConfig.allowedDatastores = [
             create_mock_vsphere_object(name=ds_to_add[0])
         ]
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            datastores_to_add=ds_to_add
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
-        assert len(c.value.args[0]["added_datastores"]) == 0
-        assert len(c.value.args[0]["removed_datastores"]) == 0
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        assert len(result["added_datastores"]) == 0
+        assert len(result["removed_datastores"]) == 0
 
     def test_remove(self, mocker):
         self.__prepare(mocker)
 
         ds_to_remove = ['ds1']
-
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
+            cluster='foo',
             datastores_to_remove=ds_to_remove
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
-        assert len(c.value.args[0]["added_datastores"]) == 0
-        assert len(c.value.args[0]["removed_datastores"]) == 0
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        assert len(result["added_datastores"]) == 0
+        assert len(result["removed_datastores"]) == 0
 
         self.test_cluster.configurationEx.systemVMsConfig.allowedDatastores = [
             create_mock_vsphere_object(name=ds_to_remove[0])
         ]
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            datastores_to_remove=ds_to_remove
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
-        assert len(c.value.args[0]["added_datastores"]) == 0
-        assert set(c.value.args[0]["removed_datastores"]) == set(ds_to_remove)
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert len(result["added_datastores"]) == 0
+        assert set(result["removed_datastores"]) == set(ds_to_remove)
 
     def test_absolute_list(self, mocker):
         self.__prepare(mocker)
@@ -119,52 +92,30 @@ class TestClusterVcls(ModuleTestCase):
             create_mock_vsphere_object(name='ds3'),
         ]
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
+            cluster='foo',
             allowed_datastores=allowed_datastores
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
-        assert set(c.value.args[0]["added_datastores"]) == set([])
-        assert set(c.value.args[0]["removed_datastores"]) == set(['ds1', 'ds2'])
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert set(result["added_datastores"]) == set([])
+        assert set(result["removed_datastores"]) == set(['ds1', 'ds2'])
 
         self.test_cluster.configurationEx.systemVMsConfig.allowedDatastores = [
             create_mock_vsphere_object(name='ds3'),
         ]
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            allowed_datastores=allowed_datastores
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
-        assert set(c.value.args[0]["added_datastores"]) == set([])
-        assert set(c.value.args[0]["removed_datastores"]) == set([])
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        assert set(result["added_datastores"]) == set([])
+        assert set(result["removed_datastores"]) == set([])
 
         self.test_cluster.configurationEx.systemVMsConfig.allowedDatastores = [
             create_mock_vsphere_object(name='ds1'),
         ]
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            allowed_datastores=allowed_datastores
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
-        assert set(c.value.args[0]["added_datastores"]) == set(allowed_datastores)
-        assert set(c.value.args[0]["removed_datastores"]) == set(['ds1'])
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert set(result["added_datastores"]) == set(allowed_datastores)
+        assert set(result["removed_datastores"]) == set(['ds1'])

--- a/tests/unit/plugins/modules/test_content_library_item_info.py
+++ b/tests/unit/plugins/modules/test_content_library_item_info.py
@@ -7,7 +7,7 @@ import pytest
 from ansible_collections.vmware.vmware.plugins.modules import content_library_item_info
 
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -27,14 +27,5 @@ class TestGuestInfo(ModuleTestCase):
     def test_gather(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            content_library_item_info.main()
-
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=content_library_item_info.main, module_args={})
+        assert result["changed"] is False

--- a/tests/unit/plugins/modules/test_deploy_content_library_ovf.py
+++ b/tests/unit/plugins/modules/test_deploy_content_library_ovf.py
@@ -15,7 +15,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import 
     VmwareRestClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     MockVmwareObject
@@ -41,11 +41,7 @@ class TestDeployContentLibraryOvf(ModuleTestCase):
     def test_present(self, mocker):
         self.__prepare(mocker)
         mocker.patch.object(VmwareContentDeployOvf, 'get_deployed_vm', return_value=None)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             vm_name=self.test_vm.name,
             library_item_id='111',
             datastore='foo',
@@ -53,27 +49,11 @@ class TestDeployContentLibraryOvf(ModuleTestCase):
             resource_pool='foo'
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
-        assert c.value.args[0]["vm"]["moid"] is self.test_vm._GetMoId()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert result["vm"]["moid"] is self.test_vm._GetMoId()
 
         mocker.patch.object(VmwareContentDeployOvf, 'get_deployed_vm', return_value=self.test_vm)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
-            vm_name=self.test_vm.name,
-            library_item_id='111',
-            datastore='foo',
-            datacenter='foo',
-            resource_pool='foo'
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
-        assert c.value.args[0]["vm"]["moid"] is self.test_vm._GetMoId()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        assert result["vm"]["moid"] is self.test_vm._GetMoId()

--- a/tests/unit/plugins/modules/test_deploy_content_library_template.py
+++ b/tests/unit/plugins/modules/test_deploy_content_library_template.py
@@ -15,7 +15,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import 
     VmwareRestClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     MockVmwareObject
@@ -41,11 +41,7 @@ class TestDeployContentLibraryTemplate(ModuleTestCase):
     def test_present(self, mocker):
         self.__prepare(mocker)
         mocker.patch.object(VmwareContentDeployTemplate, 'get_deployed_vm', return_value=None)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             vm_name=self.test_vm.name,
             library_item_id='111',
             datastore='foo',
@@ -53,18 +49,12 @@ class TestDeployContentLibraryTemplate(ModuleTestCase):
             resource_pool='foo'
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
-        assert c.value.args[0]["vm"]["moid"] is self.test_vm._GetMoId()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert result["vm"]["moid"] is self.test_vm._GetMoId()
 
         mocker.patch.object(VmwareContentDeployTemplate, 'get_deployed_vm', return_value=self.test_vm)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             vm_name=self.test_vm.name,
             library_item_id='111',
             datastore='foo',
@@ -72,8 +62,6 @@ class TestDeployContentLibraryTemplate(ModuleTestCase):
             resource_pool='foo'
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
-        assert c.value.args[0]["vm"]["moid"] is self.test_vm._GetMoId()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        assert result["vm"]["moid"] is self.test_vm._GetMoId()

--- a/tests/unit/plugins/modules/test_deploy_folder_template.py
+++ b/tests/unit/plugins/modules/test_deploy_folder_template.py
@@ -15,7 +15,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import 
     VmwareRestClient
 )
 from ...common.utils import (
-    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     MockVmwareObject
@@ -46,71 +46,43 @@ class TestVmwareFolderTemplate(ModuleTestCase):
         self.__prepare(mocker)
         # test template_name
         mocker.patch.object(VmwareFolderTemplate, 'get_deployed_vm', return_value=None)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             vm_name=self.test_vm.name,
             template_name="foo",
             datacenter='foo',
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
-        assert c.value.args[0]["vm"]["moid"] is self.test_vm._GetMoId()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert result["vm"]["moid"] is self.test_vm._GetMoId()
 
         # test template_id
         mocker.patch.object(VmwareFolderTemplate, 'get_deployed_vm', return_value=None)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             vm_name=self.test_vm.name,
             template_id="foo",
             datacenter='foo',
         )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        assert result["vm"]["moid"] is self.test_vm._GetMoId()
 
         # test no change
         mocker.patch.object(VmwareFolderTemplate, 'get_deployed_vm', return_value=self.test_vm)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
-            vm_name=self.test_vm.name,
-            template_name="foo",
-            datacenter='foo',
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is False
-        assert c.value.args[0]["vm"]["moid"] is self.test_vm._GetMoId()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        assert result["vm"]["moid"] is self.test_vm._GetMoId()
 
     def test_template_error(self, mocker):
         self.__prepare(mocker)
         mocker.patch.object(VmwareFolderTemplate, 'get_deployed_vm', return_value=None)
         mocker.patch.object(VmwareFolderTemplate, 'get_objs_by_name_or_moid', return_value=None)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             vm_name=self.test_vm.name,
             template_id="foo",
             datacenter='foo',
         )
 
-        with pytest.raises(AnsibleFailJson) as c:
-            module_main()
-
-        assert c.value.args[0]["msg"].startswith('Unable to find template with ID')
-        assert c.value.args[0]["failed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args, expect_success=False)
+        assert result["msg"].startswith('Unable to find template with ID')
+        assert result["failed"] is True

--- a/tests/unit/plugins/modules/test_esxi_connection.py
+++ b/tests/unit/plugins/modules/test_esxi_connection.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     create_mock_vsphere_object,
@@ -37,70 +37,50 @@ class TestEsxiConnection(ModuleTestCase):
         self.__prepare(mocker)
         self.test_esxi.runtime.connectionState = 'connected'
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter="",
             esxi_host_name=self.test_esxi.name,
             state="connected"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
 
         self.test_esxi.runtime.connectionState = 'disconnected'
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter="",
             esxi_host_name=self.test_esxi.name,
             state="disconnected"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
 
     def test_state_connected(self, mocker):
         self.__prepare(mocker)
         self.test_esxi.runtime.connectionState = 'disconnected'
         self.test_esxi.ReconnectHost_Task.return_value = MockVsphereTask()
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter="",
             esxi_host_name=self.test_esxi.name,
             state="connected"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
 
     def test_state_disconnected(self, mocker):
         self.__prepare(mocker)
         self.test_esxi.runtime.connectionState = 'connected'
         self.test_esxi.DisconnectHost_Task.return_value = MockVsphereTask()
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter="",
             esxi_host_name=self.test_esxi.name,
             state="disconnected"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True

--- a/tests/unit/plugins/modules/test_esxi_host.py
+++ b/tests/unit/plugins/modules/test_esxi_host.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     create_mock_vsphere_object,
@@ -43,54 +43,41 @@ class TestEsxiHost(ModuleTestCase):
 
         self.test_esxi.parent = self.mock_cluster
         mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=True,
+        module_args = dict(
+            cluster='foo',
             datacenter='foo',
             esxi_host_name=self.test_esxi.name,
             esxi_username="foo",
             esxi_password="foo"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
 
         self.test_esxi.parent.parent = self.mock_folder
         mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter='foo',
             folder='bar',
             esxi_host_name=self.test_esxi.name,
             esxi_username="foo",
             esxi_password="foo"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
 
         mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=None)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=True,
+        module_args = dict(
+            cluster='foo',
             datacenter='foo',
             esxi_host_name=self.test_esxi.name,
             state='absent'
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
 
     def test_state_present(self, mocker):
         self.__prepare(mocker)
@@ -99,11 +86,7 @@ class TestEsxiHost(ModuleTestCase):
         self.mock_folder.AddStandaloneHost.return_value = MockVsphereTask()
         self.mock_folder.AddStandaloneHost.return_value.info.result = self.test_esxi
         mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=None)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter='foo',
             folder="foo/vm/bar",
             esxi_host_name=self.test_esxi.name,
@@ -111,10 +94,9 @@ class TestEsxiHost(ModuleTestCase):
             esxi_username="foo",
             esxi_password="foo"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
 
     def test_state_present_move(self, mocker):
         self.__prepare(mocker)
@@ -122,21 +104,17 @@ class TestEsxiHost(ModuleTestCase):
         self.test_esxi.parent = self.mock_folder
         self.mock_cluster.MoveHostInto_Task.return_value = MockVsphereTask()
         mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=True,
+        module_args = dict(
+            cluster='foo',
             datacenter='foo',
             esxi_host_name=self.test_esxi.name,
             ssl_thumbprint='fdsfadf',
             esxi_username="foo",
             esxi_password="foo"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
 
     def test_state_absent(self, mocker):
         self.__prepare(mocker)
@@ -144,11 +122,7 @@ class TestEsxiHost(ModuleTestCase):
         self.test_esxi.parent = self.mock_folder
         self.mock_folder.Destroy_Task.return_value = MockVsphereTask()
         mocker.patch.object(VmwareHost, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             datacenter='foo',
             folder="foo/vm/bar",
             esxi_host_name=self.test_esxi.name,
@@ -156,7 +130,6 @@ class TestEsxiHost(ModuleTestCase):
             esxi_username="foo",
             esxi_password="foo"
         )
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
 
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True

--- a/tests/unit/plugins/modules/test_esxi_maintenance_mode.py
+++ b/tests/unit/plugins/modules/test_esxi_maintenance_mode.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     MockEsxiHost
@@ -34,68 +34,46 @@ class TestEsxiMaintenanceMode(ModuleTestCase):
     def test_no_change(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name=self.test_esxi.name,
             enable_maintenance_mode=False
         )
         self.test_esxi.runtime.inMaintenanceMode = False
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name=self.test_esxi.name,
             enable_maintenance_mode=True
         )
         self.test_esxi.runtime.inMaintenanceMode = True
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False
 
     def test_enable(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name=self.test_esxi.name,
             enable_maintenance_mode=True
         )
         self.test_esxi.runtime.inMaintenanceMode = False
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
 
     def test_disable(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name=self.test_esxi.name,
             enable_maintenance_mode=False
         )
         self.test_esxi.runtime.inMaintenanceMode = True
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
-
-        assert c.value.args[0]["changed"] is True
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True

--- a/tests/unit/plugins/modules/test_folder.py
+++ b/tests/unit/plugins/modules/test_folder.py
@@ -13,7 +13,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     MockVmwareObject,
@@ -35,74 +35,54 @@ class TestEsxiMaintenanceMode(ModuleTestCase):
         self.__prepare(mocker)
         mocker.patch.object(VmwareFolder, 'get_folder_by_absolute_path', return_value=self.mock_folder)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             absolute_path="/DC0/host/test"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        assert c.value.args[0]["folder"]["moid"] is self.mock_folder._moId
+        assert result["changed"] is False
+        assert result["folder"]["moid"] is self.mock_folder._moId
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             relative_path="test",
             datacenter="DC0",
             folder_type="host"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        assert c.value.args[0]["folder"]["moid"] is self.mock_folder._moId
+        assert result["changed"] is False
+        assert result["folder"]["moid"] is self.mock_folder._moId
 
     def test_state_absent_no_change(self, mocker):
         self.__prepare(mocker)
         mocker.patch.object(VmwareFolder, 'get_folder_by_absolute_path', return_value=None)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             state="absent",
             relative_path="test",
             datacenter="DC0",
             folder_type="host"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False
 
     def test_state_absent_with_change(self, mocker):
         self.__prepare(mocker)
         mocker.patch.object(VmwareFolder, 'get_folder_by_absolute_path', return_value=self.mock_folder)
         self.mock_folder.Destroy = mock.Mock(return_value=MockVsphereTask())
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             absolute_path="/DC0/host/test",
             state="absent"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
         self.mock_folder.Destroy.assert_called_once()
 
     def test_state_present_with_change(self, mocker):
@@ -112,17 +92,12 @@ class TestEsxiMaintenanceMode(ModuleTestCase):
         ])
         self.mock_folder.CreateFolder = mock.Mock(return_value=MockVmwareObject(moid="2"))
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             absolute_path="/DC0/host/test",
             state="present"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
-        assert c.value.args[0]["folder"]["moid"] == "2"
+        assert result["changed"] is True
+        assert result["folder"]["moid"] == "2"

--- a/tests/unit/plugins/modules/test_guest_info.py
+++ b/tests/unit/plugins/modules/test_guest_info.py
@@ -7,7 +7,7 @@ import pytest
 from ansible_collections.vmware.vmware.plugins.modules import guest_info
 
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -27,14 +27,5 @@ class TestGuestInfo(ModuleTestCase):
     def test_gather(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            guest_info.main()
-
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=guest_info.main, module_args={})
+        assert result["changed"] is False

--- a/tests/unit/plugins/modules/test_license_info.py
+++ b/tests/unit/plugins/modules/test_license_info.py
@@ -7,7 +7,7 @@ import pytest
 from ansible_collections.vmware.vmware.plugins.modules import license_info
 
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -32,14 +32,5 @@ class TestGuestInfo(ModuleTestCase):
     def test_gather(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            license_info.main()
-
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=license_info.main, module_args={})
+        assert result["changed"] is False

--- a/tests/unit/plugins/modules/test_local_content_library.py
+++ b/tests/unit/plugins/modules/test_local_content_library.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import 
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import PyvmomiClient
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import ModulePyvmomiBase
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -35,43 +35,32 @@ class TestLocalContentLibrary(ModuleTestCase):
     def test_absent(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name='test',
             state='absent'
         )
         mocker.patch.object(VmwareContentLibrary, 'get_content_library_ids', return_value=[])
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False
 
         mocker.patch.object(VmwareContentLibrary, 'get_content_library_ids', return_value=[self.test_library])
         mocker.patch.object(self.library_service, 'get', return_value=self.test_library)
         mocker.patch.object(self.typed_library_service, 'delete')
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
 
     def test_present(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name='test',
             state='present',
             datastore='foo'
         )
         mocker.patch.object(VmwareContentLibrary, 'get_content_library_ids', return_value=[])
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True

--- a/tests/unit/plugins/modules/test_subscribed_content_library.py
+++ b/tests/unit/plugins/modules/test_subscribed_content_library.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import 
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import PyvmomiClient
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import ModulePyvmomiBase
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -35,44 +35,33 @@ class TestSubscribedContentLibrary(ModuleTestCase):
     def test_absent(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name='test',
             state='absent'
         )
         mocker.patch.object(VmwareContentLibrary, 'get_content_library_ids', return_value=[])
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False
 
         mocker.patch.object(VmwareContentLibrary, 'get_content_library_ids', return_value=[self.test_library])
         mocker.patch.object(self.library_service, 'get', return_value=self.test_library)
         mocker.patch.object(self.typed_library_service, 'delete')
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
 
     def test_present(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name='test',
             state='present',
             datastore='foo',
             subscription_url='https://foo'
         )
         mocker.patch.object(VmwareContentLibrary, 'get_content_library_ids', return_value=[])
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True

--- a/tests/unit/plugins/modules/test_vcsa_backup_schedule_info.py
+++ b/tests/unit/plugins/modules/test_vcsa_backup_schedule_info.py
@@ -11,7 +11,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import 
     VmwareRestClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -41,45 +41,29 @@ class TestContentTemplate(ModuleTestCase):
             "foo": self.__mock_schedule(mocker), "bar": self.__mock_schedule(mocker)
         }
         # test no name
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
-        )
+        module_args = dict()
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        assert len(c.value.args[0]["schedules"]) == 2
+        assert result["changed"] is False
+        assert len(result["schedules"]) == 2
 
         # test name match
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name="foo"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        assert len(c.value.args[0]["schedules"]) == 1
+        assert result["changed"] is False
+        assert len(result["schedules"]) == 1
 
         # test no match
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name="not real"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        assert len(c.value.args[0]["schedules"]) == 0
+        assert result["changed"] is False
+        assert len(result["schedules"]) == 0

--- a/tests/unit/plugins/modules/test_vm_advanced_settings.py
+++ b/tests/unit/plugins/modules/test_vm_advanced_settings.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     create_mock_vsphere_object,
@@ -46,43 +46,31 @@ class TestVmPowerstate(ModuleTestCase):
     def test_no_change(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             name="vm1",
             state="present",
-            settings=dict(),
-            validate_certs=False,
-            add_cluster=False
+            settings=dict()
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False
 
     def test_add_settings(self, mocker):
         self.__prepare(mocker)
 
         self.vm_mock.config.extraConfig = self.option_set(dict(one=1, two=2))
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             name="vm1",
             state="present",
-            settings=dict(two=10, three=3),
-            validate_certs=False,
-            add_cluster=False
+            settings=dict(two=10, three=3)
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
         self.vm_mock.ReconfigVM_Task.assert_called_once()
-        assert c.value.args[0]["updated_settings"] == dict(
+        assert result["updated_settings"] == dict(
             two={'old': 2, 'new': 10},
             three={'old': None, 'new': 3}
         )
@@ -91,22 +79,16 @@ class TestVmPowerstate(ModuleTestCase):
         self.__prepare(mocker)
 
         self.vm_mock.config.extraConfig = self.option_set(dict(one=1, two=2))
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             name="vm1",
             state="absent",
-            settings=dict(two="", three=3, one=10),
-            validate_certs=False,
-            add_cluster=False
+            settings=dict(two="", three=3, one=10)
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
         self.vm_mock.ReconfigVM_Task.assert_called_once()
-        assert c.value.args[0]["updated_settings"] == dict(
+        assert result["updated_settings"] == dict(
             two={'old': 2, 'new': None},
         )

--- a/tests/unit/plugins/modules/test_vm_list_group_by_clusters_info.py
+++ b/tests/unit/plugins/modules/test_vm_list_group_by_clusters_info.py
@@ -7,7 +7,7 @@ import pytest
 from ansible_collections.vmware.vmware.plugins.modules import vm_list_group_by_clusters_info
 
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 
 pytestmark = pytest.mark.skipif(
@@ -35,14 +35,5 @@ class TestVMList(ModuleTestCase):
     def test_gather(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
-        )
-
-        with pytest.raises(AnsibleExitJson) as c:
-            vm_list_group_by_clusters_info.main()
-
-        assert c.value.args[0]["changed"] is False
+        result = run_module(module_entry=vm_list_group_by_clusters_info.main, module_args={})
+        assert result["changed"] is False

--- a/tests/unit/plugins/modules/test_vm_powerstate.py
+++ b/tests/unit/plugins/modules/test_vm_powerstate.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import RunningTaskMonitor, VmQuestionHandler
 
@@ -45,36 +45,25 @@ class TestVmPowerstate(ModuleTestCase):
     def test_no_change(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="DC0",
             folder="DC0/vm/e2e-qe",
             name="vm1",
-            state="powered-on",
-            validate_certs=False,
-            add_cluster=False
+            state="powered-on"
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
+        assert result["changed"] is False
 
     def test_power_on(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="DC0",
             folder="DC0/vm/e2e-qe",
             name="vm1",
-            state="powered-on",
-            validate_certs=False,
-            add_cluster=False
+            state="powered-on"
         )
 
         mocker.patch.object(RunningTaskMonitor, 'wait_for_completion', return_value=(True, True))
@@ -85,24 +74,18 @@ class TestVmPowerstate(ModuleTestCase):
             }
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
 
     def test_power_off(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="DC0",
             folder="DC0/vm/e2e-qe",
             name="vm1",
-            state="powered-off",
-            validate_certs=False,
-            add_cluster=False
+            state="powered-off"
         )
 
         mocker.patch.object(RunningTaskMonitor, 'wait_for_completion', return_value=(True, True))
@@ -112,24 +95,18 @@ class TestVmPowerstate(ModuleTestCase):
             }
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
 
     def test_scheduled_power_off(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="DC0",
             folder="DC0/vm/e2e-qe",
             name="vm1",
             state="powered-off",
-            validate_certs=False,
-            add_cluster=False,
             scheduled_at="09/03/2025 10:18",
             scheduled_task_name="task_00001",
             scheduled_task_description="Sample task to poweroff VM",
@@ -138,7 +115,6 @@ class TestVmPowerstate(ModuleTestCase):
 
         mocker.patch.object(VmPowerstateModule, 'is_vcenter', return_value=True)
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True

--- a/tests/unit/plugins/modules/test_vm_resource_info.py
+++ b/tests/unit/plugins/modules/test_vm_resource_info.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     create_mock_vsphere_object
@@ -34,19 +34,14 @@ class TestVmwareVmResourceInfo(ModuleTestCase):
 
     def test_get_by_id(self, mocker):
         self.__prepare(mocker)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             name=self.test_vm.name
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        output_vm = c.value.args[0]["vms"][0]
+        assert result["changed"] is False
+        output_vm = result["vms"][0]
         assert output_vm['moid'] == self.test_vm._GetMoId()
         assert output_vm['name'] == self.test_vm.name
         assert output_vm['esxi_host'] != {}
@@ -56,18 +51,12 @@ class TestVmwareVmResourceInfo(ModuleTestCase):
 
     def test_get_all(self, mocker):
         self.__prepare(mocker)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False
-        )
+        module_args = dict()
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        output_vm = c.value.args[0]["vms"][0]
+        assert result["changed"] is False
+        output_vm = result["vms"][0]
         assert output_vm['moid'] == self.test_vm._GetMoId()
         assert output_vm['name'] == self.test_vm.name
         assert output_vm['esxi_host'] != {}
@@ -77,22 +66,17 @@ class TestVmwareVmResourceInfo(ModuleTestCase):
 
     def test_get_minimum(self, mocker):
         self.__prepare(mocker)
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
-            add_cluster=False,
+        module_args = dict(
             gather_cpu_config=False,
             gather_cpu_stats=False,
             gather_memory_config=False,
             gather_memory_stats=False,
         )
 
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is False
-        output_vm = c.value.args[0]["vms"][0]
+        assert result["changed"] is False
+        output_vm = result["vms"][0]
         assert output_vm['moid'] == self.test_vm._GetMoId()
         assert output_vm['name'] == self.test_vm.name
         assert output_vm['esxi_host'] != {}

--- a/tests/unit/plugins/modules/test_vm_snapshot.py
+++ b/tests/unit/plugins/modules/test_vm_snapshot.py
@@ -12,7 +12,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
     PyvmomiClient
 )
 from ...common.utils import (
-    AnsibleExitJson, ModuleTestCase, set_module_args,
+    run_module, ModuleTestCase
 )
 from ...common.vmware_object_mocks import (
     MockVsphereTask
@@ -54,70 +54,52 @@ class TestVmSnapshot(ModuleTestCase):
     def test_take_snapshot(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="DC0",
             folder="DC0/vm/e2e-qe",
             name="vm1",
             state="present",
             snapshot_name="snap1",
-            description="snap1_description",
-            validate_certs=False,
-            add_cluster=False
+            description="snap1_description"
         )
 
         self.vm_mock.snapshot = None
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
 
     def test_rename_snapshot(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="DC0",
             folder="DC0/vm/e2e-qe",
             name="vm1",
             state="present",
             snapshot_name="snap1",
             new_snapshot_name="im_renamed",
-            description="im_redescribed",
-            validate_certs=False,
-            add_cluster=False
+            description="im_redescribed"
         )
 
         self.vm_mock.snapshot = self.snap3_mock
         self.snap3_mock.rootSnapshotList = [self.snap3_mock]
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True
 
     def test_remove_snapshot(self, mocker):
         self.__prepare(mocker)
 
-        set_module_args(
-            hostname="127.0.0.1",
-            username="administrator@local",
-            password="123456",
+        module_args = dict(
             datacenter="DC0",
             folder="DC0/vm/e2e-qe",
             name="vm1",
             state="absent",
-            snapshot_name="snap1",
-            validate_certs=False,
-            add_cluster=False
+            snapshot_name="snap1"
         )
 
         self.vm_mock.snapshot = self.snap3_mock
         self.snap3_mock.rootSnapshotList = [self.snap3_mock]
-        with pytest.raises(AnsibleExitJson) as c:
-            module_main()
+        result = run_module(module_entry=module_main, module_args=module_args)
 
-        assert c.value.args[0]["changed"] is True
+        assert result["changed"] is True


### PR DESCRIPTION
##### SUMMARY
Adding ansible 2.19 support for https://github.com/ansible-collections/vmware.vmware/issues/171
2.19 is still pre-release, but the community has asked us to ensure testing so our collection can be safely included in Ansible 12 and issues are resolved with time to spare