### PR TITLE
Drop aiohttp requirement

### DIFF
--- a/changelogs/fragments/230-drop-aiohttp-requirement.yml
+++ b/changelogs/fragments/230-drop-aiohttp-requirement.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Drop incorrect requirement on aiohttp (https://github.com/ansible-collections/vmware.vmware/pull/230).

--- a/plugins/modules/deploy_content_library_ovf.py
+++ b/plugins/modules/deploy_content_library_ovf.py
@@ -22,7 +22,6 @@ author:
 
 requirements:
     - vSphere Automation SDK
-    - aiohttp
 
 extends_documentation_fragment:
     - vmware.vmware.base_options

--- a/plugins/modules/deploy_content_library_template.py
+++ b/plugins/modules/deploy_content_library_template.py
@@ -22,7 +22,6 @@ author:
 
 requirements:
     - vSphere Automation SDK
-    - aiohttp
 
 seealso:
     - module: vmware.vmware.deploy_content_library_ovf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyVmomi>=8.0.3.0.1
 vmware-vcenter
 vmware-vapi-common-client
-aiohttp

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -3,3 +3,4 @@ ansible-core==2.19.0b5
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.2.0
 podman
 requests
+aiohttp

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,3 @@
 pyVmomi>=8.0.3.0.1
 vmware-vcenter
 vmware-vapi-common-client
-aiohttp


### PR DESCRIPTION
##### SUMMARY
It looks like the collection defines a requirement on aiohttp, but it doesn't use it anywhere:

```
$ grep -r aiohttp plugins/
plugins/modules/deploy_content_library_template.py:    - aiohttp
plugins/modules/deploy_content_library_ovf.py:    - aiohttp
$
```

You see, this package is documented as a requirement but not used anywhere.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
deploy_content_library_ovf
deploy_content_library_template
requirements.txt
tests/integration/requirements.txt
tests/unit/requirements.txt

##### ADDITIONAL INFORMATION
https://forum.ansible.com/t/44392