### PR TITLE
fix typo in cluster ha pdl restart mode

### DIFF
--- a/changelogs/fragments/181-cluster-ha-pdl-typo.yml
+++ b/changelogs/fragments/181-cluster-ha-pdl-typo.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cluster_ha - fix typo that causes PDL response mode 'restart' to throw an error

--- a/plugins/modules/cluster_ha.py
+++ b/plugins/modules/cluster_ha.py
@@ -321,7 +321,7 @@ class VmwareCluster(ModulePyvmomiBase):
     @property
     def storage_pdl_response_mode(self):
         if self.params['storage_pdl_response_mode'] == 'restart':
-            return 'restartAgressive'
+            return 'restartAggressive'
         return self.params['storage_pdl_response_mode']
 
     @property


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/179

There is a typo when using the PDL mode 'restart'. It causes the module to fail with an error

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_ha

