### PR TITLE
fix: cluster admission control: set requested policy also when ac is disabled

### DIFF
--- a/changelogs/fragments/244-fix-cluster-ac-policy/244-fix-cluster-ac-policy.yml
+++ b/changelogs/fragments/244-fix-cluster-ac-policy/244-fix-cluster-ac-policy.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cluster_ha - Fix admission control policy not being updated when ac is disabled

--- a/plugins/modules/cluster_ha.py
+++ b/plugins/modules/cluster_ha.py
@@ -490,6 +490,9 @@ class VmwareCluster(ModulePyvmomiBase):
         if not isinstance(ac_config, policy_classes[self.params.get("admission_control_policy")]):
             return True
 
+        if not ha_config.admissionControlEnabled:
+            return True
+
         if self.params.get("admission_control_policy") == 'dedicated_host':
             ac_config.failoverHosts.sort(key=lambda h: h.name)
             if ac_config.failoverHosts != self.ac_failover_hosts:


### PR DESCRIPTION
If the cluster admission control (ac.) policy is set and then ac. is disabled, we want to reinstate the policy setting and enable ac.
See bug for details on how to reproduce.

Fixes: #243