### PR TITLE
add folder_paths_are_absolute param

### DIFF
--- a/changelogs/fragments/218-add-abs-folder-opt.yml
+++ b/changelogs/fragments/218-add-abs-folder-opt.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - add folder_paths_are_absolute option to all modules that support folder paths, allowing
+    users to specify if folder paths are absolute and override the default behavior of
+    intelligently determining if the path is absolute or relative.
+    (https://github.com/ansible-collections/vmware.vmware/issues/202)

--- a/plugins/doc_fragments/module_deploy_vm_base_options.py
+++ b/plugins/doc_fragments/module_deploy_vm_base_options.py
@@ -39,6 +39,18 @@ options:
         type: str
         required: false
         aliases: [folder]
+    folder_paths_are_absolute:
+        description:
+            - If true, any folder path parameters are treated as absolute paths.
+            - If false, modules will try to intelligently determine if the path is absolute
+              or relative.
+            - This option is useful when your environment has a complex folder structure. By default,
+              modules will try to intelligently determine if the path is absolute or relative.
+              They may mistakenly prepend the datacenter name or other folder names, and this option
+              can be used to avoid this.
+        type: bool
+        required: false
+        default: false
     resource_pool:
         description:
             - The name of a resource pool into which the virtual machine should be deployed.

--- a/plugins/module_utils/_module_deploy_vm_base.py
+++ b/plugins/module_utils/_module_deploy_vm_base.py
@@ -24,6 +24,7 @@ def vm_deploy_module_argument_spec():
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         datastore=dict(type='str', required=False),
         datastore_cluster=dict(type='str', required=False),
+        folder_paths_are_absolute=dict(type='bool', required=False, default=False),
     )
 
 
@@ -82,6 +83,8 @@ class ModuleVmDeployBase(ModulePyvmomiBase):
             return self._vm_folder
         if not self.params.get('vm_folder'):
             fq_folder = format_folder_path_as_vm_fq_path('', self.params['datacenter'])
+        elif self.params.get('folder_paths_are_absolute'):
+            fq_folder = self.params.get('vm_folder')
         else:
             fq_folder = format_folder_path_as_vm_fq_path(self.params.get('vm_folder'), self.params['datacenter'])
 

--- a/plugins/module_utils/_module_pyvmomi_base.py
+++ b/plugins/module_utils/_module_pyvmomi_base.py
@@ -150,7 +150,10 @@ class ModulePyvmomiBase(PyvmomiClient):
         else:
             folder = None
             if self.params.get(folder_param):
-                _fq_path = format_folder_path_as_vm_fq_path(self.params.get(folder_param), self.params.get('datacenter'))
+                if self.params.get('folder_paths_are_absolute'):
+                    _fq_path = self.params.get(folder_param)
+                else:
+                    _fq_path = format_folder_path_as_vm_fq_path(self.params.get(folder_param), self.params.get('datacenter'))
                 folder = self.get_folder_by_absolute_path(_fq_path, fail_on_missing=fail_on_missing)
             vms = self.get_objs_by_name_or_moid([vim.VirtualMachine], self.params.get(_search_id), return_all=True, search_root_folder=folder)
 

--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -68,6 +68,18 @@ options:
           folder as the source virtual machine.
         type: str
         aliases: [template_folder]
+    folder_paths_are_absolute:
+        description:
+            - If true, any folder path parameters are treated as absolute paths.
+            - If false, modules will try to intelligently determine if the path is absolute
+              or relative.
+            - This option is useful when your environment has a complex folder structure. By default,
+              modules will try to intelligently determine if the path is absolute or relative.
+              They may mistakenly prepend the datacenter name or other folder names, and this option
+              can be used to avoid this.
+        type: bool
+        required: false
+        default: false
     template_name:
         description:
             - The name of template to manage.
@@ -265,6 +277,7 @@ def main():
         vm_moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
         vm_folder=dict(type='str', required=False),
