### PR TITLE
fix: Update content_template.py to use correct param in check mode

### DIFF
--- a/plugins/modules/content_template.py
+++ b/plugins/modules/content_template.py
@@ -302,7 +302,7 @@ def main():
     vmware_contentlib = VmwareContentTemplate(module)
     if module.check_mode:
         result.update(
-            vm_name=module.params['name'],
+            vm_name=module.params['vm_name'],
             changed=True,
             desired_operation='{} template'.format(module.params.get('state')),
         )


### PR DESCRIPTION
##### SUMMARY
Typo in code for check mode means it tried to access a module param which doesn't exist.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
content_template

##### ADDITIONAL INFORMATION
Tryt to use content_template in check mode

```
ansible_collections/vmware/vmware/plugins/modules/content_template.py", line 305, in main
KeyError: 'name'
```
