### PR TITLE
remove six imports

### DIFF
--- a/changelogs/fragments/232-remove-six-imports.yml
+++ b/changelogs/fragments/232-remove-six-imports.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Remove six imports from _facts.py and _vsphere_tasks.py due to new sanity rules. Python 2 (already not supported) will fail to execute these files.

--- a/plugins/module_utils/_facts.py
+++ b/plugins/module_utils/_facts.py
@@ -20,7 +20,6 @@ except ImportError:
     pass
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import integer_types, string_types, iteritems
 import ansible.module_utils.common._collections_compat as collections_compat
 from ansible_collections.vmware.vmware.plugins.module_utils._folder_paths import get_folder_path_of_vsphere_object
 
@@ -500,8 +499,8 @@ def serialize_spec(clonespec):
             data[x] = []
             for xe in xo:
                 data[x].append(serialize_spec(xe))
-        elif issubclass(xt, string_types + integer_types + (float, bool)):
-            if issubclass(xt, integer_types):
+        elif issubclass(xt, (str, int, float, bool)):
+            if issubclass(xt, int):
                 data[x] = int(xo)
             else:
                 data[x] = to_text(xo)
@@ -539,7 +538,7 @@ def deepmerge_dicts(d, u):
     Returns:
         dict, with u merged into d
     """
-    for k, v in iteritems(u):
+    for k, v in u.items():
         if isinstance(v, collections_compat.Mapping):
             d[k] = deepmerge_dicts(d.get(k, {}), v)
         else:

--- a/plugins/module_utils/_vsphere_tasks.py
+++ b/plugins/module_utils/_vsphere_tasks.py
@@ -15,7 +15,6 @@ import traceback
 from random import randint
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import raise_from
 
 PYVMOMI_IMP_ERR = None
 try:
@@ -85,10 +84,7 @@ class RunningTaskMonitor():
             except AttributeError:
                 error_msg = self.task.info.error
             finally:
-                raise_from(
-                    TaskError(error_msg, host_thumbprint=host_thumbprint, parent_error=self.task.info.error),
-                    self.task.info.error
-                )
+                raise TaskError(error_msg, host_thumbprint=host_thumbprint, parent_error=self.task.info.error) from self.task.info.error
 
         if self.task.info.state in [vim.TaskInfo.State.running, vim.TaskInfo.State.queued]:
             return False


### PR DESCRIPTION
##### SUMMARY
Removes types and methods imported from six, replacing them with python3 versions. This is to fix a sanity check coming from devel.

See https://github.com/ansible-collections/vmware.vmware/pull/230

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/_facts.py
module_utils/_vsphere_tasks.py
