### PR TITLE
Re-enable pyvmomi 9.0 in tests

### DIFF
--- a/changelogs/fragments/213_re-enable_pyvmomi-for-tests.yml
+++ b/changelogs/fragments/213_re-enable_pyvmomi-for-tests.yml
@@ -1,0 +1,3 @@
+trivial:
+  - Re-Enable pyvmomi for testes
+    (https://github.com/ansible-collections/vmware.vmware/pull/213).

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -3,6 +3,3 @@ ansible-core==2.19.0b5
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.2.0
 podman
 requests
-
-# pyvmomi 9 deprecated a json encoder, and tests use community.vmware which still has not released a fix yet
-pyVmomi<9.0.0.0.0


### PR DESCRIPTION
I hope I've fixed the issues with pyvmomi 9 in community.vmware 5.7.1. So let's give it another try with pyvmomi 9 :-)