### PR TITLE
fix ds cluster deployments

### DIFF
--- a/changelogs/fragments/183-fix-datastore-cluster-deploy.yml
+++ b/changelogs/fragments/183-fix-datastore-cluster-deploy.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - deploy_content_library_ovf - fix error when deploying from a datastore cluster by simplifying the ds selection process

--- a/plugins/module_utils/_module_deploy_vm_base.py
+++ b/plugins/module_utils/_module_deploy_vm_base.py
@@ -51,9 +51,7 @@ class ModuleVmDeployBase(ModulePyvmomiBase):
                 fail_on_missing=True,
                 datacenter=self.datacenter
             )
-            datastore = self.get_sdrs_recommended_datastore_from_ds_cluster(dsc)
-            if not datastore:
-                datastore = self.get_datastore_with_max_free_space(dsc.childEntity)
+            datastore = self.get_datastore_with_max_free_space(dsc.childEntity)
             self._datastore = datastore
 
         return self._datastore

--- a/plugins/module_utils/_module_pyvmomi_base.py
+++ b/plugins/module_utils/_module_pyvmomi_base.py
@@ -368,30 +368,6 @@ class ModulePyvmomiBase(PyvmomiClient):
 
         return None
 
-    def get_sdrs_recommended_datastore_from_ds_cluster(self, ds_cluster):
-        """
-            Returns the Storage DRS recommended datastore from a datastore cluster
-            Args:
-                ds_cluster: datastore cluster managed object
-
-            Returns:
-                Datastore object, or none if sdrs is not configured for the cluster
-
-        """
-        # Check if Datastore Cluster provided by user is SDRS ready
-        if not ds_cluster.podStorageDrsEntry.storageDrsConfig.podConfig.enabled:
-            return None
-
-        pod_sel_spec = vim.storageDrs.PodSelectionSpec()
-        pod_sel_spec.storagePod = ds_cluster
-        storage_spec = vim.storageDrs.StoragePlacementSpec()
-        storage_spec.podSelectionSpec = pod_sel_spec
-        storage_spec.type = 'create'
-
-        rec = self.content.storageResourceManager.RecommendDatastores(storageSpec=storage_spec)
-        rec_action = rec.recommendations[0].action[0]
-        return rec_action.destination
-
     def get_datastore_with_max_free_space(self, datastores):
         """
             Returns the datasotre object with the maximum amount of freespace from a list of datastores.

--- a/plugins/modules/deploy_content_library_ovf.py
+++ b/plugins/modules/deploy_content_library_ovf.py
@@ -209,7 +209,8 @@ class VmwareContentDeployOvf(ModuleVmDeployBase):
 
         if not response.succeeded:
             self.module.fail_json(msg=(
-                "Failed to deploy OVF %s to VM %s" % (self.library_item_id, self.params['vm_name'])
+                "Failed to deploy OVF %s to VM %s. Check vSphere event log for more details" %
+                (self.library_item_id, self.params['vm_name'])
             ))
 
         return response.resource_id.id


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/152

This fixes deployments that use a datastore cluster by simplifying how we pick which DS is used. Now we select the datastore with the most space available. Previously we tried to use SDRS to select the best DS but the method requires so many inputs, it is not feasible to use it for these modules. See https://github.com/vmware/pyvmomi/issues/213

In the future we may want to re-add this method but right now it has no use and doesn't work so I removed it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
deploy_content_library_ovf