### PR TITLE
Fix non-existent method in content_template

### DIFF
--- a/changelogs/fragments/206-fix-content-template-err.yml
+++ b/changelogs/fragments/206-fix-content-template-err.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - content_template - Replace non-existent method used when handling api errors

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -214,8 +214,6 @@ class VmwareContentTemplate(ModuleRestBase):
         template_id = ''
         try:
             template_id = self._template_service.create(create_spec)
-        except Error as error:
-            self.module.fail_json(msg="%s" % self.get_error_message(error))
         except Exception as err:
             self.module.fail_json(msg="%s" % to_native(err))
 

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -239,6 +239,8 @@ class VmwareContentTemplate(ModuleRestBase):
 
         try:
             self.api_client.content.library.Item.delete(template_id)
+        except Error as error:
+            self.module.fail_json(msg=' ,'.join([err.default_message % err.args for err in error.messages]))
         except Exception as err:
             self.module.fail_json(msg="%s" % to_native(err))
 

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -214,6 +214,8 @@ class VmwareContentTemplate(ModuleRestBase):
         template_id = ''
         try:
             template_id = self._template_service.create(create_spec)
+        except Error as error:
+            self.module.fail_json(msg=' ,'.join([err.default_message % err.args for err in error.messages]))
         except Exception as err:
             self.module.fail_json(msg="%s" % to_native(err))
 
@@ -239,8 +241,6 @@ class VmwareContentTemplate(ModuleRestBase):
 
         try:
             self.api_client.content.library.Item.delete(template_id)
-        except Error as error:
-            self.module.fail_json(msg=' ,'.join([err.default_message % err.args for err in error.messages]))
         except Exception as err:
             self.module.fail_json(msg="%s" % to_native(err))
 


### PR DESCRIPTION
##### SUMMARY
Replaces a non-existent method from the content_template module. This method is present in the community collection, where this module came from originally. But it no longer exists. It seems we have not hit this piece of code, until now.

I think the error _was_ being thrown because of an issue in the test lab, but it is no longer happening. I copied how other modules handle this error and used that in place of the bad method.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
content_template