+        folder_paths_are_absolute=dict(type='bool', required=False, default=False),
         library=dict(type='str', required=True),
         host=dict(type='str'),
         cluster=dict(type='str', aliases=['cluster_name']),

--- a/plugins/modules/deploy_folder_template.py
+++ b/plugins/modules/deploy_folder_template.py
@@ -149,9 +149,12 @@ class VmwareFolderTemplate(ModuleVmDeployBase):
         if self.params['template_folder_id']:
             folder = self.get_folders_by_name_or_moid(self.params['template_folder_id'], fail_on_missing=True)[0]
         else:
-            fq_folder_path = format_folder_path_as_vm_fq_path(
-                self.params.get("template_folder"), self.params.get("datacenter")
-            )
+            if self.params.get("folder_paths_are_absolute"):
+                fq_folder_path = self.params.get("template_folder")
+            else:
+                fq_folder_path = format_folder_path_as_vm_fq_path(
+                    self.params.get("template_folder"), self.params.get("datacenter")
+                )
             folder = self.get_folder_by_absolute_path(fq_folder_path, fail_on_missing=True)
         return folder
 

--- a/plugins/modules/guest_info.py
+++ b/plugins/modules/guest_info.py
@@ -72,6 +72,18 @@ options:
           - This parameter is only used if O(name) is supplied, and can help identify the machine you want to query.
           - For example 'datacenter name/vm/path/to/folder' or 'path/to/folder'
         type: str
+    folder_paths_are_absolute:
+        description:
+            - If true, any folder path parameters are treated as absolute paths.
+            - If false, modules will try to intelligently determine if the path is absolute
+              or relative.
+            - This option is useful when your environment has a complex folder structure. By default,
+              modules will try to intelligently determine if the path is absolute or relative.
+              They may mistakenly prepend the datacenter name or other folder names, and this option
+              can be used to avoid this.
+        type: bool
+        required: false
+        default: false
     gather_tags:
         description:
             - If true, gather any tags attached to the vm(s)
@@ -295,6 +307,7 @@ def main():
             moid=dict(type='str'),
             datacenter=dict(type='str', required=False, aliases=['datacenter_name']),
             folder=dict(type='str', required=False),
+            folder_paths_are_absolute=dict(type='bool', required=False, default=False),
 
             gather_tags=dict(type='bool', default=False),
 

--- a/plugins/modules/vm_advanced_settings.py
+++ b/plugins/modules/vm_advanced_settings.py
@@ -70,6 +70,18 @@ options:
             - For example 'datacenter_name/vm/path/to/folder' or 'path/to/folder'
         type: str
         required: false
+    folder_paths_are_absolute:
+        description:
+            - If true, any folder path parameters are treated as absolute paths.
+            - If false, modules will try to intelligently determine if the path is absolute
+              or relative.
+            - This option is useful when your environment has a complex folder structure. By default,
+              modules will try to intelligently determine if the path is absolute or relative.
+              They may mistakenly prepend the datacenter name or other folder names, and this option
+              can be used to avoid this.
+        type: bool
+        required: false
+        default: false
     settings:
         description:
             - A dictionary that describes the advanced settings you want to manage.
@@ -256,6 +268,7 @@ def main():
                 moid=dict(type='str'),
                 use_instance_uuid=dict(type='bool', default=False),
                 folder=dict(type='str', required=False),
+                folder_paths_are_absolute=dict(type='bool', required=False, default=False),
                 settings=dict(type='dict', required=True),
             )
         },

--- a/plugins/modules/vm_powerstate.py
+++ b/plugins/modules/vm_powerstate.py
@@ -64,6 +64,18 @@ options:
             - For example 'datacenter_name/vm/path/to/folder' or 'path/to/folder'
         type: str
         required: false
