### PR TITLE
cluster ha advanced setting bugfix

### DIFF
--- a/changelogs/fragments/192-fix-advanced-settings-cluster-ha.yml
+++ b/changelogs/fragments/192-fix-advanced-settings-cluster-ha.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - cluster_ha - Fix error when non-string advanced settings are applied
+    (https://github.com/ansible-collections/vmware.vmware/issues/190)
+  - cluster_drs - Fix error when non-string advanced settings are applied
+    (https://github.com/ansible-collections/vmware.vmware/issues/190)

--- a/plugins/module_utils/_advanced_settings.py
+++ b/plugins/module_utils/_advanced_settings.py
@@ -1,0 +1,89 @@
+try:
+    from pyVmomi import vim, VmomiSupport
+except ImportError:
+    pass
+
+
+class AdvancedSettings():
+    def __init__(self, cast_all_values_to_str: bool = False):
+        """
+        Advanced settings are essentially a dictionary of options attached to a
+        vsphere entity. Depending on the object type, there may be restrictions
+        about what keys and value types are accepted. Generally though, any value
+        type can be added as long as it can be cast to a pyvmomi class type.
+        Typical use cases include taking a dictionary from the user and comparing it
+        to a list of Option objects (key/value pairs) from vsphere.
+        """
+        self._settings = dict()
+        self.cast_all_values_to_str = cast_all_values_to_str
+
+    def add_setting(self, key, value):
+        self._settings[key] = self._convert_py_primitive_to_vmodl_type(value)
+
+    @classmethod
+    def from_py_dict(cls, data, cast_all_values_to_str: bool = False):
+        obj = cls(cast_all_values_to_str=cast_all_values_to_str)
+        for key, value in data.items():
+            obj.add_setting(key, value)
+
+        return obj
+
+    @classmethod
+    def from_vsphere_config(cls, config):
+        obj = cls()
+        for option in config:
+            obj._settings[option.key] = option.value
+
+        return obj
+
+    def to_vsphere_config(self):
+        """
+        Converts the current settings dict into an array of OptionValues, which
+        can be used in vSphere config specs
+        """
+        config = []
+        for k, v in self._settings.items():
+            option = vim.option.OptionValue()
+            option.key = k
+            option.value = v
+            config.append(option)
+        return config
+
+    def is_empty(self):
+        return len(self._settings.keys()) == 0
+
+    def difference(self, other):
+        """
+        Returns settings that are in self but are not in other, similar to set.difference()
+        Returns
+            AdvancedSettings
+        """
+        diff = self._settings.copy()
+        for other_key, other_value in other._settings.items():
+            if other_key not in self._settings:
+                continue
+
+            if self._settings[other_key] != other_value:
+                continue
+
+            del diff[other_key]
+        return AdvancedSettings.from_py_dict(diff, self.cast_all_values_to_str)
+
+    def _convert_py_primitive_to_vmodl_type(self, value):
+        """
+        Advanced setting options can allow "any type" according to vSphere, but
+        in practice only strings and integers are used. In some cases (Cluster HA),
+        using the wrong type can provide an error. Until someone mentions a use case
+        that requires a different type, just use strings and integers
+        """
+        if not self.cast_all_values_to_str:
+            if isinstance(value, bool):
+                return VmomiSupport.vmodlTypes['bool'](value)
+
+            elif isinstance(value, float):
+                return VmomiSupport.vmodlTypes['float'](value)
+
+            elif isinstance(value, int):
+                return VmomiSupport.vmodlTypes['int'](value)
+
+        return VmomiSupport.vmodlTypes['string'](value)

--- a/plugins/module_utils/_vsphere_tasks.py
+++ b/plugins/module_utils/_vsphere_tasks.py
@@ -27,8 +27,9 @@ except ImportError:
 
 
 class TaskError(Exception):
-    def __init__(self, *args, **kwargs):
-        super(TaskError, self).__init__(*args, **kwargs)
+    def __init__(self, message, **kwargs):
+        self.__dict__.update(kwargs)
+        super(TaskError, self).__init__(message)
 
 
 class RunningTaskMonitor():
@@ -84,7 +85,10 @@ class RunningTaskMonitor():
             except AttributeError:
                 error_msg = self.task.info.error
             finally:
-                raise_from(TaskError(error_msg, host_thumbprint), self.task.info.error)
+                raise_from(
+                    TaskError(error_msg, host_thumbprint=host_thumbprint, parent_error=self.task.info.error),
+                    self.task.info.error
+                )
 
         if self.task.info.state in [vim.TaskInfo.State.running, vim.TaskInfo.State.queued]:
             return False

--- a/tests/integration/run_eco_vcenter_ci.sh
+++ b/tests/integration/run_eco_vcenter_ci.sh
@@ -12,7 +12,6 @@ fi
 
 # Generates a string starting with 'test-' followed by 4 random lowercase characters
 tiny_prefix="test-vmware-$(uuidgen | tr -d '-' | cut -c1-4 | tr '[:upper:]' '[:lower:]')"
-tiny_prefix="mmtest"
 if grep -qa 'tiny_prefix' "${BASE_DIR}/integration_config.yml"; then
     sed -i "s|tiny_prefix:.*|tiny_prefix: $tiny_prefix|" "${BASE_DIR}/integration_config.yml"
 else
@@ -38,7 +37,7 @@ total=0
 for target in $(ansible-test integration --list-target | grep 'vmware_'); do
     echo "Running integration test for $target"
     total=$((total + 1))
-    if ansible-test integration $target --skip-tags force-simulator-run --verbose; then
+    if ansible-test integration $target --skip-tags force-simulator-run; then
         echo -e "Test: $target ${GREEN}Passed${NC}" | tee -a /tmp/vmware_vmware_tests_report.txt
     else
         echo -e "Test: $target ${RED}Failed${NC}" | tee -a /tmp/vmware_vmware_tests_report.txt

--- a/tests/integration/run_eco_vcenter_ci.sh
+++ b/tests/integration/run_eco_vcenter_ci.sh
@@ -37,9 +37,6 @@ total=0
 
 for target in $(ansible-test integration --list-target | grep 'vmware_'); do
     echo "Running integration test for $target"
-    if [ "$target" != "vmware_cluster_drs" ]; then
-        continue
-    fi
     total=$((total + 1))
     if ansible-test integration $target --skip-tags force-simulator-run --verbose; then
         echo -e "Test: $target ${GREEN}Passed${NC}" | tee -a /tmp/vmware_vmware_tests_report.txt

--- a/tests/integration/run_eco_vcenter_ci.sh
+++ b/tests/integration/run_eco_vcenter_ci.sh
@@ -12,6 +12,7 @@ fi
 
 # Generates a string starting with 'test-' followed by 4 random lowercase characters
 tiny_prefix="test-vmware-$(uuidgen | tr -d '-' | cut -c1-4 | tr '[:upper:]' '[:lower:]')"
+tiny_prefix="mmtest"
 if grep -qa 'tiny_prefix' "${BASE_DIR}/integration_config.yml"; then
     sed -i "s|tiny_prefix:.*|tiny_prefix: $tiny_prefix|" "${BASE_DIR}/integration_config.yml"
 else
@@ -36,8 +37,11 @@ total=0
 
 for target in $(ansible-test integration --list-target | grep 'vmware_'); do
     echo "Running integration test for $target"
+    if [ "$target" != "vmware_cluster_drs" ]; then
+        continue
+    fi
     total=$((total + 1))
-    if ansible-test integration $target --skip-tags force-simulator-run; then
+    if ansible-test integration $target --skip-tags force-simulator-run --verbose; then
         echo -e "Test: $target ${GREEN}Passed${NC}" | tee -a /tmp/vmware_vmware_tests_report.txt
     else
         echo -e "Test: $target ${RED}Failed${NC}" | tee -a /tmp/vmware_vmware_tests_report.txt

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -46,6 +46,10 @@
           restart_vms: true
           default_vm_restart_priority: low
         host_isolation_response: none
+        advanced_settings:
+          das.isolationaddress0: "1.2.3.4"
+          das.usedefaultisolationaddress: true
+          das.isolationshutdowntimeout: 310
       register: _first
     - name: Set HA Settings In Test Cluster Again - Idempotency
       vmware.vmware.cluster_ha:
@@ -55,6 +59,10 @@
           restart_vms: true
           default_vm_restart_priority: low
         host_isolation_response: none
+        advanced_settings:
+          das.isolationaddress0: "1.2.3.4"
+          das.usedefaultisolationaddress: true
+          das.isolationshutdowntimeout: 310
       register: _idem
     - name: Gather Cluster Settings
       vmware.vmware.cluster_info:

--- a/tests/unit/plugins/module_utils/test_advanced_settings.py
+++ b/tests/unit/plugins/module_utils/test_advanced_settings.py
@@ -1,0 +1,107 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.vmware.vmware.plugins.module_utils._advanced_settings import AdvancedSettings
+
+
+class TestAdvancedSettings():
+    def test_add_setting(self, mocker):
+        test = AdvancedSettings()
+
+        test.add_setting('one', 1)
+        assert test._settings['one'] == 1
+
+        test.add_setting('one', 2)
+        assert test._settings['one'] == 2
+
+        test.add_setting('two', 2)
+        assert test._settings['one'] == 2
+        assert test._settings['two'] == 2
+
+        test.add_setting('two', 'two')
+        assert test._settings['two'] == 'two'
+
+        test.add_setting('two', False)
+        assert test._settings['two'] is False
+
+        test.add_setting('two', 1.0)
+        assert test._settings['two'] == 1.0
+
+    def test_add_setting_string_only(self, mocker):
+        test = AdvancedSettings(cast_all_values_to_str=True)
+
+        test.add_setting('one', 1)
+        assert test._settings['one'] == '1'
+
+        test.add_setting('one', 2)
+        assert test._settings['one'] == '2'
+
+        test.add_setting('two', 2)
+        assert test._settings['one'] == '2'
+        assert test._settings['two'] == '2'
+
+        test.add_setting('two', 'two')
+        assert test._settings['two'] == 'two'
+
+        test.add_setting('two', False)
+        assert test._settings['two'] == 'False'
+
+        test.add_setting('two', 1.0)
+        assert test._settings['two'] == '1.0'
+
+    def test_from_py_dict(self, mocker):
+        test = AdvancedSettings.from_py_dict({'one': 1, 'two': 'two'})
+
+        assert test._settings['one'] == 1
+        assert test._settings['two'] == 'two'
+
+        test = AdvancedSettings.from_py_dict({'one': 1, 'two': 'two'}, True)
+
+        assert test._settings['one'] == '1'
+        assert test._settings['two'] == 'two'
+
+    def test_from_vsphere_config(self, mocker):
+        option_1, option_2 = mocker.Mock(), mocker.Mock()
+        option_1.key, option_1.value = 'one', 1
+        option_2.key, option_2.value = 'two', 'two'
+        test = AdvancedSettings.from_vsphere_config([option_1, option_2])
+
+        assert test._settings['one'] == 1
+        assert test._settings['two'] == 'two'
+
+    def test_is_empty(self, mocker):
+        test = AdvancedSettings()
+        assert test.is_empty()
+
+        test.add_setting('one', 1)
+        assert not test.is_empty()
+
+    def test_difference(self, mocker):
+        test_1 = AdvancedSettings.from_py_dict({'one': 1, 'two': 'two'})
+        test_2 = AdvancedSettings.from_py_dict({'one': 3, 'two': 'two'})
+
+        diff_1_2 = test_1.difference(test_2)
+        diff_2_1 = test_2.difference(test_1)
+
+        assert diff_1_2._settings['one'] == 1
+        assert len(diff_1_2._settings) == 1
+
+        assert diff_2_1._settings['one'] == 3
+        assert len(diff_2_1._settings) == 1
+
+    def test_to_vsphere_config(self, mocker):
+        test = AdvancedSettings.from_py_dict({'one': 1, 'two': 'two'})
+        out = test.to_vsphere_config()
+        assert len(out) == 2
+        assert out[0].key == 'one'
+        assert out[0].value == 1
+        assert out[1].key == 'two'
+        assert out[1].value == 'two'
+
+        test = AdvancedSettings.from_py_dict({'one': 1, 'two': 'two'}, True)
+        out = test.to_vsphere_config()
+        assert len(out) == 2
+        assert out[0].key == 'one'
+        assert out[0].value == '1'
+        assert out[1].key == 'two'
+        assert out[1].value == 'two'

--- a/tests/unit/plugins/modules/test_cluster_ha.py
+++ b/tests/unit/plugins/modules/test_cluster_ha.py
@@ -29,6 +29,7 @@ class TestClusterHa(ModuleTestCase):
         mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
         self.test_cluster = MockCluster()
         self.test_cluster.configurationEx.dasConfig = mocker.Mock()
+        self.test_cluster.configurationEx.dasConfig.option = []
 
         mocker.patch.object(VmwareCluster, 'get_datacenter_by_name_or_moid', return_value=mocker.Mock())
         mocker.patch.object(VmwareCluster, 'get_cluster_by_name_or_moid', return_value=self.test_cluster)


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/190

When a user tries to specify a non-string value for cluster HA or DRS advanced settings, an error is thrown.
This error is vague and unhelpful for the HA module. DRS actually has a decent error, so I didnt modify that

This change converts all values to strings for those modules and also adds a better error message for the HA module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_ha
cluster_drs

##### ADDITIONAL INFORMATION
Tests need https://github.com/ansible-collections/vmware.vmware/pull/191
