### PR TITLE
add cluster admission policy required_by

### DIFF
--- a/changelogs/fragments/201-add-cluster-ha-required-if.yml
+++ b/changelogs/fragments/201-add-cluster-ha-required-if.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - cluster_ha - Add module required_by rules for admission control arguments that are mentioned in the docs
+    (https://github.com/ansible-collections/vmware.vmware/issues/201)

--- a/plugins/modules/cluster_ha.py
+++ b/plugins/modules/cluster_ha.py
@@ -752,7 +752,13 @@ def main():
         supports_check_mode=True,
         required_if=[
             ('admission_control_policy', 'dedicated_host', ('admission_control_dedicated_hosts',), False)
-        ]
+        ],
+        required_by={
+            'admission_control_failover_level': 'admission_control_policy',
+            'admission_control_cpu_reserve_percentage': 'admission_control_policy',
+            'admission_control_memory_reserve_percentage': 'admission_control_policy',
+            'admission_control_dedicated_hosts': 'admission_control_policy',
+        }
     )
 
     result = dict(


### PR DESCRIPTION
##### SUMMARY
Partial fix for https://github.com/ansible-collections/vmware.vmware/issues/201

The admission control policy is required if a user sets any other admission control options. This is mentioned in the docs but is otherwise un-enforced. The current behavior is to just ignore admission control options. This change adds `required_by` for admission control policy parameters so the module will alert the user instead

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_ha