+    folder_paths_are_absolute:
+        description:
+            - If true, any folder path parameters are treated as absolute paths.
+            - If false, modules will try to intelligently determine if the path is absolute
+              or relative.
+            - This option is useful when your environment has a complex folder structure. By default,
+              modules will try to intelligently determine if the path is absolute or relative.
+              They may mistakenly prepend the datacenter name or other folder names, and this option
+              can be used to avoid this.
+        type: bool
+        required: false
+        default: false
     scheduled_at:
         description:
             - Date and time in string format at which specified task needs to be performed.
@@ -418,6 +430,7 @@ def main():
                 moid=dict(type='str'),
                 use_instance_uuid=dict(type='bool', default=False),
                 folder=dict(type='str', required=False),
+                folder_paths_are_absolute=dict(type='bool', required=False, default=False),
                 force=dict(type='bool', default=False),
                 scheduled_at=dict(type='str', required=False),
                 scheduled_task_name=dict(type='str', required=False),

--- a/plugins/modules/vm_snapshot.py
+++ b/plugins/modules/vm_snapshot.py
@@ -66,6 +66,18 @@ options:
         - This parameter is required if O(name) is supplied.
         - For example 'datacenter name/vm/path/to/folder' or 'path/to/folder'
         type: str
+    folder_paths_are_absolute:
+        description:
+            - If true, any folder path parameters are treated as absolute paths.
+            - If false, modules will try to intelligently determine if the path is absolute
+              or relative.
+            - This option is useful when your environment has a complex folder structure. By default,
+              modules will try to intelligently determine if the path is absolute or relative.
+              They may mistakenly prepend the datacenter name or other folder names, and this option
+              can be used to avoid this.
+        type: bool
+        required: false
+        default: false
     datacenter:
         description:
         - Datacenter to search for the virtual machine.
@@ -393,6 +405,7 @@ def main():
                 use_instance_uuid=dict(type='bool', default=False),
                 remove_all=dict(type='bool', default=False),
                 folder=dict(type='str'),
+                folder_paths_are_absolute=dict(type='bool', required=False, default=False),
                 datacenter=dict(type='str'),
                 snapshot_name=dict(type='str'),
                 snapshot_id=dict(type='int'),

