### PR TITLE
fix: iterate until parent is a datacenter in cluster_info

### DIFF
--- a/changelogs/fragments/238-fix-wrong-datacenter-in-cluster-info.yml
+++ b/changelogs/fragments/238-fix-wrong-datacenter-in-cluster-info.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cluster_info - Fix wrong datacenter name if you have folders between cluster and datacenter. 

--- a/plugins/module_utils/_facts.py
+++ b/plugins/module_utils/_facts.py
@@ -303,9 +303,12 @@ class ClusterFacts():
         }
 
     def identifier_facts(self):
+        parent = self.cluster.parent
+        while parent and not isinstance(parent, vim.Datacenter):
+            parent = parent.parent
         return {
             "moid": self.cluster._moId,
-            "datacenter": self.cluster.parent.parent.name
+            "datacenter": getattr(parent, "name", "")
         }
 
     def host_facts(self):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Actual behaviour: If you have a folder between your datacenter and cluster, datacenter will be "hosts". 

This fix iterate until the parent is a vim.Datacenter

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cluster_info
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
