### PR TITLE
apply timeout to shutdownguest state

### DIFF
--- a/changelogs/fragments/223-fix-powerstate-wait.yml
+++ b/changelogs/fragments/223-fix-powerstate-wait.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vm_powerstate - Ensure timeout option also applies to the shutdown-guest state

--- a/tests/unit/plugins/modules/test_vm_powerstate.py
+++ b/tests/unit/plugins/modules/test_vm_powerstate.py
@@ -14,6 +14,9 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
 from ...common.utils import (
     run_module, ModuleTestCase
 )
+from ...common.vmware_object_mocks import (
+    MockVsphereTask
+)
 from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import RunningTaskMonitor, VmQuestionHandler
 
 pytestmark = pytest.mark.skipif(
@@ -69,7 +72,7 @@ class TestVmPowerstate(ModuleTestCase):
         mocker.patch.object(RunningTaskMonitor, 'wait_for_completion', return_value=(True, True))
         self.vm_mock.configure_mock(
             **{
-                "PowerOn.return_value": type('', (object,), {"info": type('', (object,), {"state": "success"})()})(),
+                "PowerOn.return_value": MockVsphereTask(),
                 "summary.runtime.powerState.lower.return_value": "poweredoff"
             }
         )
@@ -91,7 +94,7 @@ class TestVmPowerstate(ModuleTestCase):
         mocker.patch.object(RunningTaskMonitor, 'wait_for_completion', return_value=(True, True))
         self.vm_mock.configure_mock(
             **{
-                "PowerOff.return_value": type('', (object,), {"info": type('', (object,), {"state": "success"})()})()
+                "PowerOff.return_value": MockVsphereTask()
             }
         )
 
@@ -118,3 +121,37 @@ class TestVmPowerstate(ModuleTestCase):
         result = run_module(module_entry=module_main, module_args=module_args)
 
         assert result["changed"] is True
+
+    def _side_effect_power_off_vm(self, *args, **kwargs):
+        self.vm_mock.summary.runtime.powerState = 'poweredoff'
+
+    def test_poll_vm_state_for_shutdown(self, mocker):
+        self.__prepare(mocker)
+
+        self.vm_mock.configure_mock(
+            **{
+                "ShutdownGuest.return_value": MockVsphereTask(),
+                "summary.runtime.powerState": 'poweredon',
+                "guest.toolsRunningStatus": 'guestToolsRunning'
+            }
+        )
+        mocker.patch.object(RunningTaskMonitor, 'wait_for_completion', return_value=(True, True))
+        module_args = dict(
+            datacenter="DC0",
+            folder="DC0/vm/e2e-qe",
+            name="vm1",
+            state="shutdown-guest",
+            timeout=1
+        )
+        run_module(module_entry=module_main, module_args=module_args, expect_success=False)
+
+        mock_time = mocker.patch('time.sleep', side_effect=self._side_effect_power_off_vm)
+        module_args = dict(
+            datacenter="DC0",
+            folder="DC0/vm/e2e-qe",
+            name="vm1",
+            state="shutdown-guest",
+            timeout=7
+        )
+        run_module(module_entry=module_main, module_args=module_args)
+        assert mock_time.call_count == 1


### PR DESCRIPTION
##### SUMMARY
Partial fix for https://github.com/ansible-collections/vmware.vmware/issues/224

Applies the timeout option to the shutdown-guest state, which was behavior the community module was already doing

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vm_powerstate