--- a/tests/unit/plugins/modules/test_folder_template_from_vm.py
+++ b/tests/unit/plugins/modules/test_folder_template_from_vm.py
@@ -1,0 +1,166 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.folder_template_from_vm import (
+    VmwareFolderTemplate,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient
+)
+from ...common.utils import (
+    run_module, ModuleTestCase
+)
+from ...common.vmware_object_mocks import (
+    create_mock_vsphere_object
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestVmwareFolderTemplateFromVm(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        self.test_vm = create_mock_vsphere_object(name="test")
+        self.test_vm.runtime.powerState = 'poweredOff'
+        self.test_template = create_mock_vsphere_object(name="test-template")
+        self.test_template.config.template = True
+        self.test_folder = create_mock_vsphere_object(name="test-folder")
+        self.test_template.parent = self.test_folder
+
+        mocker.patch.object(VmwareFolderTemplate, 'is_vcenter', return_value=True)
+        mocker.patch.object(VmwareFolderTemplate, 'get_folder_by_absolute_path', return_value=self.test_folder)
+        mocker.patch.object(VmwareFolderTemplate, 'get_vms_using_params', return_value=[self.test_vm])
+
+    def test_present(self, mocker):
+        self.__prepare(mocker)
+        # test template creation
+        mocker.patch.object(VmwareFolderTemplate, 'check_if_template_exists', return_value=False)
+        create_template_mock = mocker.patch.object(VmwareFolderTemplate, 'create_template_in_folder')
+        module_args = dict(
+            vm_name="test-vm",
+            template_name="test-template",
+            template_folder="my/template/folder",
+            datacenter="datacenter",
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        create_template_mock.assert_called_once()
+
+        # test no change when template exists
+        mocker.patch.object(VmwareFolderTemplate, 'check_if_template_exists', return_value=self.test_template)
+        create_template_mock.reset_mock()
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        create_template_mock.assert_not_called()
+
+    def test_absent(self, mocker):
+        self.__prepare(mocker)
+        # test template removal
+        template_mock = mocker.Mock()
+        mocker.patch.object(VmwareFolderTemplate, 'check_if_template_exists', return_value=template_mock)
+        module_args = dict(
+            template_name="test-template",
+            template_folder="my/template/folder",
+            datacenter="datacenter",
+            state="absent"
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        template_mock.Destroy_Task.assert_called_once()
+
+        # test no change when template doesn't exist
+        mocker.patch.object(VmwareFolderTemplate, 'check_if_template_exists', return_value=False)
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+
+    def test_folder_paths_are_absolute_true(self, mocker):
+        self.__prepare(mocker)
+        get_folder_mock = mocker.patch.object(VmwareFolderTemplate, 'get_folder_by_absolute_path', return_value=self.test_folder)
+        mocker.patch.object(VmwareFolderTemplate, 'check_if_template_exists', return_value=False)
+        mocker.patch.object(VmwareFolderTemplate, 'create_template_in_folder')
+
+        module_args = dict(
+            vm_name="test-vm",
+            template_name="test-template",
+            template_folder="/datacenter/vm/my/absolute/path",
+            datacenter="datacenter",
+            folder_paths_are_absolute=True,
+        )
+
+        run_module(module_entry=module_main, module_args=module_args)
+        get_folder_mock.assert_called_with("/datacenter/vm/my/absolute/path", fail_on_missing=True)
+
+    def test_folder_paths_are_absolute_false(self, mocker):
+        self.__prepare(mocker)
+        get_folder_mock = mocker.patch.object(VmwareFolderTemplate, 'get_folder_by_absolute_path', return_value=self.test_folder)
+        mocker.patch.object(VmwareFolderTemplate, 'check_if_template_exists', return_value=False)
+        mocker.patch.object(VmwareFolderTemplate, 'create_template_in_folder')
+
+        module_args = dict(
+            vm_name="test-vm",
+            template_name="test-template",
+            template_folder="my/relative/path",
+            datacenter="datacenter",
+            folder_paths_are_absolute=False,
+        )
+
+        run_module(module_entry=module_main, module_args=module_args)
+        get_folder_mock.assert_called_with("datacenter/vm/my/relative/path", fail_on_missing=True)
+
+        # test default behavior (should be same as False)
+        get_folder_mock.reset_mock()
+        module_args = dict(
+            vm_name="test-vm",
+            template_name="test-template",
+            template_folder="my/relative/path",
+            datacenter="datacenter",
+        )
+
+        run_module(module_entry=module_main, module_args=module_args)
+        get_folder_mock.assert_called_with("datacenter/vm/my/relative/path", fail_on_missing=True)
+
+    def test_vm_identification_methods(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(VmwareFolderTemplate, 'check_if_template_exists', return_value=False)
+        create_template_mock = mocker.patch.object(VmwareFolderTemplate, 'create_template_in_folder')
+
+        # test with vm_name
+        module_args = dict(
+            vm_name="test-vm",
+            template_name="test-template",
+            template_folder="my/template/folder",
+            datacenter="datacenter",
+        )
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+        # test with vm_uuid
+        create_template_mock.reset_mock()
+        module_args = dict(
+            vm_uuid="test-uuid",
+            template_name="test-template",
+            template_folder="my/template/folder",
+            datacenter="datacenter",
+        )
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+        # test with vm_moid
+        create_template_mock.reset_mock()
+        module_args = dict(
+            vm_moid="test-moid",
+            template_name="test-template",
+            template_folder="my/template/folder",
+            datacenter="datacenter",
+        )
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/202

Adds a paramter that allows users to force folder path parameters to be treated as absolute paths. Without this option, modules try to prefix paths with the datastore name it is missing. 
In environments with multiple datacenters, users might have folders or more complex paths. The modules will mistakenly prefix the datacenter and create an invlaid path. Which means they cannot use the modules at all

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
deploy_*
esxi_host
folder_template_from_vm
