### PR TITLE
Feature/vm add networks

### DIFF
--- a/plugins/module_utils/vm/_change_set.py
+++ b/plugins/module_utils/vm/_change_set.py
@@ -66,14 +66,12 @@ class ParameterChangeSet:
 
     @property
     def changes(self):
-        # TODO I think we should return a list of devices changed too,
-        # but I'm not sure how to represent them via json yet
+        # TODO remove hasattr checks once all objects implement abstractvsphereobject
         return {
             "changed_parameters": self._changed_parameters,
-            # "objects_to_add": self.objects_to_add,
-            # "objects_to_update": self.objects_to_update,
-            # "objects_in_sync": self.objects_in_sync,
-            # "objects_to_remove": self.objects_to_remove,
+            "objects_to_add": [obj.to_change_set_output()['new_value'] for obj in self.objects_to_add if hasattr(obj, "to_change_set_output")],
+            "objects_to_update": [obj.to_change_set_output() for obj in self.objects_to_update if hasattr(obj, "to_change_set_output")],
+            "objects_to_remove": [obj.to_change_set_output()['old_value'] for obj in self.objects_to_remove if hasattr(obj, "to_change_set_output")],
         }
 
     def are_changes_required(self):
@@ -210,6 +208,11 @@ class ParameterChangeSet:
             raise ValueError("change_set must be an instance of ParameterChangeSet")
 
         self._changed_parameters.update(other._changed_parameters)
+        self.objects_to_add.extend(other.objects_to_add)
+        self.objects_to_update.extend(other.objects_to_update)
+        self.objects_in_sync.extend(other.objects_in_sync)
+        self.objects_to_remove.extend(other.objects_to_remove)
+
         self.power_cycle_required = (
             self.power_cycle_required or other.power_cycle_required
         )

--- a/plugins/module_utils/vm/_configuration_builder.py
+++ b/plugins/module_utils/vm/_configuration_builder.py
@@ -18,6 +18,9 @@ from ansible_collections.vmware.vmware.plugins.module_utils.vm._change_set impor
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._device_tracker import (
     DeviceTracker,
 )
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._vsphere_object_cache import (
+    VsphereObjectCache,
+)
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._error_handler import (
     ErrorHandler,
 )
@@ -148,6 +151,7 @@ class ConfigurationBuilder:
 
         # Create services with focused dependencies
         self.device_tracker = DeviceTracker()
+        self.vsphere_object_cache = VsphereObjectCache(self.module)
         self.error_handler = ErrorHandler(self.module, self.device_tracker)
         self.placement = VmPlacement(self.module)
 
@@ -212,6 +216,7 @@ class ConfigurationBuilder:
                     vm=self.vm,
                     device_tracker=self.device_tracker,
                     controller_handlers=self._create_controller_handlers(),
+                    vsphere_object_cache=self.vsphere_object_cache,
                 ),
                 handlers
             )

--- a/plugins/module_utils/vm/objects/_abstract.py
+++ b/plugins/module_utils/vm/objects/_abstract.py
@@ -1,0 +1,222 @@
+"""
+Abstract base class for VMware vSphere object representations.
+
+This module defines the AbstractVsphereObject class, which serves as the foundation
+for all VMware vSphere object representations in the VM configuration management
+system. It provides a consistent interface for handling VMware objects, change
+detection, and specification generation.
+
+The main use case is to represent parameter version of a vSphere object and the
+live version of the same object. If both versions implement the same interface,
+it is easier to compare and link parameters and what's actually in vSphere.
+
+Classes:
+    AbstractVsphereObject: Abstract base class for all vSphere object representations
+"""
+
+from abc import ABC, abstractmethod
+
+
+class AbstractVsphereObject(ABC):
+    """
+    Abstract base class for VMware vSphere object representations.
+
+    The class supports two main representation modes:
+    1. Input parameters: An object that represents the desired state of a vSphere object.
+    2. Live object: An object that represents the current state of a vSphere object.
+
+    Key Features:
+    - Change detection through linked device comparison
+    - VMware specification generation for both new and update operations
+    - Module output formatting for Ansible integration
+
+    Attributes:
+        _raw_object: Original VMware object from pyVmomi (optional, only makes sense for live objects)
+        _linked_device: Corresponding live device for change detection (optional, only makes sense for input parameters)
+    """
+
+    def __init__(self, raw_object=None):
+        """
+        Initialize the vSphere object representation.
+
+        Args:
+            raw_object: Original VMware object from pyVmomi (optional)
+                       Used when creating object from existing VMware device
+        """
+        self._raw_object = raw_object
+        self._linked_device = None
+
+    @classmethod
+    @abstractmethod
+    def from_device_spec(cls, device_spec):
+        """
+        Create object instance from VMware device specification.
+
+        This factory method creates an appropriate object instance based on
+        the provided VMware device spec from vSphere.
+
+        Args:
+            device_spec: VMware device specification object from vSphere (pyvmomi most likely)
+
+        Returns:
+            AbstractVsphereObject: Appropriate subclass instance
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses
+        """
+        raise NotImplementedError("from_device_spec must be implemented by subclasses")
+
+    @abstractmethod
+    def to_new_spec(self):
+        """
+        Generate VMware specification for new object creation.
+
+        Creates a VMware device specification that can be used to create
+        a new object in vSphere. The specification should include all
+        necessary properties for the object type.
+
+        Returns:
+            VMware device specification object
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses
+        """
+        raise NotImplementedError("to_new_spec must be implemented by subclasses")
+
+    @abstractmethod
+    def to_update_spec(self):
+        """
+        Generate VMware specification for object modification.
+
+        Creates a VMware device specification that can be used to update
+        an existing object in vSphere. The specification should include
+        only the properties that need to be changed.
+
+        Returns:
+            VMware device specification object
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses
+        """
+        raise NotImplementedError("to_update_spec must be implemented by subclasses")
+
+    @abstractmethod
+    def differs_from_linked_device(self):
+        """
+        Determine if this object differs from its linked live device.
+
+        Compares the current object configuration with the linked live device
+        to detect changes. This is used for change detection in VM configuration
+        management.
+
+        Returns:
+            bool: True if the object differs from the linked device, False otherwise
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses
+        """
+        raise NotImplementedError("differs_from_linked_device must be implemented by subclasses")
+
+    def _compare_attributes_for_changes(self, param_value, device_value):
+        """
+        Helper method to compare two attribute values to determine if a change is required.
+
+        This method provides comparison logic for different values with Ansible idempotency in mind.
+        If a parameter value is not specified (None), it is not considered a change.
+        If a device value is not specified (None), it is considered a change.
+        If a parameter value is an AbstractVsphereObject, it is compared using the differs_from_linked_device method.
+        Otherwise, the direct equality comparison is used.
+
+        Args:
+            param_value: Value from module parameters (desired state)
+            device_value: Value from existing device (current state)
+
+        Returns:
+            bool: True if the values represent a change, False otherwise
+
+        """
+        if param_value is None:
+            return False
+
+        if device_value is None:
+            return True
+
+        if isinstance(param_value, AbstractVsphereObject):
+            return param_value.differs_from_linked_device()
+        return param_value != device_value
+
+    @abstractmethod
+    def _to_module_output(self):
+        """
+        Convert object to module output format.
+
+        Generates a dictionary representation of the object suitable for
+        Ansible module output. This format is used for reporting object
+        state and changes to the user.
+
+        Returns:
+            dict: Module output representation of the object
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses
+        """
+        raise NotImplementedError("_to_module_output must be implemented by subclasses")
+
+    def to_change_set_output(self):
+        """
+        Generate change set output for configuration tracking.
+
+        Creates a dictionary containing both the new and old values of the
+        object, suitable for change tracking and reporting. None values
+        are filtered out to keep the output clean.
+
+        Returns:
+            dict: Change set output with 'new_value' and 'old_value' keys
+                - new_value: Current object state
+                - old_value: Previous object state (empty dict if no linked device)
+
+        Example:
+            {
+                "new_value": {"name": "new_name", "size": 1024},
+                "old_value": {"name": "old_name", "size": 512}
+            }
+        """
+        new_value = self._to_module_output()
+        old_value = {}
+        if self._linked_device is not None:
+            old_value = self._linked_device._to_module_output()
+
+        # Remove None values from both new and old values
+        for key, value in new_value.copy().items():
+            if value is None:
+                del new_value[key]
+                if key in old_value:
+                    del old_value[key]
+
+        return {
+            "new_value": new_value,
+            "old_value": old_value,
+        }
+
+    def link_corresponding_live_device(self, device: "AbstractVsphereObject"):
+        """
+        Link this object to its corresponding live device for change detection.
+
+        Establishes a link between the current object (representing desired state)
+        and the corresponding live device (representing current state). This link
+        is used for change detection and comparison operations.
+
+        Args:
+            device: The corresponding live device object to link
+
+        Raises:
+            Exception: If a device is already linked (prevents multiple links)
+
+        Note:
+            This method should be called when setting up change detection
+            between desired and current object states.
+        """
+        if self._linked_device is not None:
+            raise Exception("Linked device already set, cannot link another one.")
+
+        self._linked_device = device

--- a/plugins/module_utils/vm/objects/_network_adapter.py
+++ b/plugins/module_utils/vm/objects/_network_adapter.py
@@ -608,7 +608,7 @@ class NetworkAdapter(AbstractVsphereObject):
         """
         network_adapter_spec = vim.vm.device.VirtualDeviceSpec()
         network_adapter_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
-        network_adapter_spec.device = self.adapter_vim_class()
+        network_adapter_spec.device = self.adapter_vim_class() if self.adapter_vim_class is not None else vim.vm.device.VirtualVmxnet3()
         network_adapter_spec.device.key = -randint(25000, 29999)
 
         network_adapter_spec.device.deviceInfo = vim.Description()
@@ -668,12 +668,9 @@ class NetworkAdapter(AbstractVsphereObject):
         for easy identification in error messages and logs.
 
         Returns:
-            str: Human-readable network adapter name (e.g., "Network Adapter - VirtualE1000 - 0")
+            str: Human-readable network adapter name (e.g., "Network Adapter 1")
         """
-        return "Network Adapter - %s - %s" % (
-            self.adapter_vim_class.__name__,
-            self.index,
-        )
+        return "Network Adapter %s" % self.index
 
     def _update_network_adapter_spec_with_options(self, network_adapter_spec):
         """
@@ -709,7 +706,7 @@ class NetworkAdapter(AbstractVsphereObject):
             dict
         """
         return {
-            "type": self.adapter_vim_class.__name__.lower(),
+            "type": None if self.adapter_vim_class is None else self.adapter_vim_class.__name__.lower(),
             "portgroup": self.portgroup._to_module_output(),
             "connect_at_power_on": self.connect_at_power_on,
             "connected": self.connected,

--- a/plugins/module_utils/vm/objects/_network_adapter.py
+++ b/plugins/module_utils/vm/objects/_network_adapter.py
@@ -1,66 +1,116 @@
 """
 Network adapter object representation for VM configuration management.
 
-This module provides the NetworkAdapter class, which represents a virtual network adapter
-and handles the creation and modification of VMware network adapter specifications.
-It manages network adapter properties such as portgroup_name, adapter_type, connect_at_power_on, shares, shares_level, reservation, limit, and mac_address.
+This module provides classes for managing VMware virtual network adapters and their
+associated configurations. It supports different types of network backings including
+distributed virtual switches (DVS), NSX-T logical switches, and standard vSwitches.
 
-It is meant to represent one of the items in the module's 'network_adapters' parameter.
+Classes:
+    NetworkAdapterResourceAllocation: Manages resource allocation settings for network adapters
+    NetworkAdapterPortgroup: Abstract base class for network portgroup configurations
+    DvsNetworkAdapterPortgroup: Handles distributed virtual switch portgroup configurations
+    NsxtNetworkAdapterPortgroup: Handles NSX-T logical switch configurations
+    VswitchNetworkAdapterPortgroup: Handles standard vSwitch portgroup configurations
+    NetworkAdapter: Main class representing a virtual network adapter
+
+The module is designed to work with VMware's pyVmomi library and integrates with
+the VM configuration management system to handle network adapter creation, modification,
+and change detection.
 """
 
 from random import randint
+from abc import ABC
 
 try:
     from pyVmomi import vim
 except ImportError:
     pass
 
-class NetworkAdapterPortgroup:
-    def __init__(self, name, lookup_service):
-        self.name = name
-        try:
-            self._portgroup = lookup_service.get_portgroup(name)
-        except Exception:
-            try:
-                self._portgroup = lookup_service.get_distributed_virtual_portgroup(name)
-            except Exception:
-                raise ValueError("Portgroup %s not found" % name)
-
-    def device_portgroup_differs_from_config(self, device_portgroup):
-        if self._portgroup is None:
-            return True
-
-        return self._portgroup.name != device_portgroup.name
+from ._abstract import AbstractVsphereObject
 
 
-class NetworkAdapterResourceAllocation:
-    def __init__(self, shares=None, shares_level=None, reservation=None, limit=None):
+class NetworkAdapterResourceAllocation(AbstractVsphereObject):
+    """
+    Manages resource allocation settings for virtual network adapters.
+
+    This class handles the configuration of network resource allocation including
+    shares, reservations, and limits for virtual network adapters. It provides
+    methods to convert between VMware API objects and internal representations.
+
+    Attributes:
+        shares (int, optional): Custom shares value when shares_level is "custom"
+        shares_level (str, optional): Pre-defined shares level ("low", "normal", "high", "custom")
+        reservation (int, optional): Reserved network bandwidth in Mbps
+        limit (int, optional): Maximum network bandwidth in Mbps
+        _raw_device: Original VMware resource allocation object
+        _linked_device: Corresponding live device for change detection
+    """
+
+    def __init__(self, shares=None, shares_level=None, reservation=None, limit=None, raw_device=None):
+        """
+        Initialize network adapter resource allocation.
+
+        Args:
+            shares (int, optional): Custom shares value. Only used when shares_level is "custom"
+            shares_level (str, optional): Pre-defined allocation level ("low", "normal", "high", "custom")
+            reservation (int, optional): Reserved network bandwidth in Mbps
+            limit (int, optional): Maximum network bandwidth in Mbps
+            raw_device: Original VMware resource allocation object
+        """
+        super().__init__(raw_device)
         self.shares = shares
         self.shares_level = shares_level
         self.reservation = reservation
         self.limit = limit
 
-    def device_allocation_differs_from_config(self, device_allocation):
-        _diff = False
-        if not _diff and self.shares is not None:
-            _diff = device_allocation.shares.level != 'custom' or device_allocation.shares.shares != self.shares
+    @classmethod
+    def from_device_spec(cls, device_allocation):
+        """
+        Create instance from VMware device allocation specification.
 
-        if not _diff and self.shares_level is not None:
-            _diff = device_allocation.shares.level != self.shares_level
+        Args:
+            device_allocation: VMware VirtualEthernetCard.ResourceAllocation object
 
-        if not _diff and self.limit is not None:
-            _diff = device_allocation.limit != self.limit
+        Returns:
+            NetworkAdapterResourceAllocation: Configured resource allocation instance
+        """
+        return cls(
+            shares=device_allocation.share.shares if device_allocation.share.level == "custom" else None,
+            shares_level=device_allocation.share.level if device_allocation.share.level != "custom" else None,
+            reservation=device_allocation.reservation,
+            limit=device_allocation.limit,
+            raw_device=device_allocation,
+        )
 
-        if not _diff and self.reservation is not None:
-            _diff = device_allocation.reservation != self.reservation
+    def differs_from_linked_device(self):
+        """
+        Check if this resource allocation differs from the linked live device.
 
-        return _diff
+        Returns:
+            bool: True if there are differences, False otherwise
+        """
+        if self._linked_device is None:
+            return True
 
-    def create_resource_allocation_spec(self):
+        return (
+            self._compare_attributes_for_changes(self.shares, self._linked_device.shares) or
+            self._compare_attributes_for_changes(self.shares_level, self._linked_device.shares_level) or
+            self._compare_attributes_for_changes(self.reservation, self._linked_device.reservation) or
+            self._compare_attributes_for_changes(self.limit, self._linked_device.limit)
+        )
+
+    def to_new_spec(self):
+        """
+        Convert to VMware resource allocation specification for new devices.
+
+        Returns:
+            vim.vm.device.VirtualEthernetCard.ResourceAllocation or None:
+                VMware resource allocation spec, or None if no allocation configured
+        """
         if self.shares is None and self.shares_level is None and self.limit is None and self.reservation is None:
             return None
 
-        allocation = vim.ResourceAllocationInfo()
+        allocation = vim.vm.device.VirtualEthernetCard.ResourceAllocation()
         if self.shares_level is not None or self.shares is not None:
             shares_info = vim.SharesInfo()
             if self.shares is not None:
@@ -68,7 +118,7 @@ class NetworkAdapterResourceAllocation:
                 shares_info.shares = self.shares
             else:
                 shares_info.level = self.shares_level
-            allocation.shares = shares_info
+            allocation.share = shares_info
 
         if self.limit is not None:
             allocation.limit = self.limit
@@ -78,159 +128,421 @@ class NetworkAdapterResourceAllocation:
 
         return allocation
 
+    def to_update_spec(self):
+        """
+        Convert to VMware resource allocation specification for device updates.
 
-class NetworkAdapter:
+        Returns:
+            vim.vm.device.VirtualEthernetCard.ResourceAllocation or None:
+                VMware resource allocation spec, or None if no allocation configured
+        """
+        return self.to_new_spec()
+
+    def _to_module_output(self):
+        """
+        Generate a module output friendly representation of the resource allocation.
+
+        Returns:
+            dict
+        """
+        return {
+            "shares": self.shares,
+            "shares_level": self.shares_level,
+            "reservation": self.reservation,
+            "limit": self.limit,
+        }
+
+class NetworkAdapterPortgroup(AbstractVsphereObject, ABC):
+    """
+    Abstract base class for network adapter portgroup configurations.
+
+    This class provides the foundation for different types of network portgroup
+    configurations including distributed virtual switches, NSX-T logical switches,
+    and standard vSwitches.
+    """
+
+    def __init__(self, raw_device=None):
+        """
+        Initialize network adapter portgroup.
+
+        Args:
+            raw_device: Original VMware portgroup object
+        """
+        super().__init__(raw_device)
+
+    @classmethod
+    def from_device_spec(cls, device_backing):
+        """
+        Create appropriate portgroup instance from live VMware device backing.
+
+        Args:
+            device_backing: VMware device backing object
+
+        Returns:
+            NetworkAdapterPortgroup: Appropriate portgroup subclass instance
+        """
+        if hasattr(device_backing, 'port'):
+            return DvsNetworkAdapterPortgroup(device_backing.port.portgroupKey, device_backing.port.switchUuid, raw_device=device_backing)
+        elif hasattr(device_backing, 'opaqueNetworkId'):
+            return NsxtNetworkAdapterPortgroup(device_backing.opaqueNetworkId, raw_device=device_backing)
+        else:
+            return VswitchNetworkAdapterPortgroup(device_backing.deviceName, device_backing.network, raw_device=device_backing)
+
+    @classmethod
+    def from_portgroup(cls, portgroup):
+        """
+        Create appropriate portgroup instance from live VMware portgroup object.
+
+        Args:
+            portgroup: VMware portgroup object
+
+        Returns:
+            NetworkAdapterPortgroup or None: Appropriate portgroup subclass instance, or None if portgroup is None
+        """
+        if portgroup is None:
+            return None
+
+        if hasattr(portgroup, 'key'):
+            return DvsNetworkAdapterPortgroup(portgroup.key, portgroup.config.distributedVirtualSwitch.uuid, raw_device=portgroup)
+        elif hasattr(portgroup, 'capability'):
+            return NsxtNetworkAdapterPortgroup(portgroup.summary.opaqueNetworkId, raw_device=portgroup)
+        else:
+            return VswitchNetworkAdapterPortgroup(portgroup.name, portgroup, raw_device=portgroup)
+
+
+class DvsNetworkAdapterPortgroup(NetworkAdapterPortgroup):
+    """
+    Handles distributed virtual switch (DVS) portgroup configurations.
+
+    This class manages network adapter configurations that connect to distributed
+    virtual switch portgroups, which are used in VMware vSphere environments with
+    distributed switches.
+
+    Attributes:
+        key (str): Portgroup key identifier
+        switch_uuid (str): Distributed virtual switch UUID
+    """
+
+    def __init__(self, key, switch_uuid, raw_device=None):
+        """
+        Initialize DVS network adapter portgroup.
+
+        Args:
+            key (str): Portgroup key identifier
+            switch_uuid (str): Distributed virtual switch UUID
+            raw_device: Original VMware portgroup object
+        """
+        super().__init__(raw_device)
+        self.key = key
+        self.switch_uuid = switch_uuid
+
+    def to_new_spec(self):
+        """
+        Convert to VMware DVS portgroup backing specification for new devices.
+
+        Returns:
+            vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo:
+                VMware DVS portgroup backing spec
+        """
+        dvs_port_connection = vim.dvs.PortConnection()
+        dvs_port_connection.portgroupKey = self.key
+        dvs_port_connection.switchUuid = self.switch_uuid
+        backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
+        backing.port = dvs_port_connection
+
+        return backing
+
+    def to_update_spec(self):
+        """
+        Convert to VMware DVS portgroup backing specification for device updates.
+
+        Returns:
+            vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo:
+                VMware DVS portgroup backing spec
+        """
+        return self.to_new_spec()
+
+    def differs_from_linked_device(self):
+        """
+        Check if this DVS portgroup differs from the linked live device.
+
+        Returns:
+            bool: True if there are differences, False otherwise
+        """
+        if self._linked_device is None:
+            return True
+
+        return (
+            self._compare_attributes_for_changes(self.key, self._linked_device.key) or
+            self._compare_attributes_for_changes(self.switch_uuid, self._linked_device.switch_uuid)
+        )
+
+    def _to_module_output(self):
+        """
+        Generate module output friendly representation of the DVS portgroup.
+
+        Returns:
+            dict
+        """
+        return {
+            "key": self.key,
+            "switch_uuid": self.switch_uuid,
+        }
+
+
+class NsxtNetworkAdapterPortgroup(NetworkAdapterPortgroup):
+    """
+    Handles NSX-T logical switch configurations.
+
+    This class manages network adapter configurations that connect to NSX-T
+    logical switches, providing network virtualization capabilities in VMware
+    environments with NSX-T integration.
+
+    Attributes:
+        opaque_network_id (str): NSX-T logical switch opaque network ID
+    """
+
+    def __init__(self, opaque_network_id, raw_device=None):
+        """
+        Initialize NSX-T network adapter portgroup.
+
+        Args:
+            opaque_network_id (str): NSX-T logical switch opaque network ID
+            raw_device: Original VMware portgroup object
+        """
+        super().__init__(raw_device)
+        self.opaque_network_id = opaque_network_id
+
+    def to_new_spec(self):
+        """
+        Convert to VMware NSX-T portgroup backing specification for new devices.
+
+        Returns:
+            vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo:
+                VMware NSX-T portgroup backing spec
+        """
+        backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
+        backing.opaqueNetworkType = 'nsx.LogicalSwitch'
+        backing.opaqueNetworkId = self.opaque_network_id
+        backing.deviceInfo.summary = 'nsx.LogicalSwitch: %s' % self.opaque_network_id
+
+        return backing
+
+    def to_update_spec(self):
+        """
+        Convert to VMware NSX-T portgroup backing specification for device updates.
+
+        Returns:
+            vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo:
+                VMware NSX-T portgroup backing spec
+        """
+        return self.to_new_spec()
+
+    def differs_from_linked_device(self):
+        """
+        Check if this NSX-T portgroup differs from the linked live device.
+
+        Returns:
+            bool: True if there are differences, False otherwise
+        """
+        if self._linked_device is None:
+            return True
+
+        return self._compare_attributes_for_changes(self.opaque_network_id, self._linked_device.opaque_network_id)
+
+    def _to_module_output(self):
+        """
+        Generate module output friendly representation of the NSX-T portgroup.
+
+        Returns:
+            dict
+        """
+        return {
+            "opaque_network_id": self.opaque_network_id,
+        }
+
+
+class VswitchNetworkAdapterPortgroup(NetworkAdapterPortgroup):
+    """
+    Handles standard vSwitch portgroup configurations.
+
+    This class manages network adapter configurations that connect to standard
+    VMware vSwitch portgroups, which are the traditional networking option in
+    vSphere environments.
+
+    Attributes:
+        name (str): Portgroup name
+        network: VMware network object reference
+    """
+
+    def __init__(self, name, network, raw_device=None):
+        """
+        Initialize vSwitch network adapter portgroup.
+
+        Args:
+            name (str): Portgroup name
+            network: VMware network object reference
+            raw_device: Original VMware portgroup object
+        """
+        super().__init__(raw_device)
+        self.name = name
+        self.network = network
+
+    def to_new_spec(self):
+        """
+        Convert to VMware vSwitch portgroup backing specification for new devices.
+
+        Returns:
+            vim.vm.device.VirtualEthernetCard.NetworkBackingInfo:
+                VMware vSwitch portgroup backing spec
+        """
+        backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+        backing.network = self.network
+        backing.deviceName = self.name
+
+        return backing
+
+    def to_update_spec(self):
+        """
+        Convert to VMware vSwitch portgroup backing specification for device updates.
+
+        Returns:
+            vim.vm.device.VirtualEthernetCard.NetworkBackingInfo:
+                VMware vSwitch portgroup backing spec
+        """
+        return self.to_new_spec()
+
+    def differs_from_linked_device(self):
+        """
+        Check if this vSwitch portgroup differs from the linked live device.
+
+        Returns:
+            bool: True if there are differences, False otherwise
+        """
+        if self._linked_device is None:
+            return True
+
+        return (
+            self._compare_attributes_for_changes(self.name, self._linked_device.name) or
+            self._compare_attributes_for_changes(self.network, self._linked_device.network)
+        )
+
+    def _to_module_output(self):
+        """
+        Generate module output friendly representation of the vSwitch portgroup.
+
+        Returns:
+            dict
+        """
+        return {
+            "name": self.name,
+            "network": self.network._GetMoId(),
+        }
+
+
+class NetworkAdapter(AbstractVsphereObject):
     """
     Represents a virtual network adapter for VM configuration.
 
     This class encapsulates the properties and behavior of a virtual network adapter,
-    including its portgroup_name, adapter_type, connect_at_power_on, shares, shares_level, reservation, limit, and mac_address. It
-    provides methods to create VMware device specifications for both new
-    disk creation and existing disk modification.
+    including its portgroup configuration, adapter type, connection settings, resource
+    allocation, and MAC address. It provides methods to create VMware device specifications
+    for both new adapter creation and existing adapter modification.
 
-    The disk maintains references to both the desired configuration and
-    any existing VM device, enabling change detection and spec generation.
+    The adapter maintains references to both the desired configuration and any existing
+    VM device, enabling change detection and spec generation.
 
     Attributes:
-        portgroup_name (str): Name of the portgroup or distributed virtual portgroup for this interface.
-        adapter_type (str): Type of the network adapter.
-        connect_at_power_on (bool): Specifies whether or not to connect the network adapter when the virtual machine starts.
-        shares (int): The percentage of network resources allocated to the network adapter.
-        shares_level (str): The pre-defined allocation level of network resources for the network adapter.
-        reservation (int): The amount of network resources reserved for the network adapter.
-        limit (int): The maximum amount of network resources the network adapter can use.
-        mac_address (str): The MAC address of the network adapter.
-        _spec: VMware device specification (when generated)
-        _device: Existing VMware device object (when linked)
+        index (int): The global index of the network adapter
+        adapter_vim_class (class): Vim class of the network adapter (e.g., vim.vm.device.VirtualE1000)
+        portgroup (NetworkAdapterPortgroup): Portgroup configuration for this adapter
+        connect_at_power_on (bool): Whether to connect the adapter when VM starts
+        connected (bool): Current connection state of the adapter
+        resource_allocation (NetworkAdapterResourceAllocation): Resource allocation settings
+        mac_address (str): MAC address of the network adapter ("automatic" for generated)
+        _raw_object: Original VMware device object
+        _linked_device: Corresponding live device for change detection
     """
 
-    def __init__(self, label, portgroup_name, adapter_type, connect_at_power_on, connected, mac_address, resource_allocation: NetworkAdapterResourceAllocation):
+    def __init__(self, index, adapter_vim_class, connect_at_power_on, connected, mac_address, resource_allocation: NetworkAdapterResourceAllocation, portgroup: NetworkAdapterPortgroup, raw_object=None):
         """
-        Initialize a new disk object.
+        Initialize a new network adapter object.
 
         Args:
-            label (str): Label for the network adapter.
-            portgroup_name (str): Name of the portgroup or distributed virtual portgroup for this interface.
-            adapter_type (str): Type of the network adapter.
-            connect_at_power_on (bool): Specifies whether or not to connect the network adapter when the virtual machine starts.
-            shares (int): The percentage of network resources allocated to the network adapter.
-            shares_level (str): The pre-defined allocation level of network resources for the network adapter.
-            reservation (int): The amount of network resources reserved for the network adapter.
-            limit (int): The maximum amount of network resources the network adapter can use.
-            mac_address (str): The MAC address of the network adapter.
-
-        Side Effects:
-            Converts size string to kilobytes.
-            Registers this disk with the controller.
+            index (int): The global index of the network adapter
+            adapter_vim_class (class): Vim class of the network adapter
+            connect_at_power_on (bool): Whether to connect the adapter when VM starts
+            connected (bool): Current connection state of the adapter
+            mac_address (str): MAC address ("automatic" for generated, specific address for manual)
+            resource_allocation (NetworkAdapterResourceAllocation): Resource allocation settings
+            portgroup (NetworkAdapterPortgroup): Portgroup configuration
+            raw_object: Original VMware device object
         """
-        self.label = label
-        self.adapter_type = adapter_type
-        try:
-            _ = self.adapter_type_vim_class()
-        except KeyError:
-            raise ValueError("Unsupported network adapter type: %s" % self.adapter_type)
-
-        self.portgroup_name = portgroup_name
+        super().__init__(raw_object=raw_object)
+        self.index = index
+        self.adapter_vim_class = adapter_vim_class
+        self.portgroup = portgroup
         self.connect_at_power_on = connect_at_power_on
         self.connected = connected
         self.resource_allocation = resource_allocation
         self.mac_address = mac_address
 
-        self._spec = None
-        self._device = None
-
-    @property
-    def key(self):
+    @classmethod
+    def from_device_spec(cls, device_spec):
         """
-        Get the VMware device key for this disk.
+        Create network adapter instance from VMware device specification.
 
-        The device key is VMware's unique identifier for the disk. This
-        property returns the key from either the existing device or the
-        generated specification.
+        Args:
+            device_spec: VMware VirtualDeviceSpec object
 
         Returns:
-            int or None: VMware device key, or None if no device/spec exists
+            NetworkAdapter: Configured network adapter instance
         """
-        if self._device is not None:
-            return self._device.key
-        if self._spec is not None:
-            return self._spec.device.key
-        return None
+        return cls(
+            index="",
+            adapter_vim_class=type(device_spec),
+            portgroup=NetworkAdapterPortgroup.from_device_spec(device_spec.backing),
+            connect_at_power_on=device_spec.connectable.startConnected,
+            connected=device_spec.connectable.connected,
+            mac_address="automatic" if device_spec.addressType == "generated" else device_spec.macAddress,
+            resource_allocation=NetworkAdapterResourceAllocation.from_device_spec(device_spec.resourceAllocation),
+            raw_object=device_spec,
+        )
 
-    @property
-    def name_as_str(self):
+    def differs_from_linked_device(self):
         """
-        Get a human-readable name for this network adapter.
-
-        Generates a descriptive name including the portgroup_name and adapter_type for easy identification in error messages and logs.
+        Check if this network adapter differs from the linked live device.
 
         Returns:
-            str: Human-readable network adapter name (e.g., "Network Adapter - foo")
+            bool: True if there are differences, False otherwise
         """
-        return "Network Adapter - %s - %s" % (self.label)
+        if self._linked_device is None:
+            return True
 
-    @property
-    def adapter_type_vim_class(self):
-        """
-        Get the VMware device class for this network adapter type.
-        vim classes are defined as a property so the sdk is lazily loaded and the linter is happy.
-        """
-        NETWORK_ADAPTER_TYPE_TO_VIM_DEVICE_CLASS_MAP = {
-            "pcnet32": vim.vm.device.VirtualPCNet32,
-            "vmxnet2": vim.vm.device.VirtualVmxnet2,
-            "vmxnet3": vim.vm.device.VirtualVmxnet3,
-            "e1000": vim.vm.device.VirtualE1000,
-            "e1000e": vim.vm.device.VirtualE1000e,
-        }
-        return NETWORK_ADAPTER_TYPE_TO_VIM_DEVICE_CLASS_MAP[self.adapter_type]
+        att = [
+            (self.portgroup, self._linked_device.portgroup),
+            (self.resource_allocation, self._linked_device.resource_allocation),
+            (self.mac_address, self._linked_device.mac_address),
+            (self.connect_at_power_on, self._linked_device.connect_at_power_on),
+            (self.connected, self._linked_device.connected),
+        ]
 
-    def update_network_adapter_spec(self):
-        """
-        Create a VMware device specification for updating an existing network adapter.
+        for a in att:
+            if self._compare_attributes_for_changes(a[0], a[1]):
+                raise Exception("diffs %s from %s" % (a[0], a[1]))
+                return True
+        return False
 
-        Generates a device specification that can be used to modify the
-        properties of an existing network adapter on a VM. The specification includes
-        all current network adapter properties.
+    def to_new_spec(self):
+        """
+        Convert to VMware device specification for new network adapter creation.
 
         Returns:
-            vim.vm.device.VirtualDeviceSpec: VMware device specification for network adapter update
-
-        Side Effects:
-            Caches the generated specification in self._spec
-        """
-        network_adapter_spec = vim.vm.device.VirtualDeviceSpec()
-        network_adapter_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
-        network_adapter_spec.device = self._device
-
-        if self.mac_address == 'automatic':
-            network_adapter_spec.device.addressType = 'generated'
-        elif self.mac_address is not None:
-            network_adapter_spec.device.addressType = 'manual'
-            network_adapter_spec.device.macAddress = self.mac_address
-
-        self._update_network_adapter_spec_with_options(network_adapter_spec)
-        self._spec = network_adapter_spec
-        return network_adapter_spec
-
-    def create_network_adapter_spec(self):
-        """
-        Create a VMware device specification for adding a new disk.
-
-        Generates a device specification that can be used to add this network adapter
-        to a VM. Includes file creation operation and assigns a temporary
-        device key for VMware's internal tracking.
-        The device key is overwritten by VMware when the network adapter is created.
-
-        Returns:
-            vim.vm.device.VirtualDeviceSpec: VMware device specification for network adapter creation
-
-        Side Effects:
-            Caches the generated specification in self._spec.
-            Assigns a random negative device key for temporary identification.
+            vim.vm.device.VirtualDeviceSpec: VMware device specification for new adapter
         """
         network_adapter_spec = vim.vm.device.VirtualDeviceSpec()
         network_adapter_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
-        network_adapter_spec.device = self.adapter_type_vim_class()
+        network_adapter_spec.device = self.adapter_vim_class()
         network_adapter_spec.device.key = -randint(25000, 29999)
 
         network_adapter_spec.device.deviceInfo = vim.Description()
@@ -242,12 +554,55 @@ class NetworkAdapter:
             network_adapter_spec.device.macAddress = self.mac_address
 
         self._update_network_adapter_spec_with_options(network_adapter_spec)
-        self._spec = network_adapter_spec
         return network_adapter_spec
+
+    def to_update_spec(self):
+        """
+        Convert to VMware device specification for network adapter updates.
+
+        Returns:
+            vim.vm.device.VirtualDeviceSpec: VMware device specification for adapter update
+        """
+        network_adapter_spec = vim.vm.device.VirtualDeviceSpec()
+        network_adapter_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+        network_adapter_spec.device = self._raw_object or self._linked_device._raw_object
+
+        if self.mac_address == 'automatic':
+            network_adapter_spec.device.addressType = 'generated'
+        elif self.mac_address is not None:
+            network_adapter_spec.device.addressType = 'manual'
+            network_adapter_spec.device.macAddress = self.mac_address
+
+        self._update_network_adapter_spec_with_options(network_adapter_spec)
+        return network_adapter_spec
+
+    def link_corresponding_live_device(self, device: "NetworkAdapter"):
+        """
+        Link this network adapter to its corresponding live device for change detection.
+
+        Args:
+            device (NetworkAdapter): The live network adapter device to link
+        """
+        super().link_corresponding_live_device(device)
+        self.portgroup.link_corresponding_live_device(device.portgroup)
+        self.resource_allocation.link_corresponding_live_device(device.resource_allocation)
+
+    @property
+    def name_as_str(self):
+        """
+        Get a human-readable name for this network adapter.
+
+        Generates a descriptive name including the adapter type, portgroup name, and index
+        for easy identification in error messages and logs.
+
+        Returns:
+            str: Human-readable network adapter name (e.g., "Network Adapter - VirtualE1000 - 0")
+        """
+        return "Network Adapter - %s - %s" % (self.adapter_vim_class.__name__, self.index)
 
     def _update_network_adapter_spec_with_options(self, network_adapter_spec):
         """
-        Sets the network adapter spec options that are shared between create and update operations.
+        Set the network adapter spec options that are shared between create and update operations.
 
         Args:
             network_adapter_spec: VMware device specification to configure
@@ -261,62 +616,26 @@ class NetworkAdapter:
         if self.connected is not None:
             network_adapter_spec.device.connectable.connected = self.connected
 
-        network_adapter_spec.device.deviceInfo.summary = self.name_as_str
-        allocation_spec = self.resource_allocation.create_resource_allocation_spec()
+        allocation_spec = self.resource_allocation.to_new_spec()
         if allocation_spec is not None:
             network_adapter_spec.device.resourceAllocation = allocation_spec
 
-    def linked_device_differs_from_config(self):
-        """
-        Check if the linked VM device differs from desired configuration.
+        portgroup_spec = self.portgroup.to_new_spec()
+        if portgroup_spec is not None:
+            network_adapter_spec.device.backing = portgroup_spec
 
-        Compares the properties of an existing VM disk device with the
-        desired configuration to determine if changes are needed. Used
-        for change detection in existing VMs.
+    def _to_module_output(self):
+        """
+        Generate module output friendly representation of the network adapter.
 
         Returns:
-            bool: True if the device differs from desired config, False if in sync
-
-        Note:
-            Returns True if no device is linked (indicating creation is needed).
+            dict
         """
-        if not self._device:
-            return True
-
-        if self._linked_device_differs_from_config_mac_address():
-            return True
-
-        if self.resource_allocation.device_allocation_differs_from_config(self._device.resourceAllocation):
-            return True
-
-        return (
-            self._device.connectable.startConnected != self.connect_at_power_on
-            or self._device.connectable.connected != self.connected
-            or self._device.deviceInfo.summary != self.name_as_str
-        )
-
-    def _linked_device_differs_from_config_mac_address(self):
-        if self.mac_address == 'automatic':
-            return self._device.addressType != 'generated'
-        elif self.mac_address is not None:
-            return self._device.addressType != 'manual' or self._device.macAddress != self.mac_address
-        else:
-            return False
-
-    def _linked_device_differs_from_config_allocation(self):
-        _diff = False
-        if not _diff and self.shares is not None:
-            _diff = self._device.resourceAllocation.shares.level != 'custom' or self._device.resourceAllocation.shares.shares != self.shares
-
-        if not _diff and self.shares_level is not None:
-            _diff = self._device.resourceAllocation.shares.level != self.shares_level
-
-        if not _diff and self.limit is not None:
-            _diff = self._device.resourceAllocation.limit != self.limit
-
-        if not _diff and self.reservation is not None:
-            _diff = self._device.resourceAllocation.reservation != self.reservation
-
-        return _diff
-
-
+        return {
+            "type": self.adapter_vim_class.__name__.lower(),
+            "portgroup": self.portgroup._to_module_output(),
+            "connect_at_power_on": self.connect_at_power_on,
+            "connected": self.connected,
+            "resource_allocation": self.resource_allocation._to_module_output(),
+            "mac_address": self.mac_address,
+        }

--- a/plugins/module_utils/vm/objects/_network_adapter.py
+++ b/plugins/module_utils/vm/objects/_network_adapter.py
@@ -1,0 +1,322 @@
+"""
+Network adapter object representation for VM configuration management.
+
+This module provides the NetworkAdapter class, which represents a virtual network adapter
+and handles the creation and modification of VMware network adapter specifications.
+It manages network adapter properties such as portgroup_name, adapter_type, connect_at_power_on, shares, shares_level, reservation, limit, and mac_address.
+
+It is meant to represent one of the items in the module's 'network_adapters' parameter.
+"""
+
+from random import randint
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+class NetworkAdapterPortgroup:
+    def __init__(self, name, lookup_service):
+        self.name = name
+        try:
+            self._portgroup = lookup_service.get_portgroup(name)
+        except Exception:
+            try:
+                self._portgroup = lookup_service.get_distributed_virtual_portgroup(name)
+            except Exception:
+                raise ValueError("Portgroup %s not found" % name)
+
+    def device_portgroup_differs_from_config(self, device_portgroup):
+        if self._portgroup is None:
+            return True
+
+        return self._portgroup.name != device_portgroup.name
+
+
+class NetworkAdapterResourceAllocation:
+    def __init__(self, shares=None, shares_level=None, reservation=None, limit=None):
+        self.shares = shares
+        self.shares_level = shares_level
+        self.reservation = reservation
+        self.limit = limit
+
+    def device_allocation_differs_from_config(self, device_allocation):
+        _diff = False
+        if not _diff and self.shares is not None:
+            _diff = device_allocation.shares.level != 'custom' or device_allocation.shares.shares != self.shares
+
+        if not _diff and self.shares_level is not None:
+            _diff = device_allocation.shares.level != self.shares_level
+
+        if not _diff and self.limit is not None:
+            _diff = device_allocation.limit != self.limit
+
+        if not _diff and self.reservation is not None:
+            _diff = device_allocation.reservation != self.reservation
+
+        return _diff
+
+    def create_resource_allocation_spec(self):
+        if self.shares is None and self.shares_level is None and self.limit is None and self.reservation is None:
+            return None
+
+        allocation = vim.ResourceAllocationInfo()
+        if self.shares_level is not None or self.shares is not None:
+            shares_info = vim.SharesInfo()
+            if self.shares is not None:
+                shares_info.level = "custom"
+                shares_info.shares = self.shares
+            else:
+                shares_info.level = self.shares_level
+            allocation.shares = shares_info
+
+        if self.limit is not None:
+            allocation.limit = self.limit
+
+        if self.reservation is not None:
+            allocation.reservation = self.reservation
+
+        return allocation
+
+
+class NetworkAdapter:
+    """
+    Represents a virtual network adapter for VM configuration.
+
+    This class encapsulates the properties and behavior of a virtual network adapter,
+    including its portgroup_name, adapter_type, connect_at_power_on, shares, shares_level, reservation, limit, and mac_address. It
+    provides methods to create VMware device specifications for both new
+    disk creation and existing disk modification.
+
+    The disk maintains references to both the desired configuration and
+    any existing VM device, enabling change detection and spec generation.
+
+    Attributes:
+        portgroup_name (str): Name of the portgroup or distributed virtual portgroup for this interface.
+        adapter_type (str): Type of the network adapter.
+        connect_at_power_on (bool): Specifies whether or not to connect the network adapter when the virtual machine starts.
+        shares (int): The percentage of network resources allocated to the network adapter.
+        shares_level (str): The pre-defined allocation level of network resources for the network adapter.
+        reservation (int): The amount of network resources reserved for the network adapter.
+        limit (int): The maximum amount of network resources the network adapter can use.
+        mac_address (str): The MAC address of the network adapter.
+        _spec: VMware device specification (when generated)
+        _device: Existing VMware device object (when linked)
+    """
+
+    def __init__(self, label, portgroup_name, adapter_type, connect_at_power_on, connected, mac_address, resource_allocation: NetworkAdapterResourceAllocation):
+        """
+        Initialize a new disk object.
+
+        Args:
+            label (str): Label for the network adapter.
+            portgroup_name (str): Name of the portgroup or distributed virtual portgroup for this interface.
+            adapter_type (str): Type of the network adapter.
+            connect_at_power_on (bool): Specifies whether or not to connect the network adapter when the virtual machine starts.
+            shares (int): The percentage of network resources allocated to the network adapter.
+            shares_level (str): The pre-defined allocation level of network resources for the network adapter.
+            reservation (int): The amount of network resources reserved for the network adapter.
+            limit (int): The maximum amount of network resources the network adapter can use.
+            mac_address (str): The MAC address of the network adapter.
+
+        Side Effects:
+            Converts size string to kilobytes.
+            Registers this disk with the controller.
+        """
+        self.label = label
+        self.adapter_type = adapter_type
+        try:
+            _ = self.adapter_type_vim_class()
+        except KeyError:
+            raise ValueError("Unsupported network adapter type: %s" % self.adapter_type)
+
+        self.portgroup_name = portgroup_name
+        self.connect_at_power_on = connect_at_power_on
+        self.connected = connected
+        self.resource_allocation = resource_allocation
+        self.mac_address = mac_address
+
+        self._spec = None
+        self._device = None
+
+    @property
+    def key(self):
+        """
+        Get the VMware device key for this disk.
+
+        The device key is VMware's unique identifier for the disk. This
+        property returns the key from either the existing device or the
+        generated specification.
+
+        Returns:
+            int or None: VMware device key, or None if no device/spec exists
+        """
+        if self._device is not None:
+            return self._device.key
+        if self._spec is not None:
+            return self._spec.device.key
+        return None
+
+    @property
+    def name_as_str(self):
+        """
+        Get a human-readable name for this network adapter.
+
+        Generates a descriptive name including the portgroup_name and adapter_type for easy identification in error messages and logs.
+
+        Returns:
+            str: Human-readable network adapter name (e.g., "Network Adapter - foo")
+        """
+        return "Network Adapter - %s - %s" % (self.label)
+
+    @property
+    def adapter_type_vim_class(self):
+        """
+        Get the VMware device class for this network adapter type.
+        vim classes are defined as a property so the sdk is lazily loaded and the linter is happy.
+        """
+        NETWORK_ADAPTER_TYPE_TO_VIM_DEVICE_CLASS_MAP = {
+            "pcnet32": vim.vm.device.VirtualPCNet32,
+            "vmxnet2": vim.vm.device.VirtualVmxnet2,
+            "vmxnet3": vim.vm.device.VirtualVmxnet3,
+            "e1000": vim.vm.device.VirtualE1000,
+            "e1000e": vim.vm.device.VirtualE1000e,
+        }
+        return NETWORK_ADAPTER_TYPE_TO_VIM_DEVICE_CLASS_MAP[self.adapter_type]
+
+    def update_network_adapter_spec(self):
+        """
+        Create a VMware device specification for updating an existing network adapter.
+
+        Generates a device specification that can be used to modify the
+        properties of an existing network adapter on a VM. The specification includes
+        all current network adapter properties.
+
+        Returns:
+            vim.vm.device.VirtualDeviceSpec: VMware device specification for network adapter update
+
+        Side Effects:
+            Caches the generated specification in self._spec
+        """
+        network_adapter_spec = vim.vm.device.VirtualDeviceSpec()
+        network_adapter_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+        network_adapter_spec.device = self._device
+
+        if self.mac_address == 'automatic':
+            network_adapter_spec.device.addressType = 'generated'
+        elif self.mac_address is not None:
+            network_adapter_spec.device.addressType = 'manual'
+            network_adapter_spec.device.macAddress = self.mac_address
+
+        self._update_network_adapter_spec_with_options(network_adapter_spec)
+        self._spec = network_adapter_spec
+        return network_adapter_spec
+
+    def create_network_adapter_spec(self):
+        """
+        Create a VMware device specification for adding a new disk.
+
+        Generates a device specification that can be used to add this network adapter
+        to a VM. Includes file creation operation and assigns a temporary
+        device key for VMware's internal tracking.
+        The device key is overwritten by VMware when the network adapter is created.
+
+        Returns:
+            vim.vm.device.VirtualDeviceSpec: VMware device specification for network adapter creation
+
+        Side Effects:
+            Caches the generated specification in self._spec.
+            Assigns a random negative device key for temporary identification.
+        """
+        network_adapter_spec = vim.vm.device.VirtualDeviceSpec()
+        network_adapter_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        network_adapter_spec.device = self.adapter_type_vim_class()
+        network_adapter_spec.device.key = -randint(25000, 29999)
+
+        network_adapter_spec.device.deviceInfo = vim.Description()
+        network_adapter_spec.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
+        if self.mac_address == 'automatic' or self.mac_address is None:
+            network_adapter_spec.device.addressType = 'generated'
+        else:
+            network_adapter_spec.device.addressType = 'manual'
+            network_adapter_spec.device.macAddress = self.mac_address
+
+        self._update_network_adapter_spec_with_options(network_adapter_spec)
+        self._spec = network_adapter_spec
+        return network_adapter_spec
+
+    def _update_network_adapter_spec_with_options(self, network_adapter_spec):
+        """
+        Sets the network adapter spec options that are shared between create and update operations.
+
+        Args:
+            network_adapter_spec: VMware device specification to configure
+
+        Side Effects:
+            Modifies the provided network_adapter_spec with network adapter properties.
+        """
+        if self.connect_at_power_on is not None:
+            network_adapter_spec.device.connectable.startConnected = self.connect_at_power_on
+
+        if self.connected is not None:
+            network_adapter_spec.device.connectable.connected = self.connected
+
+        network_adapter_spec.device.deviceInfo.summary = self.name_as_str
+        allocation_spec = self.resource_allocation.create_resource_allocation_spec()
+        if allocation_spec is not None:
+            network_adapter_spec.device.resourceAllocation = allocation_spec
+
+    def linked_device_differs_from_config(self):
+        """
+        Check if the linked VM device differs from desired configuration.
+
+        Compares the properties of an existing VM disk device with the
+        desired configuration to determine if changes are needed. Used
+        for change detection in existing VMs.
+
+        Returns:
+            bool: True if the device differs from desired config, False if in sync
+
+        Note:
+            Returns True if no device is linked (indicating creation is needed).
+        """
+        if not self._device:
+            return True
+
+        if self._linked_device_differs_from_config_mac_address():
+            return True
+
+        if self.resource_allocation.device_allocation_differs_from_config(self._device.resourceAllocation):
+            return True
+
+        return (
+            self._device.connectable.startConnected != self.connect_at_power_on
+            or self._device.connectable.connected != self.connected
+            or self._device.deviceInfo.summary != self.name_as_str
+        )
+
+    def _linked_device_differs_from_config_mac_address(self):
+        if self.mac_address == 'automatic':
+            return self._device.addressType != 'generated'
+        elif self.mac_address is not None:
+            return self._device.addressType != 'manual' or self._device.macAddress != self.mac_address
+        else:
+            return False
+
+    def _linked_device_differs_from_config_allocation(self):
+        _diff = False
+        if not _diff and self.shares is not None:
+            _diff = self._device.resourceAllocation.shares.level != 'custom' or self._device.resourceAllocation.shares.shares != self.shares
+
+        if not _diff and self.shares_level is not None:
+            _diff = self._device.resourceAllocation.shares.level != self.shares_level
+
+        if not _diff and self.limit is not None:
+            _diff = self._device.resourceAllocation.limit != self.limit
+
+        if not _diff and self.reservation is not None:
+            _diff = self._device.resourceAllocation.reservation != self.reservation
+
+        return _diff
+
+

--- a/plugins/module_utils/vm/parameter_handlers/_abstract.py
+++ b/plugins/module_utils/vm/parameter_handlers/_abstract.py
@@ -160,7 +160,7 @@ class AbstractDeviceLinkedParameterHandler(AbstractParameterHandler):
     3. Use device_tracker for device identification and error reporting
 
     Attributes:
-        vim_device_class: VMware device class this handler manages (must be overridden)
+        vim_device_class: VMware device class(es) this handler manages (must be overridden)
         device_type_to_sub_class_map (dict): Registry of device types to handler classes
         device_tracker: Service for device identification and error reporting
     """
@@ -187,6 +187,7 @@ class AbstractDeviceLinkedParameterHandler(AbstractParameterHandler):
         """
         Get the VMware device class this handler manages. This is a property so vim imports can
         be done lazily, and not cause sanity checks to fail.
+        Can be a single class, or a tuple of classes.
         """
         raise NotImplementedError
 
@@ -226,3 +227,10 @@ class AbstractDeviceLinkedParameterHandler(AbstractParameterHandler):
             May update internal state to track device relationships.
         """
         raise NotImplementedError
+
+
+class DeviceLinkError(Exception):
+    """
+    Exception raised when a device cannot be linked to a parameter handler.
+    """
+    pass

--- a/plugins/module_utils/vm/parameter_handlers/device_linked/_controllers.py
+++ b/plugins/module_utils/vm/parameter_handlers/device_linked/_controllers.py
@@ -14,6 +14,7 @@ VMware requirements.
 from abc import abstractmethod
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers._abstract import (
     AbstractDeviceLinkedParameterHandler,
+    DeviceLinkError,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._controllers import (
     ScsiController,
@@ -181,8 +182,10 @@ class DiskControllerParameterHandlerBase(AbstractDeviceLinkedParameterHandler):
                 controller._device = device
                 return
 
-        raise Exception(
-            f"Controller {self.controllers[0].device_class.__name__} not found for device {device.busNumber}"
+        raise DeviceLinkError(
+            "Controller %s not found for device %s" % (self.controllers[0].device_class.__name__, device.busNumber),
+            device,
+            self,
         )
 
 

--- a/plugins/module_utils/vm/parameter_handlers/device_linked/_disks.py
+++ b/plugins/module_utils/vm/parameter_handlers/device_linked/_disks.py
@@ -12,6 +12,7 @@ placement and validates disk parameters against available controllers.
 
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers._abstract import (
     AbstractDeviceLinkedParameterHandler,
+    DeviceLinkError,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._disk import Disk
 from ansible_collections.vmware.vmware.plugins.module_utils.vm._utils import (
@@ -228,7 +229,9 @@ class DiskParameterHandler(AbstractDeviceLinkedParameterHandler):
                 disk._device = device
                 return
 
-        raise Exception(
+        raise DeviceLinkError(
             "Disk not found for device %s on controller %s"
-            % (device.unitNumber, device.controllerKey)
+            % (device.unitNumber, device.controllerKey),
+            device,
+            self,
         )

--- a/plugins/module_utils/vm/parameter_handlers/device_linked/_disks.py
+++ b/plugins/module_utils/vm/parameter_handlers/device_linked/_disks.py
@@ -53,7 +53,7 @@ class DiskParameterHandler(AbstractDeviceLinkedParameterHandler):
     HANDLER_NAME = "disk"
 
     def __init__(
-        self, error_handler, params, change_set, vm, device_tracker, controller_handlers
+        self, error_handler, params, change_set, vm, device_tracker, controller_handlers, **kwargs
     ):
         """
         Initialize the disk parameter handler.

--- a/plugins/module_utils/vm/parameter_handlers/device_linked/_network_adapters.py
+++ b/plugins/module_utils/vm/parameter_handlers/device_linked/_network_adapters.py
@@ -1,0 +1,203 @@
+"""
+Disk parameter handler for VM storage configuration.
+
+This module provides the DiskParameterHandler class which manages virtual disk
+configuration including disk creation, modification, and controller assignment.
+It handles disk parameter validation, device linking, and VMware specification
+generation for storage management.
+
+The handler works closely with controller handlers to ensure proper disk
+placement and validates disk parameters against available controllers.
+"""
+
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers._abstract import (
+    AbstractDeviceLinkedParameterHandler,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._network_adapter import NetworkAdapter
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+
+class NetworkAdapterParameterHandler(AbstractDeviceLinkedParameterHandler):
+    """
+    Handler for virtual network adapter configuration parameters.
+
+    This handler manages the creation, modification, and validation of virtual
+    network adapters on VMs. It processes network adapter parameters, validates
+    controller assignments, and generates VMware device specifications for network
+    adapter operations.
+
+    The handler requires coordination with controller handlers to ensure that
+    network adapters are properly assigned to available controllers. It validates
+    device specifications and ensures that all required controllers exist.
+
+    Managed Parameters:
+    - network_adapters: List of network adapter configurations with portgroup_name, adapter_type, and device_node
+
+    Each network adapter configuration includes:
+    - portgroup_name: Name of the portgroup or distributed virtual portgroup for this interface.
+    - adapter_type: Type of the network adapter.
+    - connect_at_power_on: Specifies whether or not to connect the network adapter when the virtual machine starts.
+    - shares: The percentage of network resources allocated to the network adapter.
+    - shares_level: The pre-defined allocation level of network resources for the network adapter.
+    - reservation: The amount of network resources reserved for the network adapter.
+    - limit: The maximum amount of network resources the network adapter can use.
+    - mac_address: The MAC address of the network adapter.
+
+    Attributes:
+        network_adapters (list): List of NetworkAdapter objects representing desired network adapter configuration
+    """
+
+    HANDLER_NAME = "network_adapter"
+
+    def __init__(
+        self, error_handler, params, change_set, vm, device_tracker
+    ):
+        """
+        Initialize the disk parameter handler.
+
+        Args:
+            error_handler: Service for parameter validation error handling
+            params (dict): Module parameters containing network adapter configuration
+            change_set: Service for tracking configuration changes and requirements
+            vm: VM object being configured (None for new VM creation)
+            device_tracker: Service for device identification and error reporting
+        """
+        super().__init__(error_handler, params, change_set, vm, device_tracker)
+        self._check_if_params_are_defined_by_user("network_adapters", required_for_vm_creation=True)
+
+        self.network_adapters = []
+
+    @property
+    def vim_device_class(self):
+        """
+        Get the VMware device class for this network adapter type.
+        This is a parent class; network adapters are all subclasses of this vim class.
+        """
+        return vim.vm.device.VirtualEthernetCard
+
+    def verify_parameter_constraints(self):
+        """
+        Validate disk parameter constraints and requirements.
+
+        Parses disk parameters and validates that at least one disk is defined
+        for VM creation or modification. Validates that all required controllers
+        exist and that disk specifications are valid.
+
+        Raises:
+            Calls error_handler.fail_with_parameter_error() for invalid disk
+            parameters, missing controllers, or missing disk definitions.
+        """
+        if len(self.network_adapters) == 0:
+            try:
+                self._parse_network_adapter_params()
+            except ValueError as e:
+                self.error_handler.fail_with_parameter_error(
+                    parameter_name="network_adapters",
+                    message="Error parsing network adapter parameters: %s" % str(e),
+                    details={"error": str(e)},
+                )
+
+    def _parse_network_adapter_params(self):
+        """
+        Parse network adapter parameters and create NetworkAdapter objects.
+
+        Processes the network adapter parameter list, validates specifications,
+        and creates NetworkAdapter objects.
+
+        Side Effects:
+            Populates self.network_adapters with NetworkAdapter objects representing desired configuration.
+        """
+        network_params = self.params.get("network_adapters") or {}
+        for label, network_param in network_params.items():
+            network_adapter = NetworkAdapter(
+                label=label,
+                portgroup_name=network_param.get("portgroup_name"),
+                adapter_type=network_param.get("adapter_type"),
+                connect_at_power_on=network_param.get("connect_at_power_on"),
+                connected=network_param.get("connected"),
+                shares=network_param.get("shares"),
+                shares_level=network_param.get("shares_level"),
+                reservation=network_param.get("reservation"),
+                limit=network_param.get("limit"),
+                mac_address=network_param.get("mac_address"),
+            )
+            self.network_adapters.append(network_adapter)
+
+    def populate_config_spec_with_parameters(self, configspec):
+        """
+        Populate VMware configuration specification with network adapter parameters.
+
+        Adds network adapter device specifications to the configuration for both new
+        network adapter creation and existing network adapter modification. Tracks device IDs
+        for proper error reporting and device management.
+
+        Args:
+            configspec: VMware VirtualMachineConfigSpec to populate
+
+        Side Effects:
+            Adds network adapter device specifications to configspec.deviceChange.
+            Tracks device IDs through device_tracker for error reporting.
+        """
+        for network_adapter in self.change_set.objects_to_add:
+            self.device_tracker.track_device_id_from_spec(network_adapter)
+            configspec.deviceChange.append(network_adapter.create_network_adapter_spec())
+        for network_adapter in self.change_set.objects_to_update:
+            self.device_tracker.track_device_id_from_spec(network_adapter)
+            configspec.deviceChange.append(network_adapter.update_network_adapter_spec())
+
+    def compare_live_config_with_desired_config(self):
+        """
+        Compare current VM disk configuration with desired configuration.
+
+        Analyzes each disk to determine if it needs to be added, updated,
+        or is already in sync with the desired configuration. Categorizes
+        disks based on their current state and required changes.
+
+        Returns:
+            ParameterChangeSet: Updated change set with disk change requirements
+
+        Side Effects:
+            Updates change_set with disk objects categorized by required actions.
+        """
+        for network_adapter in self.network_adapters:
+            if network_adapter._device is None:
+                self.change_set.objects_to_add.append(network_adapter)
+            elif network_adapter.linked_device_differs_from_config():
+                self.change_set.objects_to_update.append(network_adapter)
+            else:
+                self.change_set.objects_in_sync.append(network_adapter)
+
+        return self.change_set
+
+    def link_vm_device(self, device):
+        """
+        Link a VMware network adapter device to the appropriate network adapter object.
+
+        Matches a VMware network adapter device to the corresponding network adapter object based
+        on controller key and unit number. This establishes the connection
+        between the existing VM device and the handler's network adapter representation.
+
+        Args:
+            device: VMware VirtualEthernetCard device to link
+
+        Raises:
+            Exception: If no matching network adapter object is found for the device
+
+        Side Effects:
+            Sets the _device attribute on the matching disk object.
+        """
+        for network_adapter in self.network_adapters:
+            if (
+                isinstance(device, network_adapter.vim_device_class)
+                and device.deviceInfo.label == network_adapter.label
+            ):
+                network_adapter._device = device
+                return
+
+        raise Exception(
+            "Network adapter not found for device %s" % device.deviceInfo.label
+        )

--- a/plugins/module_utils/vm/parameter_handlers/device_linked/_network_adapters.py
+++ b/plugins/module_utils/vm/parameter_handlers/device_linked/_network_adapters.py
@@ -1,13 +1,13 @@
 """
-Disk parameter handler for VM storage configuration.
+Network adapter parameter handler for VM network adapter configuration.
 
-This module provides the DiskParameterHandler class which manages virtual disk
-configuration including disk creation, modification, and controller assignment.
-It handles disk parameter validation, device linking, and VMware specification
+This module provides the NetworkAdapterParameterHandler class which manages virtual network adapter
+configuration including network adapter creation, modification, and portgroup assignment.
+It handles network adapter parameter validation, device linking, and VMware specification
 generation for storage management.
 
-The handler works closely with controller handlers to ensure proper disk
-placement and validates disk parameters against available controllers.
+The handler works closely with portgroup handlers to ensure proper network adapter
+placement and validates network adapter parameters against available portgroups.
 """
 
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers._abstract import (
@@ -68,7 +68,7 @@ class AbstractNetworkAdapterParameterHandler(AbstractDeviceLinkedParameterHandle
         **kwargs
     ):
         """
-        Initialize the disk parameter handler.
+        Initialize the network adapter parameter handler.
 
         Args:
             error_handler: Service for parameter validation error handling
@@ -76,6 +76,7 @@ class AbstractNetworkAdapterParameterHandler(AbstractDeviceLinkedParameterHandle
             change_set: Service for tracking configuration changes and requirements
             vm: VM object being configured (None for new VM creation)
             device_tracker: Service for device identification and error reporting
+            vsphere_object_cache: Service for caching vsphere objects
         """
         super().__init__(error_handler, params, change_set, vm, device_tracker)
         self.vsphere_object_cache = vsphere_object_cache
@@ -83,15 +84,14 @@ class AbstractNetworkAdapterParameterHandler(AbstractDeviceLinkedParameterHandle
 
     def verify_parameter_constraints(self):
         """
-        Validate disk parameter constraints and requirements.
+        Validate network adapter parameter constraints and requirements.
 
-        Parses disk parameters and validates that at least one disk is defined
-        for VM creation or modification. Validates that all required controllers
-        exist and that disk specifications are valid.
+        Parses network adapter parameters. Validates that all required portgroups
+        exist and that network adapter specifications are valid.
 
         Raises:
-            Calls error_handler.fail_with_parameter_error() for invalid disk
-            parameters, missing controllers, or missing disk definitions.
+            Calls error_handler.fail_with_parameter_error() for invalid network adapter
+            parameters, missing portgroups, or missing network adapter definitions.
         """
         if len(self.adapters) == 0:
             try:
@@ -178,10 +178,10 @@ class AbstractNetworkAdapterParameterHandler(AbstractDeviceLinkedParameterHandle
         adapters based on their current state and required changes.
 
         Returns:
-            ParameterChangeSet: Updated change set with disk change requirements
+            ParameterChangeSet: Updated change set with network adapter change requirements
 
         Side Effects:
-            Updates change_set with disk objects categorized by required actions.
+            Updates change_set with network adapter objects categorized by required actions.
         """
         for network_adapter in self.adapters:
             if network_adapter._live_object is None:

--- a/plugins/module_utils/vm/services/_vsphere_object_cache.py
+++ b/plugins/module_utils/vm/services/_vsphere_object_cache.py
@@ -44,9 +44,13 @@ class VsphereObjectCache(ModulePyvmomiBase, AbstractService):
 
         # dvs portgroups are technically standard portgroups, so we need to check for dvs first and
         # then fallback to standard portgroups
-        portgroup = self.get_dvs_portgroup_by_name_or_moid(portgroup_identifier, fail_on_missing=True)
+        portgroup = self.get_dvs_portgroup_by_name_or_moid(
+            portgroup_identifier, fail_on_missing=True
+        )
         if not portgroup:
-            portgroup = self.get_standard_portgroup_by_name_or_moid(portgroup_identifier, fail_on_missing=False)
+            portgroup = self.get_standard_portgroup_by_name_or_moid(
+                portgroup_identifier, fail_on_missing=False
+            )
 
         self._cache[portgroup.name] = portgroup
         self._cache[portgroup._GetMoId()] = portgroup

--- a/plugins/module_utils/vm/services/_vsphere_object_cache.py
+++ b/plugins/module_utils/vm/services/_vsphere_object_cache.py
@@ -45,11 +45,11 @@ class VsphereObjectCache(ModulePyvmomiBase, AbstractService):
         # dvs portgroups are technically standard portgroups, so we need to check for dvs first and
         # then fallback to standard portgroups
         portgroup = self.get_dvs_portgroup_by_name_or_moid(
-            portgroup_identifier, fail_on_missing=True
+            portgroup_identifier, fail_on_missing=False
         )
         if not portgroup:
             portgroup = self.get_standard_portgroup_by_name_or_moid(
-                portgroup_identifier, fail_on_missing=False
+                portgroup_identifier, fail_on_missing=True
             )
 
         self._cache[portgroup.name] = portgroup

--- a/plugins/module_utils/vm/services/_vsphere_object_cache.py
+++ b/plugins/module_utils/vm/services/_vsphere_object_cache.py
@@ -1,0 +1,54 @@
+"""
+Service for looking up and caching objects from vSphere.
+
+This service is used to look up objects from vSphere so other modules can use them.
+Unlike the placement service, this service does is not aware of parameters and has a less specific use case.
+Objects are cached based on the identifier used to look them up, and the MOID (if it is different from the identifier).
+"""
+
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._abstract import (
+    AbstractService,
+)
+
+
+class VsphereObjectCache(ModulePyvmomiBase, AbstractService):
+    """
+    Service for looking up and caching objects from vSphere.
+
+    This service is used to look up objects from vSphere so other modules can use them.
+    Unlike the placement service, this service does is not aware of parameters and has a less specific use case.
+    Objects are cached based on the name and MOID of the object.
+    """
+
+    def __init__(self, module):
+        """
+        Initialize the service.
+
+        Args:
+            module: Ansible module instance for parameter access and vSphere connectivity
+        """
+        ModulePyvmomiBase.__init__(self, module)
+        self._cache = {}
+
+    def get_portgroup(self, portgroup_identifier):
+        """
+        Get the target portgroup for VM placement.
+
+        Resolves and caches the portgroup object for VM placement.
+        """
+        if portgroup_identifier in self._cache:
+            return self._cache[portgroup_identifier]
+
+        # dvs portgroups are technically standard portgroups, so we need to check for dvs first and
+        # then fallback to standard portgroups
+        portgroup = self.get_dvs_portgroup_by_name_or_moid(portgroup_identifier, fail_on_missing=True)
+        if not portgroup:
+            portgroup = self.get_standard_portgroup_by_name_or_moid(portgroup_identifier, fail_on_missing=False)
+
+        self._cache[portgroup.name] = portgroup
+        self._cache[portgroup._GetMoId()] = portgroup
+
+        return portgroup

--- a/plugins/modules/_vm_stub.py
+++ b/plugins/modules/_vm_stub.py
@@ -376,11 +376,24 @@ options:
                 choices: [ usb2, usb3 ]
                 default: usb3
 
-    e1000_network_adapters:
+    network_adapter_remove_unmanaged:
         description:
-            - A list of e1000 network adapters to manage on the VM.
+            - Whether to remove network adapters that are not specified in the O(network_adapters) parameter.
+            - If this is set to true, any network adapters that are not specified in the O(network_adapters) parameter will be removed.
+            - If this is set to false, the module will ignore network adapters beyond those listed in the O(network_adapters) parameter.
+        type: bool
+        required: false
+        default: false
+    network_adapters:
+        description:
+            - A list of network adapters to manage on the VM.
+            - Due to limitations in the VMware API, you cannot change the type of a network adapter once it has been created using
+              this module.
+            - The network adapter types defined in this parameter must match the types of any existing
+              adapters on the VM, in the same order that they are specified. For example, the first adapter in this list
+              must have the same type as the first adapter attached to the VM (if one exists).
+            - Any adapters in this list that do not exist on the VM will be created.
             - Portgroups must already exist; this module does not create them.
-            - If an adapter is not specified, it will be removed from the VM.
         type: list
         elements: dict
         required: false
@@ -391,6 +404,14 @@ options:
                     - The portgroup must already exist.
                 type: str
                 required: true
+            adapter_type:
+                description:
+                    - The type of the adapter.
+                    - This is required when creating a new adapter.
+                    - Note that this cannot be changed once the adapter has been created.
+                type: str
+                required: false
+                choices: [ e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov ]
             connected:
                 type: bool
                 description:
@@ -406,13 +427,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(e1000_network_adapters[].shares) or O(e1000_network_adapters[].shares_level) can be set.
+                    - Only one of O(network_adapters[].shares) or O(network_adapters[].shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(e1000_network_adapters[].shares) or O(e1000_network_adapters[].shares_level) can be set.
+                    - Only one of O(network_adapters[].shares) or O(network_adapters[].shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -435,302 +456,6 @@ options:
                     - If not specified and this is a new adapter, a random MAC address will be assigned.
                     - If not specified and this is an existing adapter, the MAC address will not be changed.
                 required: false
-    e1000e_network_adapters:
-        description:
-            - A list of e1000e network adapters to manage on the VM.
-            - Portgroups must already exist; this module does not create them.
-            - If an adapter is not specified, it will be removed from the VM.
-        type: list
-        elements: dict
-        required: false
-        suboptions:
-            network:
-                description:
-                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
-                    - The portgroup must already exist.
-                type: str
-                required: true
-            connected:
-                type: bool
-                description:
-                    - Indicates whether the NIC is currently connected.
-                required: false
-            connect_at_power_on:
-                type: bool
-                description:
-                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
-                required: false
-            shares:
-                type: int
-                description:
-                    - The percentage of network resources allocated to the network adapter.
-                    - If setting this, it should be between 0 and 100.
-                    - Only one of O(e1000e_network_adapters[].shares) or O(e1000e_network_adapters[].shares_level) can be set.
-                required: false
-            shares_level:
-                type: str
-                description:
-                    - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(e1000e_network_adapters[].shares) or O(e1000e_network_adapters[].shares_level) can be set.
-                required: false
-                choices: [ low, normal, high ]
-            reservation:
-                type: int
-                description:
-                    - The amount of network resources reserved for the network adapter.
-                    - The unit is Mbps.
-                required: false
-            limit:
-                type: int
-                description:
-                    - The maximum amount of network resources the network adapter can use.
-                    - The unit is Mbps.
-                required: false
-            mac_address:
-                type: str
-                description:
-                    - The MAC address of the network adapter.
-                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
-                    - If not specified and this is a new adapter, a random MAC address will be assigned.
-                    - If not specified and this is an existing adapter, the MAC address will not be changed.
-                required: false
-    pcnet32_network_adapters:
-        description:
-            - A list of pcnet32 network adapters to manage on the VM.
-            - Portgroups must already exist; this module does not create them.
-            - If an adapter is not specified, it will be removed from the VM.
-        type: list
-        elements: dict
-        required: false
-        suboptions:
-            network:
-                description:
-                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
-                    - The portgroup must already exist.
-                type: str
-                required: true
-            connected:
-                type: bool
-                description:
-                    - Indicates whether the NIC is currently connected.
-                required: false
-            connect_at_power_on:
-                type: bool
-                description:
-                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
-                required: false
-            shares:
-                type: int
-                description:
-                    - The percentage of network resources allocated to the network adapter.
-                    - If setting this, it should be between 0 and 100.
-                    - Only one of O(pcnet32_network_adapters[].shares) or O(pcnet32_network_adapters[].shares_level) can be set.
-                required: false
-            shares_level:
-                type: str
-                description:
-                    - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(pcnet32_network_adapters[].shares) or O(pcnet32_network_adapters[].shares_level) can be set.
-                required: false
-                choices: [ low, normal, high ]
-            reservation:
-                type: int
-                description:
-                    - The amount of network resources reserved for the network adapter.
-                    - The unit is Mbps.
-                required: false
-            limit:
-                type: int
-                description:
-                    - The maximum amount of network resources the network adapter can use.
-                    - The unit is Mbps.
-                required: false
-            mac_address:
-                type: str
-                description:
-                    - The MAC address of the network adapter.
-                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
-                    - If not specified and this is a new adapter, a random MAC address will be assigned.
-                    - If not specified and this is an existing adapter, the MAC address will not be changed.
-                required: false
-    vmxnet2_network_adapters:
-        description:
-            - A list of vmxnet2 network adapters to manage on the VM.
-            - Portgroups must already exist; this module does not create them.
-            - If an adapter is not specified, it will be removed from the VM.
-        type: list
-        elements: dict
-        required: false
-        suboptions:
-            network:
-                description:
-                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
-                    - The portgroup must already exist.
-                type: str
-                required: true
-            connected:
-                type: bool
-                description:
-                    - Indicates whether the NIC is currently connected.
-                required: false
-            connect_at_power_on:
-                type: bool
-                description:
-                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
-                required: false
-            shares:
-                type: int
-                description:
-                    - The percentage of network resources allocated to the network adapter.
-                    - If setting this, it should be between 0 and 100.
-                    - Only one of O(vmxnet2_network_adapters[].shares) or O(vmxnet2_network_adapters[].shares_level) can be set.
-                required: false
-            shares_level:
-                type: str
-                description:
-                    - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(vmxnet2_network_adapters[].shares) or O(vmxnet2_network_adapters[].shares_level) can be set.
-                required: false
-                choices: [ low, normal, high ]
-            reservation:
-                type: int
-                description:
-                    - The amount of network resources reserved for the network adapter.
-                    - The unit is Mbps.
-                required: false
-            limit:
-                type: int
-                description:
-                    - The maximum amount of network resources the network adapter can use.
-                    - The unit is Mbps.
-                required: false
-            mac_address:
-                type: str
-                description:
-                    - The MAC address of the network adapter.
-                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
-                    - If not specified and this is a new adapter, a random MAC address will be assigned.
-                    - If not specified and this is an existing adapter, the MAC address will not be changed.
-                required: false
-    vmxnet3_network_adapters:
-        description:
-            - A list of vmxnet3 network adapters to manage on the VM.
-            - Portgroups must already exist; this module does not create them.
-            - If an adapter is not specified, it will be removed from the VM.
-        type: list
-        elements: dict
-        required: false
-        suboptions:
-            network:
-                description:
-                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
-                    - The portgroup must already exist.
-                type: str
-                required: true
-            connected:
-                type: bool
-                description:
-                    - Indicates whether the NIC is currently connected.
-                required: false
-            connect_at_power_on:
-                type: bool
-                description:
-                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
-                required: false
-            shares:
-                type: int
-                description:
-                    - The percentage of network resources allocated to the network adapter.
-                    - If setting this, it should be between 0 and 100.
-                    - Only one of O(vmxnet3_network_adapters[].shares) or O(vmxnet3_network_adapters[].shares_level) can be set.
-                required: false
-            shares_level:
-                type: str
-                description:
-                    - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(vmxnet3_network_adapters[].shares) or O(vmxnet3_network_adapters[].shares_level) can be set.
-                required: false
-                choices: [ low, normal, high ]
-            reservation:
-                type: int
-                description:
-                    - The amount of network resources reserved for the network adapter.
-                    - The unit is Mbps.
-                required: false
-            limit:
-                type: int
-                description:
-                    - The maximum amount of network resources the network adapter can use.
-                    - The unit is Mbps.
-                required: false
-            mac_address:
-                type: str
-                description:
-                    - The MAC address of the network adapter.
-                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
-                    - If not specified and this is a new adapter, a random MAC address will be assigned.
-                    - If not specified and this is an existing adapter, the MAC address will not be changed.
-                required: false
-    sriov_network_adapters:
-        description:
-            - A list of sriov network adapters to manage on the VM.
-            - Portgroups must already exist; this module does not create them.
-            - If an adapter is not specified, it will be removed from the VM.
-        type: list
-        elements: dict
-        required: false
-        suboptions:
-            network:
-                description:
-                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
-                    - The portgroup must already exist.
-                type: str
-                required: true
-            connected:
-                type: bool
-                description:
-                    - Indicates whether the NIC is currently connected.
-                required: false
-            connect_at_power_on:
-                type: bool
-                description:
-                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
-                required: false
-            shares:
-                type: int
-                description:
-                    - The percentage of network resources allocated to the network adapter.
-                    - If setting this, it should be between 0 and 100.
-                    - Only one of O(sriov_network_adapters[].shares) or O(sriov_network_adapters[].shares_level) can be set.
-                required: false
-            shares_level:
-                type: str
-                description:
-                    - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(sriov_network_adapters[].shares) or O(sriov_network_adapters[].shares_level) can be set.
-                required: false
-                choices: [ low, normal, high ]
-            reservation:
-                type: int
-                description:
-                    - The amount of network resources reserved for the network adapter.
-                    - The unit is Mbps.
-                required: false
-            limit:
-                type: int
-                description:
-                    - The maximum amount of network resources the network adapter can use.
-                    - The unit is Mbps.
-                required: false
-            mac_address:
-                type: str
-                description:
-                    - The MAC address of the network adapter.
-                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
-                    - If not specified and this is a new adapter, a random MAC address will be assigned.
-                    - If not specified and this is an existing adapter, the MAC address will not be changed.
-                required: false
-
 
 extends_documentation_fragment:
     - vmware.vmware.base_options
@@ -805,12 +530,7 @@ class VmModule(ModulePyvmomiBase):
         self.configuration_registry.register_vm_aware_handler(_memory.MemoryParameterHandler)
 
         self.configuration_registry.register_device_linked_handler(_disks.DiskParameterHandler)
-        self.configuration_registry.register_device_linked_handler(_network_adapters.E1000NetworkAdapterParameterHandler)
-        self.configuration_registry.register_device_linked_handler(_network_adapters.E1000eNetworkAdapterParameterHandler)
-        self.configuration_registry.register_device_linked_handler(_network_adapters.Pcnet32NetworkAdapterParameterHandler)
-        self.configuration_registry.register_device_linked_handler(_network_adapters.Vmxnet2NetworkAdapterParameterHandler)
-        self.configuration_registry.register_device_linked_handler(_network_adapters.Vmxnet3NetworkAdapterParameterHandler)
-        self.configuration_registry.register_device_linked_handler(_network_adapters.SriovNetworkAdapterParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_network_adapters.NetworkAdapterParameterHandler)
 
         self.configuration_registry.register_controller_handler(_controllers.ScsiControllerParameterHandler)
         self.configuration_registry.register_controller_handler(_controllers.NvmeControllerParameterHandler)
@@ -954,84 +674,11 @@ def main():
                 sata_controller_count=dict(type='int', required=False, default=0),
                 usb_controllers=dict(type='list', elements='dict', required=False),
 
-                e1000_network_adapters=dict(
+                network_adapter_remove_unmanaged=dict(type='bool', required=False, default=False),
+                network_adapters=dict(
                     type='list', elements='dict', required=False, options=dict(
                         network=dict(type='str', required=True),
-                        connected=dict(type='bool', required=False),
-                        connect_at_power_on=dict(type='bool', required=False),
-                        shares=dict(type='int', required=False),
-                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
-                        reservation=dict(type='int', required=False),
-                        limit=dict(type='int', required=False),
-                        mac_address=dict(type='str', required=False),
-                    ),
-                    mutually_exclusive=[
-                        ['shares', 'shares_level']
-                    ],
-                ),
-                e1000e_network_adapters=dict(
-                    type='list', elements='dict', required=False, options=dict(
-                        network=dict(type='str', required=True),
-                        connected=dict(type='bool', required=False),
-                        connect_at_power_on=dict(type='bool', required=False),
-                        shares=dict(type='int', required=False),
-                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
-                        reservation=dict(type='int', required=False),
-                        limit=dict(type='int', required=False),
-                        mac_address=dict(type='str', required=False),
-                    ),
-                    mutually_exclusive=[
-                        ['shares', 'shares_level']
-                    ],
-                ),
-                pcnet32_network_adapters=dict(
-                    type='list', elements='dict', required=False, options=dict(
-                        network=dict(type='str', required=True),
-                        connected=dict(type='bool', required=False),
-                        connect_at_power_on=dict(type='bool', required=False),
-                        shares=dict(type='int', required=False),
-                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
-                        reservation=dict(type='int', required=False),
-                        limit=dict(type='int', required=False),
-                        mac_address=dict(type='str', required=False),
-                    ),
-                    mutually_exclusive=[
-                        ['shares', 'shares_level']
-                    ],
-                ),
-                vmxnet2_network_adapters=dict(
-                    type='list', elements='dict', required=False, options=dict(
-                        network=dict(type='str', required=True),
-                        connected=dict(type='bool', required=False),
-                        connect_at_power_on=dict(type='bool', required=False),
-                        shares=dict(type='int', required=False),
-                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
-                        reservation=dict(type='int', required=False),
-                        limit=dict(type='int', required=False),
-                        mac_address=dict(type='str', required=False),
-                    ),
-                    mutually_exclusive=[
-                        ['shares', 'shares_level']
-                    ],
-                ),
-                vmxnet3_network_adapters=dict(
-                    type='list', elements='dict', required=False, options=dict(
-                        network=dict(type='str', required=True),
-                        connected=dict(type='bool', required=False),
-                        connect_at_power_on=dict(type='bool', required=False),
-                        shares=dict(type='int', required=False),
-                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
-                        reservation=dict(type='int', required=False),
-                        limit=dict(type='int', required=False),
-                        mac_address=dict(type='str', required=False),
-                    ),
-                    mutually_exclusive=[
-                        ['shares', 'shares_level']
-                    ],
-                ),
-                sriov_network_adapters=dict(
-                    type='list', elements='dict', required=False, options=dict(
-                        network=dict(type='str', required=True),
+                        adapter_type=dict(type='str', required=False, choices=['e1000', 'e1000e', 'pcnet32', 'vmxnet2', 'vmxnet3', 'sriov']),
                         connected=dict(type='bool', required=False),
                         connect_at_power_on=dict(type='bool', required=False),
                         shares=dict(type='int', required=False),

--- a/plugins/modules/_vm_stub.py
+++ b/plugins/modules/_vm_stub.py
@@ -357,6 +357,7 @@ options:
         required: false
         default: 0
 
+    # TODO: add support for USB controllers
     usb_controllers:
         description:
             - USB device controllers to manage on the VM.
@@ -374,6 +375,74 @@ options:
                 type: str
                 choices: [ usb2, usb3 ]
                 default: usb3
+
+    network_adapters:
+        description:
+            - A dictionary of network adapters to manage on the VM.
+            - Each key is the label of the network adapter, which is
+              a user-defined string used to uniquely identify the adapter.
+            - If an adapter is not specified, it will be removed from the VM.
+        type: dict
+        required: false
+        suboptions:
+            portgroup_name:
+                description:
+                    - Name of the portgroup or distributed virtual portgroup for this interface.
+                    - The portgroup must already exist.
+                type: str
+                required: true
+            adapter_type:
+                type: str
+                description:
+                    - The type of the network adapter.
+                    - Valid values are one of [ e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov ].
+                default: vmxnet3
+                required: false
+            connected:
+                type: bool
+                description:
+                    - Indicates whether the NIC is currently connected.
+                required: false
+            connect_at_power_on:
+                type: bool
+                description:
+                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
+                required: false
+                default: true
+            shares:
+                type: int
+                description:
+                    - The percentage of network resources allocated to the network adapter.
+                    - If setting this, it should be between 0 and 100.
+                    - Only one of O(shares) or O(shares_level) can be set.
+                required: false
+            shares_level:
+                type: str
+                description:
+                    - The pre-defined allocation level of network resources for the network adapter.
+                    - Only one of O(shares) or O(shares_level) can be set.
+                required: false
+                choices: [ low, normal, high ]
+            reservation:
+                type: int
+                description:
+                    - The amount of network resources reserved for the network adapter.
+                    - The unit is Mbps.
+                required: false
+            limit:
+                type: int
+                description:
+                    - The maximum amount of network resources the network adapter can use.
+                    - The unit is Mbps.
+                required: false
+            mac_address:
+                type: str
+                description:
+                    - The MAC address of the network adapter.
+                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
+                    - If not specified and this is a new adapter, a random MAC address will be assigned.
+                    - If not specified and this is an existing adapter, the MAC address will not be changed.
+                required: false
 
 extends_documentation_fragment:
     - vmware.vmware.base_options

--- a/plugins/modules/_vm_stub.py
+++ b/plugins/modules/_vm_stub.py
@@ -406,13 +406,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(e1000_network_adapters.shares) or O(e1000_network_adapters.shares_level) can be set.
+                    - Only one of O(e1000_network_adapters[].shares) or O(e1000_network_adapters[].shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(e1000_network_adapters.shares) or O(e1000_network_adapters.shares_level) can be set.
+                    - Only one of O(e1000_network_adapters[].shares) or O(e1000_network_adapters[].shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -465,13 +465,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(e1000e_network_adapters.shares) or O(e1000e_network_adapters.shares_level) can be set.
+                    - Only one of O(e1000e_network_adapters[].shares) or O(e1000e_network_adapters[].shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(e1000e_network_adapters.shares) or O(e1000e_network_adapters.shares_level) can be set.
+                    - Only one of O(e1000e_network_adapters[].shares) or O(e1000e_network_adapters[].shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -524,13 +524,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(pcnet32_network_adapters.shares) or O(pcnet32_network_adapters.shares_level) can be set.
+                    - Only one of O(pcnet32_network_adapters[].shares) or O(pcnet32_network_adapters[].shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(pcnet32_network_adapters.shares) or O(pcnet32_network_adapters.shares_level) can be set.
+                    - Only one of O(pcnet32_network_adapters[].shares) or O(pcnet32_network_adapters[].shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -583,13 +583,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(vmxnet2_network_adapters.shares) or O(vmxnet2_network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet2_network_adapters[].shares) or O(vmxnet2_network_adapters[].shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(vmxnet2_network_adapters.shares) or O(vmxnet2_network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet2_network_adapters[].shares) or O(vmxnet2_network_adapters[].shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -642,13 +642,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(vmxnet3_network_adapters.shares) or O(vmxnet3_network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet3_network_adapters[].shares) or O(vmxnet3_network_adapters[].shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(vmxnet3_network_adapters.shares) or O(vmxnet3_network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet3_network_adapters[].shares) or O(vmxnet3_network_adapters[].shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -701,13 +701,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(sriov_network_adapters.shares) or O(sriov_network_adapters.shares_level) can be set.
+                    - Only one of O(sriov_network_adapters[].shares) or O(sriov_network_adapters[].shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(sriov_network_adapters.shares) or O(sriov_network_adapters.shares_level) can be set.
+                    - Only one of O(sriov_network_adapters[].shares) or O(sriov_network_adapters[].shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:

--- a/plugins/modules/_vm_stub.py
+++ b/plugins/modules/_vm_stub.py
@@ -376,27 +376,25 @@ options:
                 choices: [ usb2, usb3 ]
                 default: usb3
 
-    network_adapters:
+    e1000_network_adapters:
         description:
-            - A dictionary of network adapters to manage on the VM.
-            - Each key is the label of the network adapter, which is
-              a user-defined string used to uniquely identify the adapter.
+            - A list of e1000 network adapters to manage on the VM.
+            - Portgroups must already exist; this module does not create them.
             - If an adapter is not specified, it will be removed from the VM.
         type: dict
         required: false
         suboptions:
-            portgroup_name:
+            network:
                 description:
-                    - Name of the portgroup or distributed virtual portgroup for this interface.
+                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
                     - The portgroup must already exist.
                 type: str
                 required: true
-            adapter_type:
-                type: str
+            label:
                 description:
-                    - The type of the network adapter.
-                    - Valid values are one of [ e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov ].
-                default: vmxnet3
+                    - The label of the network adapter.
+                    - This is a user-defined string used to uniquely identify the adapter.
+                type: str
                 required: false
             connected:
                 type: bool
@@ -408,19 +406,18 @@ options:
                 description:
                     - Specifies whether or not to connect the network adapter when the virtual machine starts.
                 required: false
-                default: true
             shares:
                 type: int
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(shares) or O(shares_level) can be set.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(shares) or O(shares_level) can be set.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -443,6 +440,297 @@ options:
                     - If not specified and this is a new adapter, a random MAC address will be assigned.
                     - If not specified and this is an existing adapter, the MAC address will not be changed.
                 required: false
+    e1000e_network_adapters:
+        description:
+            - A list of e1000e network adapters to manage on the VM.
+            - Portgroups must already exist; this module does not create them.
+            - If an adapter is not specified, it will be removed from the VM.
+        type: dict
+        required: false
+        suboptions:
+            network:
+                description:
+                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
+                    - The portgroup must already exist.
+                type: str
+                required: true
+            connected:
+                type: bool
+                description:
+                    - Indicates whether the NIC is currently connected.
+                required: false
+            connect_at_power_on:
+                type: bool
+                description:
+                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
+                required: false
+            shares:
+                type: int
+                description:
+                    - The percentage of network resources allocated to the network adapter.
+                    - If setting this, it should be between 0 and 100.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+            shares_level:
+                type: str
+                description:
+                    - The pre-defined allocation level of network resources for the network adapter.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+                choices: [ low, normal, high ]
+            reservation:
+                type: int
+                description:
+                    - The amount of network resources reserved for the network adapter.
+                    - The unit is Mbps.
+                required: false
+            limit:
+                type: int
+                description:
+                    - The maximum amount of network resources the network adapter can use.
+                    - The unit is Mbps.
+                required: false
+            mac_address:
+                type: str
+                description:
+                    - The MAC address of the network adapter.
+                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
+                    - If not specified and this is a new adapter, a random MAC address will be assigned.
+                    - If not specified and this is an existing adapter, the MAC address will not be changed.
+                required: false
+    pcnet32_network_adapters:
+        description:
+            - A list of pcnet32 network adapters to manage on the VM.
+            - Portgroups must already exist; this module does not create them.
+            - If an adapter is not specified, it will be removed from the VM.
+        type: dict
+        required: false
+        suboptions:
+            network:
+                description:
+                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
+                    - The portgroup must already exist.
+                type: str
+                required: true
+            connected:
+                type: bool
+                description:
+                    - Indicates whether the NIC is currently connected.
+                required: false
+            connect_at_power_on:
+                type: bool
+                description:
+                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
+                required: false
+            shares:
+                type: int
+                description:
+                    - The percentage of network resources allocated to the network adapter.
+                    - If setting this, it should be between 0 and 100.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+            shares_level:
+                type: str
+                description:
+                    - The pre-defined allocation level of network resources for the network adapter.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+                choices: [ low, normal, high ]
+            reservation:
+                type: int
+                description:
+                    - The amount of network resources reserved for the network adapter.
+                    - The unit is Mbps.
+                required: false
+            limit:
+                type: int
+                description:
+                    - The maximum amount of network resources the network adapter can use.
+                    - The unit is Mbps.
+                required: false
+            mac_address:
+                type: str
+                description:
+                    - The MAC address of the network adapter.
+                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
+                    - If not specified and this is a new adapter, a random MAC address will be assigned.
+                    - If not specified and this is an existing adapter, the MAC address will not be changed.
+                required: false
+    vmxnet2_network_adapters:
+        description:
+            - A list of vmxnet2 network adapters to manage on the VM.
+            - Portgroups must already exist; this module does not create them.
+            - If an adapter is not specified, it will be removed from the VM.
+        type: dict
+        required: false
+        suboptions:
+            network:
+                description:
+                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
+                    - The portgroup must already exist.
+                type: str
+                required: true
+            connected:
+                type: bool
+                description:
+                    - Indicates whether the NIC is currently connected.
+                required: false
+            connect_at_power_on:
+                type: bool
+                description:
+                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
+                required: false
+            shares:
+                type: int
+                description:
+                    - The percentage of network resources allocated to the network adapter.
+                    - If setting this, it should be between 0 and 100.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+            shares_level:
+                type: str
+                description:
+                    - The pre-defined allocation level of network resources for the network adapter.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+                choices: [ low, normal, high ]
+            reservation:
+                type: int
+                description:
+                    - The amount of network resources reserved for the network adapter.
+                    - The unit is Mbps.
+                required: false
+            limit:
+                type: int
+                description:
+                    - The maximum amount of network resources the network adapter can use.
+                    - The unit is Mbps.
+                required: false
+            mac_address:
+                type: str
+                description:
+                    - The MAC address of the network adapter.
+                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
+                    - If not specified and this is a new adapter, a random MAC address will be assigned.
+                    - If not specified and this is an existing adapter, the MAC address will not be changed.
+                required: false
+    vmxnet3_network_adapters:
+        description:
+            - A list of vmxnet3 network adapters to manage on the VM.
+            - Portgroups must already exist; this module does not create them.
+            - If an adapter is not specified, it will be removed from the VM.
+        type: dict
+        required: false
+        suboptions:
+            network:
+                description:
+                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
+                    - The portgroup must already exist.
+                type: str
+                required: true
+            connected:
+                type: bool
+                description:
+                    - Indicates whether the NIC is currently connected.
+                required: false
+            connect_at_power_on:
+                type: bool
+                description:
+                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
+                required: false
+            shares:
+                type: int
+                description:
+                    - The percentage of network resources allocated to the network adapter.
+                    - If setting this, it should be between 0 and 100.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+            shares_level:
+                type: str
+                description:
+                    - The pre-defined allocation level of network resources for the network adapter.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+                choices: [ low, normal, high ]
+            reservation:
+                type: int
+                description:
+                    - The amount of network resources reserved for the network adapter.
+                    - The unit is Mbps.
+                required: false
+            limit:
+                type: int
+                description:
+                    - The maximum amount of network resources the network adapter can use.
+                    - The unit is Mbps.
+                required: false
+            mac_address:
+                type: str
+                description:
+                    - The MAC address of the network adapter.
+                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
+                    - If not specified and this is a new adapter, a random MAC address will be assigned.
+                    - If not specified and this is an existing adapter, the MAC address will not be changed.
+                required: false
+    sriov_network_adapters:
+        description:
+            - A list of sriov network adapters to manage on the VM.
+            - Portgroups must already exist; this module does not create them.
+            - If an adapter is not specified, it will be removed from the VM.
+        type: dict
+        required: false
+        suboptions:
+            network:
+                description:
+                    - The name or MOID of the standard or distributed virtual portgroup for this interface.
+                    - The portgroup must already exist.
+                type: str
+                required: true
+            connected:
+                type: bool
+                description:
+                    - Indicates whether the NIC is currently connected.
+                required: false
+            connect_at_power_on:
+                type: bool
+                description:
+                    - Specifies whether or not to connect the network adapter when the virtual machine starts.
+                required: false
+            shares:
+                type: int
+                description:
+                    - The percentage of network resources allocated to the network adapter.
+                    - If setting this, it should be between 0 and 100.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+            shares_level:
+                type: str
+                description:
+                    - The pre-defined allocation level of network resources for the network adapter.
+                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                required: false
+                choices: [ low, normal, high ]
+            reservation:
+                type: int
+                description:
+                    - The amount of network resources reserved for the network adapter.
+                    - The unit is Mbps.
+                required: false
+            limit:
+                type: int
+                description:
+                    - The maximum amount of network resources the network adapter can use.
+                    - The unit is Mbps.
+                required: false
+            mac_address:
+                type: str
+                description:
+                    - The MAC address of the network adapter.
+                    - If you want to use a generated or automatic mac address, set this to 'automatic'.
+                    - If not specified and this is a new adapter, a random MAC address will be assigned.
+                    - If not specified and this is an existing adapter, the MAC address will not be changed.
+                required: false
+
 
 extends_documentation_fragment:
     - vmware.vmware.base_options
@@ -490,6 +778,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handler
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked import (
     _disks,
     _controllers,
+    _network_adapters,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.vm._configuration_builder import (
     ConfigurationRegistry,
@@ -516,6 +805,12 @@ class VmModule(ModulePyvmomiBase):
         self.configuration_registry.register_vm_aware_handler(_memory.MemoryParameterHandler)
 
         self.configuration_registry.register_device_linked_handler(_disks.DiskParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_network_adapters.E1000NetworkAdapterParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_network_adapters.E1000eNetworkAdapterParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_network_adapters.Pcnet32NetworkAdapterParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_network_adapters.Vmxnet2NetworkAdapterParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_network_adapters.Vmxnet3NetworkAdapterParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_network_adapters.SriovNetworkAdapterParameterHandler)
 
         self.configuration_registry.register_controller_handler(_controllers.ScsiControllerParameterHandler)
         self.configuration_registry.register_controller_handler(_controllers.NvmeControllerParameterHandler)
@@ -659,6 +954,78 @@ def main():
                 sata_controller_count=dict(type='int', required=False, default=0),
                 usb_controllers=dict(type='list', elements='dict', required=False),
 
+                e1000_network_adapters=dict(
+                    type='list', elements='dict', required=False, options=dict(
+                        network=dict(type='str', required=True),
+                        connected=dict(type='bool', required=False),
+                        connect_at_power_on=dict(type='bool', required=False),
+                        shares=dict(type='int', required=False),
+                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
+                        reservation=dict(type='int', required=False),
+                        limit=dict(type='int', required=False),
+                        mac_address=dict(type='str', required=False),
+                    )
+                ),
+                e1000e_network_adapters=dict(
+                    type='list', elements='dict', required=False, options=dict(
+                        network=dict(type='str', required=True),
+                        connected=dict(type='bool', required=False),
+                        connect_at_power_on=dict(type='bool', required=False),
+                        shares=dict(type='int', required=False),
+                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
+                        reservation=dict(type='int', required=False),
+                        limit=dict(type='int', required=False),
+                        mac_address=dict(type='str', required=False),
+                    )
+                ),
+                pcnet32_network_adapters=dict(
+                        type='list', elements='dict', required=False, options=dict(
+                        network=dict(type='str', required=True),
+                        connected=dict(type='bool', required=False),
+                        connect_at_power_on=dict(type='bool', required=False),
+                        shares=dict(type='int', required=False),
+                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
+                        reservation=dict(type='int', required=False),
+                        limit=dict(type='int', required=False),
+                        mac_address=dict(type='str', required=False),
+                    )
+                ),
+                vmxnet2_network_adapters=dict(
+                        type='list', elements='dict', required=False, options=dict(
+                        network=dict(type='str', required=True),
+                        connected=dict(type='bool', required=False),
+                        connect_at_power_on=dict(type='bool', required=False),
+                        shares=dict(type='int', required=False),
+                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
+                        reservation=dict(type='int', required=False),
+                        limit=dict(type='int', required=False),
+                        mac_address=dict(type='str', required=False),
+                    )
+                ),
+                vmxnet3_network_adapters=dict(
+                    type='list', elements='dict', required=False, options=dict(
+                        network=dict(type='str', required=True),
+                        connected=dict(type='bool', required=False),
+                        connect_at_power_on=dict(type='bool', required=False),
+                        shares=dict(type='int', required=False),
+                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
+                        reservation=dict(type='int', required=False),
+                        limit=dict(type='int', required=False),
+                        mac_address=dict(type='str', required=False),
+                    )
+                ),
+                sriov_network_adapters=dict(
+                    type='list', elements='dict', required=False, options=dict(
+                        network=dict(type='str', required=True),
+                        connected=dict(type='bool', required=False),
+                        connect_at_power_on=dict(type='bool', required=False),
+                        shares=dict(type='int', required=False),
+                        shares_level=dict(type='str', required=False, choices=['low', 'normal', 'high']),
+                        reservation=dict(type='int', required=False),
+                        limit=dict(type='int', required=False),
+                        mac_address=dict(type='str', required=False),
+                    )
+                ),
                 timeout=dict(type='int', default=600),
             )
         },

--- a/plugins/modules/_vm_stub.py
+++ b/plugins/modules/_vm_stub.py
@@ -381,7 +381,8 @@ options:
             - A list of e1000 network adapters to manage on the VM.
             - Portgroups must already exist; this module does not create them.
             - If an adapter is not specified, it will be removed from the VM.
-        type: dict
+        type: list
+        elements: dict
         required: false
         suboptions:
             network:
@@ -390,12 +391,6 @@ options:
                     - The portgroup must already exist.
                 type: str
                 required: true
-            label:
-                description:
-                    - The label of the network adapter.
-                    - This is a user-defined string used to uniquely identify the adapter.
-                type: str
-                required: false
             connected:
                 type: bool
                 description:
@@ -411,13 +406,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(e1000_network_adapters.shares) or O(e1000_network_adapters.shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(e1000_network_adapters.shares) or O(e1000_network_adapters.shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -445,7 +440,8 @@ options:
             - A list of e1000e network adapters to manage on the VM.
             - Portgroups must already exist; this module does not create them.
             - If an adapter is not specified, it will be removed from the VM.
-        type: dict
+        type: list
+        elements: dict
         required: false
         suboptions:
             network:
@@ -469,13 +465,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(e1000e_network_adapters.shares) or O(e1000e_network_adapters.shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(e1000e_network_adapters.shares) or O(e1000e_network_adapters.shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -503,7 +499,8 @@ options:
             - A list of pcnet32 network adapters to manage on the VM.
             - Portgroups must already exist; this module does not create them.
             - If an adapter is not specified, it will be removed from the VM.
-        type: dict
+        type: list
+        elements: dict
         required: false
         suboptions:
             network:
@@ -527,13 +524,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(pcnet32_network_adapters.shares) or O(pcnet32_network_adapters.shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(pcnet32_network_adapters.shares) or O(pcnet32_network_adapters.shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -561,7 +558,8 @@ options:
             - A list of vmxnet2 network adapters to manage on the VM.
             - Portgroups must already exist; this module does not create them.
             - If an adapter is not specified, it will be removed from the VM.
-        type: dict
+        type: list
+        elements: dict
         required: false
         suboptions:
             network:
@@ -585,13 +583,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet2_network_adapters.shares) or O(vmxnet2_network_adapters.shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet2_network_adapters.shares) or O(vmxnet2_network_adapters.shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -619,7 +617,8 @@ options:
             - A list of vmxnet3 network adapters to manage on the VM.
             - Portgroups must already exist; this module does not create them.
             - If an adapter is not specified, it will be removed from the VM.
-        type: dict
+        type: list
+        elements: dict
         required: false
         suboptions:
             network:
@@ -643,13 +642,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet3_network_adapters.shares) or O(vmxnet3_network_adapters.shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(vmxnet3_network_adapters.shares) or O(vmxnet3_network_adapters.shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -677,7 +676,8 @@ options:
             - A list of sriov network adapters to manage on the VM.
             - Portgroups must already exist; this module does not create them.
             - If an adapter is not specified, it will be removed from the VM.
-        type: dict
+        type: list
+        elements: dict
         required: false
         suboptions:
             network:
@@ -701,13 +701,13 @@ options:
                 description:
                     - The percentage of network resources allocated to the network adapter.
                     - If setting this, it should be between 0 and 100.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(sriov_network_adapters.shares) or O(sriov_network_adapters.shares_level) can be set.
                 required: false
             shares_level:
                 type: str
                 description:
                     - The pre-defined allocation level of network resources for the network adapter.
-                    - Only one of O(network_adapters.shares) or O(network_adapters.shares_level) can be set.
+                    - Only one of O(sriov_network_adapters.shares) or O(sriov_network_adapters.shares_level) can be set.
                 required: false
                 choices: [ low, normal, high ]
             reservation:
@@ -964,7 +964,10 @@ def main():
                         reservation=dict(type='int', required=False),
                         limit=dict(type='int', required=False),
                         mac_address=dict(type='str', required=False),
-                    )
+                    ),
+                    mutually_exclusive=[
+                        ['shares', 'shares_level']
+                    ],
                 ),
                 e1000e_network_adapters=dict(
                     type='list', elements='dict', required=False, options=dict(
@@ -976,10 +979,13 @@ def main():
                         reservation=dict(type='int', required=False),
                         limit=dict(type='int', required=False),
                         mac_address=dict(type='str', required=False),
-                    )
+                    ),
+                    mutually_exclusive=[
+                        ['shares', 'shares_level']
+                    ],
                 ),
                 pcnet32_network_adapters=dict(
-                        type='list', elements='dict', required=False, options=dict(
+                    type='list', elements='dict', required=False, options=dict(
                         network=dict(type='str', required=True),
                         connected=dict(type='bool', required=False),
                         connect_at_power_on=dict(type='bool', required=False),
@@ -988,10 +994,13 @@ def main():
                         reservation=dict(type='int', required=False),
                         limit=dict(type='int', required=False),
                         mac_address=dict(type='str', required=False),
-                    )
+                    ),
+                    mutually_exclusive=[
+                        ['shares', 'shares_level']
+                    ],
                 ),
                 vmxnet2_network_adapters=dict(
-                        type='list', elements='dict', required=False, options=dict(
+                    type='list', elements='dict', required=False, options=dict(
                         network=dict(type='str', required=True),
                         connected=dict(type='bool', required=False),
                         connect_at_power_on=dict(type='bool', required=False),
@@ -1000,7 +1009,10 @@ def main():
                         reservation=dict(type='int', required=False),
                         limit=dict(type='int', required=False),
                         mac_address=dict(type='str', required=False),
-                    )
+                    ),
+                    mutually_exclusive=[
+                        ['shares', 'shares_level']
+                    ],
                 ),
                 vmxnet3_network_adapters=dict(
                     type='list', elements='dict', required=False, options=dict(
@@ -1012,7 +1024,10 @@ def main():
                         reservation=dict(type='int', required=False),
                         limit=dict(type='int', required=False),
                         mac_address=dict(type='str', required=False),
-                    )
+                    ),
+                    mutually_exclusive=[
+                        ['shares', 'shares_level']
+                    ],
                 ),
                 sriov_network_adapters=dict(
                     type='list', elements='dict', required=False, options=dict(
@@ -1024,7 +1039,10 @@ def main():
                         reservation=dict(type='int', required=False),
                         limit=dict(type='int', required=False),
                         mac_address=dict(type='str', required=False),
-                    )
+                    ),
+                    mutually_exclusive=[
+                        ['shares', 'shares_level']
+                    ],
                 ),
                 timeout=dict(type='int', default=600),
             )

--- a/tests/integration/targets/prepare_test_vars/vars/vcenter_vars.yml
+++ b/tests/integration/targets/prepare_test_vars/vars/vcenter_vars.yml
@@ -5,6 +5,7 @@ vcenter_datacenter: "Eco-Datacenter"
 vcenter_resource_pool: "Resources"
 vcenter_port: 443
 vcenter_validate_certs: false
+vcenter_vm_network_name: vm_traffic
 
 shared_storage_01: "eco-iscsi-ds1"
 shared_storage_02: "eco-iscsi-ds2"

--- a/tests/integration/targets/vmware_vm_stub/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_stub/tasks/main.yml
@@ -39,6 +39,9 @@
     - name: Test cpu params
       ansible.builtin.include_tasks: cpu_params_tests.yml
 
+    - name: Test network adapter params
+      ansible.builtin.include_tasks: network_adapter_params_tests.yml
+
   always:
     - name: Power off vm
       vmware.vmware.vm_powerstate:

--- a/tests/integration/targets/vmware_vm_stub/tasks/network_adapter_params_tests.yml
+++ b/tests/integration/targets/vmware_vm_stub/tasks/network_adapter_params_tests.yml
@@ -1,0 +1,57 @@
+---
+- name: Power off vm
+  vmware.vmware.vm_powerstate:
+    datacenter: "{{ vcenter_datacenter }}"
+    moid: "{{ test_vm_moid }}"
+    state: powered-off
+
+- name: Set vm network settings
+  vmware.vmware._vm_stub: &set-network-params
+    name: "{{ test_vm_name }}"
+    vmxnet3_network_adapters:
+      - network: "{{ vcenter_vm_network_name }}"
+      - network: "{{ vcenter_vm_network_name }}"
+        connected: false
+        connect_at_power_on: false
+        shares_level: "low"
+        reservation: 1000
+        limit: 1000
+        mac_address: "00:00:00:00:00:00"
+  register: _set_network_params
+
+- name: Set vm network settings - idempotence check
+  vmware.vmware._vm_stub: *set-network-params
+  register: _set_network_params_idempotent
+
+- name: Lookup VM Info
+  vmware.vmware.guest_info:
+    moid: "{{ test_vm_moid }}"
+  register: _lookup_vm_guest_info
+
+- name: Check set network params tasks
+  ansible.builtin.assert:
+    that:
+      - _set_network_params is ansible.builtin.changed
+      - _set_network_params_idempotent is not ansible.builtin.changed
+
+      - vm_guest_info.hw_interfaces | length == 2
+      - vm_guest_info.hw_eth0.addresstype == "assigned" # aka generated
+      - vm_guest_info.hw_eth0.label == "Network adapter 1"
+      - vm_guest_info.hw_eth1.addresstype == "manual"
+      - vm_guest_info.hw_eth1.label == "Network adapter 2"
+      - vm_guest_info.hw_eth1.macaddress == "00:00:00:00:00:00"
+
+  vars:
+    vm_guest_info: "{{ _lookup_vm_guest_info.guests[0] }}"
+
+- name: Set invalid  network name - expect failure
+  vmware.vmware._vm_stub:
+    name: "{{ test_vm_name }}"
+    vmxnet3_network_adapters:
+      - network: Not a real name
+  register: _invalid_network_name
+  ignore_errors: true
+
+- name: Check invalid network name test
+  ansible.builtin.assert:
+    that: _invalid_network_name is ansible.builtin.failed

--- a/tests/integration/targets/vmware_vm_stub/tasks/network_adapter_params_tests.yml
+++ b/tests/integration/targets/vmware_vm_stub/tasks/network_adapter_params_tests.yml
@@ -8,7 +8,7 @@
 - name: Set vm network settings
   vmware.vmware._vm_stub: &set-network-params
     name: "{{ test_vm_name }}"
-    vmxnet3_network_adapters:
+    network_adapters:
       - network: "{{ vcenter_vm_network_name }}"
       - network: "{{ vcenter_vm_network_name }}"
         connected: false
@@ -17,6 +17,7 @@
         reservation: 1000
         limit: 1000
         mac_address: "00:00:00:00:00:00"
+        adapter_type: e1000e
   register: _set_network_params
 
 - name: Set vm network settings - idempotence check
@@ -44,14 +45,52 @@
   vars:
     vm_guest_info: "{{ _lookup_vm_guest_info.guests[0] }}"
 
-- name: Set invalid  network name - expect failure
+- name: Set invalid network name - expect failure
   vmware.vmware._vm_stub:
     name: "{{ test_vm_name }}"
-    vmxnet3_network_adapters:
+    network_adapters:
       - network: Not a real name
   register: _invalid_network_name
   ignore_errors: true
 
+- name: Change network adapter type - expect failure
+  vmware.vmware._vm_stub:
+    name: "{{ test_vm_name }}"
+    network_adapters:
+      - network: "{{ vcenter_vm_network_name }}"
+        adapter_type: e1000e
+  register: _change_network_adapter_type
+  ignore_errors: true
+
+- name: Remove network adapter - ignore
+  vmware.vmware._vm_stub:
+    name: "{{ test_vm_name }}"
+    network_adapter_remove_unmanaged: false
+    network_adapters:
+      - network: "{{ vcenter_vm_network_name }}"
+  register: _remove_network_adapter_ignore
+
+- name: Remove network adapter - remove unmanaged
+  vmware.vmware._vm_stub:
+    name: "{{ test_vm_name }}"
+    network_adapter_remove_unmanaged: true
+    network_adapters:
+      - network: "{{ vcenter_vm_network_name }}"
+  register: _remove_network_adapter_remove_unmanaged
+
+- name: Remove network adapter - idempotence
+  vmware.vmware._vm_stub:
+    name: "{{ test_vm_name }}"
+    network_adapter_remove_unmanaged: true
+    network_adapters:
+      - network: "{{ vcenter_vm_network_name }}"
+  register: _remove_network_adapter_remove_unmanaged_idem
+
 - name: Check invalid network name test
   ansible.builtin.assert:
-    that: _invalid_network_name is ansible.builtin.failed
+    that:
+      - _invalid_network_name is ansible.builtin.failed
+      - _change_network_adapter_type is ansible.builtin.failed
+      - _remove_network_adapter_ignore is not changed
+      - _remove_network_adapter_remove_unmanaged is changed
+      - _remove_network_adapter_remove_unmanaged_idem is not changed

--- a/tests/unit/plugins/module_utils/vm/objects/test_abstract.py
+++ b/tests/unit/plugins/module_utils/vm/objects/test_abstract.py
@@ -13,6 +13,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._abstract
 class ConcreteObject(AbstractVsphereObject):
     """Concrete implementation for testing AbstractVsphereObject."""
 
+    @classmethod
     def from_live_device_spec(cls, live_device_spec):
         """Test implementation of abstract method."""
         return cls(live_device_spec)

--- a/tests/unit/plugins/module_utils/vm/objects/test_abstract.py
+++ b/tests/unit/plugins/module_utils/vm/objects/test_abstract.py
@@ -1,0 +1,89 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from unittest.mock import Mock
+
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._abstract import (
+    AbstractVsphereObject,
+)
+
+
+class ConcreteObject(AbstractVsphereObject):
+    """Concrete implementation for testing AbstractVsphereObject."""
+
+    def from_live_device_spec(cls, live_device_spec):
+        """Test implementation of abstract method."""
+        return cls(live_device_spec)
+
+    def to_new_spec(self):
+        return Mock()
+
+    def to_update_spec(self):
+        """Test implementation of abstract method."""
+        return self.to_new_spec()
+
+    def differs_from_live_object(self):
+        return True
+
+    def _to_module_output(self):
+        """Test implementation of abstract method."""
+        return {"one": 1, "two": 2}
+
+
+class TestAbstractVsphereObject:
+    """Test cases for AbstractVsphereObject base class."""
+
+    def test_successful_initialization(self):
+        """Test successful initialization with valid parameters."""
+        raw_object = Mock()
+
+        obj = ConcreteObject(raw_object)
+
+        assert obj._raw_object is raw_object
+
+    def test_compare_attributes_for_changes(self):
+        """Test compare_attributes_for_changes method."""
+        obj = ConcreteObject()
+        assert obj._compare_attributes_for_changes(None, None) is False
+        assert obj._compare_attributes_for_changes("value", None) is True
+        assert obj._compare_attributes_for_changes("value", "1") is True
+        assert obj._compare_attributes_for_changes("value", "value") is False
+
+        other_obj = ConcreteObject()
+        other_obj.differs_from_live_object = Mock()
+        other_obj.differs_from_live_object.return_value = 1
+        assert obj._compare_attributes_for_changes(other_obj, "value") == 1
+
+    def test_to_change_set_output(self):
+        """Test to_change_set_output method."""
+        obj = ConcreteObject()
+        assert obj.to_change_set_output() == {
+            "new_value": {"one": 1, "two": 2},
+            "old_value": {},
+        }
+
+        obj._live_object = ConcreteObject()
+        assert obj.to_change_set_output() == {
+            "new_value": {"one": 1, "two": 2},
+            "old_value": {"one": 1, "two": 2},
+        }
+
+        obj._to_module_output = Mock()
+        obj._to_module_output.return_value = {"one": None, "two": 2, "three": None}
+        assert obj.to_change_set_output() == {
+            "new_value": {"two": 2},
+            "old_value": {"two": 2},
+        }
+
+    def test_link_corresponding_live_object(self):
+        """Test link_corresponding_live_object method."""
+        obj = ConcreteObject()
+        assert obj._live_object is None
+
+        obj.link_corresponding_live_object(ConcreteObject())
+        assert obj._live_object is not None
+
+        with pytest.raises(Exception):
+            obj.link_corresponding_live_object(ConcreteObject())

--- a/tests/unit/plugins/module_utils/vm/parameter_handlers/device_linked/test_network_adapters.py
+++ b/tests/unit/plugins/module_utils/vm/parameter_handlers/device_linked/test_network_adapters.py
@@ -1,0 +1,247 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from unittest.mock import Mock, patch
+
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters import (
+    E1000NetworkAdapterParameterHandler,
+    E1000eNetworkAdapterParameterHandler,
+    Pcnet32NetworkAdapterParameterHandler,
+    Vmxnet2NetworkAdapterParameterHandler,
+    Vmxnet3NetworkAdapterParameterHandler,
+    SriovNetworkAdapterParameterHandler,
+)
+
+
+class TestAbstractNetworkAdapterParameterHandler:
+    @pytest.fixture
+    def parameter_handler(self):
+        """Create a E1000NetworkAdapterParameterHandler instance for testing."""
+        error_handler = Mock()
+        params = {}
+        change_set = Mock()
+        vm = Mock()
+        device_tracker = Mock()
+        vsphere_object_cache = Mock()
+
+        return E1000NetworkAdapterParameterHandler(
+            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
+        )
+
+    def test_verify_parameter_constraints(self, parameter_handler):
+        """Test verify_parameter_constraints method."""
+        parameter_handler._parse_network_adapter_params = Mock()
+        parameter_handler.verify_parameter_constraints()
+        parameter_handler._parse_network_adapter_params.assert_called_once()
+        assert parameter_handler.adapters == []
+
+        parameter_handler._parse_network_adapter_params = Mock(side_effect=ValueError("test"))
+        parameter_handler.error_handler.fail_with_parameter_error = Mock(side_effect=ValueError("test"))
+        with pytest.raises(ValueError, match="test"):
+            parameter_handler.verify_parameter_constraints()
+        parameter_handler.error_handler.fail_with_parameter_error.assert_called_once()
+
+    def test_parse_network_adapter_params(self, parameter_handler):
+        """Test parse_network_adapter_params method."""
+        parameter_handler.params = {f"{parameter_handler.HANDLER_NAME}s": [{"network": "test"}]}
+        parameter_handler._parse_network_adapter_params()
+        assert len(parameter_handler.adapters) == 1
+
+        parameter_handler.vsphere_object_cache.get_portgroup = Mock(side_effect=ValueError("test"))
+        parameter_handler.error_handler.fail_with_parameter_error = Mock(side_effect=ValueError("test"))
+        with pytest.raises(ValueError, match="test"):
+            parameter_handler._parse_network_adapter_params()
+        parameter_handler.error_handler.fail_with_parameter_error.assert_called_once()
+
+    def test_populate_config_spec_with_parameters(self, parameter_handler):
+        """Test populate_config_spec_with_parameters method."""
+        parameter_handler.change_set.objects_to_add = [Mock()]
+        parameter_handler.change_set.objects_to_update = [Mock()]
+        parameter_handler.populate_config_spec_with_parameters(Mock())
+        assert len(parameter_handler.change_set.objects_to_add) == 1
+        assert len(parameter_handler.change_set.objects_to_update) == 1
+
+    def test_compare_live_config_with_desired_config(self, parameter_handler):
+        """Test compare_live_config_with_desired_config method."""
+        adapter = Mock()
+        adapter._live_object = None
+        parameter_handler.adapters = [adapter]
+        parameter_handler.change_set.objects_to_add = []
+        parameter_handler.change_set.objects_to_update = []
+        parameter_handler.change_set.objects_in_sync = []
+        parameter_handler.compare_live_config_with_desired_config()
+        assert len(parameter_handler.change_set.objects_to_add) == 1
+        assert len(parameter_handler.change_set.objects_to_update) == 0
+        assert len(parameter_handler.change_set.objects_in_sync) == 0
+
+        parameter_handler.change_set.objects_to_add = []
+        parameter_handler.change_set.objects_to_update = []
+        parameter_handler.change_set.objects_in_sync = []
+        adapter._live_object = Mock()
+        adapter.differs_from_live_object = Mock(return_value=True)
+        parameter_handler.compare_live_config_with_desired_config()
+        assert len(parameter_handler.change_set.objects_to_add) == 0
+        assert len(parameter_handler.change_set.objects_to_update) == 1
+        assert len(parameter_handler.change_set.objects_in_sync) == 0
+
+        parameter_handler.change_set.objects_to_add = []
+        parameter_handler.change_set.objects_to_update = []
+        parameter_handler.change_set.objects_in_sync = []
+        adapter.differs_from_live_object = Mock(return_value=False)
+        parameter_handler.compare_live_config_with_desired_config()
+        assert len(parameter_handler.change_set.objects_to_add) == 0
+        assert len(parameter_handler.change_set.objects_to_update) == 0
+        assert len(parameter_handler.change_set.objects_in_sync) == 1
+
+    @patch("ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.NetworkAdapter")
+    def test_link_vm_device(self, mock_network_adapter, parameter_handler):
+        """Test link_vm_device method."""
+        adapter = Mock()
+        adapter._live_object = None
+        assert adapter._live_object is None
+
+        parameter_handler.adapters = [adapter]
+        parameter_handler.link_vm_device(Mock())
+        adapter.link_corresponding_live_object.assert_called_once()
+
+    def test_link_vm_device_no_matching_adapter(self, parameter_handler):
+        """Test link_vm_device method when no matching adapter is found."""
+        adapter = Mock()
+        adapter._live_object = Mock()
+        parameter_handler.adapters = [adapter]
+        with pytest.raises(Exception, match="Network adapter not found for device"):
+            parameter_handler.link_vm_device(Mock())
+
+
+class TestE1000NetworkAdapterParameterHandler:
+    @pytest.fixture
+    def parameter_handler(self):
+        """Create a E1000NetworkAdapterParameterHandler instance for testing."""
+        error_handler = Mock()
+        params = {}
+        change_set = Mock()
+        vm = Mock()
+        device_tracker = Mock()
+        vsphere_object_cache = Mock()
+
+        return E1000NetworkAdapterParameterHandler(
+            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
+        )
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualE1000"
+    )
+    def test_vim_device_class(self, mock_virtual_e1000, parameter_handler):
+        assert parameter_handler.vim_device_class == mock_virtual_e1000
+
+
+class TestE1000eNetworkAdapterParameterHandler:
+    @pytest.fixture
+    def parameter_handler(self):
+        """Create a E1000eNetworkAdapterParameterHandler instance for testing."""
+        error_handler = Mock()
+        params = {}
+        change_set = Mock()
+        vm = Mock()
+        device_tracker = Mock()
+        vsphere_object_cache = Mock()
+
+        return E1000eNetworkAdapterParameterHandler(
+            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
+        )
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualE1000e"
+    )
+    def test_vim_device_class(self, mock_virtual_e1000e, parameter_handler):
+        assert parameter_handler.vim_device_class == mock_virtual_e1000e
+
+
+class TestPcnet32NetworkAdapterParameterHandler:
+    @pytest.fixture
+    def parameter_handler(self):
+        """Create a Pcnet32NetworkAdapterParameterHandler instance for testing."""
+        error_handler = Mock()
+        params = {}
+        change_set = Mock()
+        vm = Mock()
+        device_tracker = Mock()
+        vsphere_object_cache = Mock()
+
+        return Pcnet32NetworkAdapterParameterHandler(
+            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
+        )
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualPCNet32"
+    )
+    def test_vim_device_class(self, mock_virtual_pcnet32, parameter_handler):
+        assert parameter_handler.vim_device_class == mock_virtual_pcnet32
+
+
+class TestVmxnet2NetworkAdapterParameterHandler:
+    @pytest.fixture
+    def parameter_handler(self):
+        """Create a Vmxnet2NetworkAdapterParameterHandler instance for testing."""
+        error_handler = Mock()
+        params = {}
+        change_set = Mock()
+        vm = Mock()
+        device_tracker = Mock()
+        vsphere_object_cache = Mock()
+
+        return Vmxnet2NetworkAdapterParameterHandler(
+            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
+        )
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualVmxnet2"
+    )
+    def test_vim_device_class(self, mock_virtual_vmxnet2, parameter_handler):
+        assert parameter_handler.vim_device_class == mock_virtual_vmxnet2
+
+
+class TestVmxnet3NetworkAdapterParameterHandler:
+    @pytest.fixture
+    def parameter_handler(self):
+        """Create a Vmxnet3NetworkAdapterParameterHandler instance for testing."""
+        error_handler = Mock()
+        params = {}
+        change_set = Mock()
+        vm = Mock()
+        device_tracker = Mock()
+        vsphere_object_cache = Mock()
+
+        return Vmxnet3NetworkAdapterParameterHandler(
+            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
+        )
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualVmxnet3"
+    )
+    def test_vim_device_class(self, mock_virtual_vmxnet3, parameter_handler):
+        assert parameter_handler.vim_device_class == mock_virtual_vmxnet3
+
+
+class TestSriovNetworkAdapterParameterHandler:
+    @pytest.fixture
+    def parameter_handler(self):
+        """Create a SriovNetworkAdapterParameterHandler instance for testing."""
+        error_handler = Mock()
+        params = {}
+        change_set = Mock()
+        vm = Mock()
+        device_tracker = Mock()
+        vsphere_object_cache = Mock()
+
+        return SriovNetworkAdapterParameterHandler(
+            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
+        )
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualSriovEthernetCard"
+    )
+    def test_vim_device_class(self, mock_virtual_sriov, parameter_handler):
+        assert parameter_handler.vim_device_class == mock_virtual_sriov

--- a/tests/unit/plugins/module_utils/vm/parameter_handlers/device_linked/test_network_adapters.py
+++ b/tests/unit/plugins/module_utils/vm/parameter_handlers/device_linked/test_network_adapters.py
@@ -6,19 +6,14 @@ import pytest
 from unittest.mock import Mock, patch
 
 from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters import (
-    E1000NetworkAdapterParameterHandler,
-    E1000eNetworkAdapterParameterHandler,
-    Pcnet32NetworkAdapterParameterHandler,
-    Vmxnet2NetworkAdapterParameterHandler,
-    Vmxnet3NetworkAdapterParameterHandler,
-    SriovNetworkAdapterParameterHandler,
+    NetworkAdapterParameterHandler,
 )
 
 
-class TestAbstractNetworkAdapterParameterHandler:
+class TestNetworkAdapterParameterHandler:
     @pytest.fixture
     def parameter_handler(self):
-        """Create a E1000NetworkAdapterParameterHandler instance for testing."""
+        """Create a NetworkAdapterParameterHandler instance for testing."""
         error_handler = Mock()
         params = {}
         change_set = Mock()
@@ -26,13 +21,14 @@ class TestAbstractNetworkAdapterParameterHandler:
         device_tracker = Mock()
         vsphere_object_cache = Mock()
 
-        return E1000NetworkAdapterParameterHandler(
+        return NetworkAdapterParameterHandler(
             error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
         )
 
     def test_verify_parameter_constraints(self, parameter_handler):
         """Test verify_parameter_constraints method."""
         parameter_handler._parse_network_adapter_params = Mock()
+        parameter_handler.params = {'network_adapters': []}
         parameter_handler.verify_parameter_constraints()
         parameter_handler._parse_network_adapter_params.assert_called_once()
         assert parameter_handler.adapters == []
@@ -45,7 +41,7 @@ class TestAbstractNetworkAdapterParameterHandler:
 
     def test_parse_network_adapter_params(self, parameter_handler):
         """Test parse_network_adapter_params method."""
-        parameter_handler.params = {f"{parameter_handler.HANDLER_NAME}s": [{"network": "test"}]}
+        parameter_handler.params = {f"{parameter_handler.HANDLER_NAME}": [{"network": "test"}]}
         parameter_handler._parse_network_adapter_params()
         assert len(parameter_handler.adapters) == 1
 
@@ -67,6 +63,7 @@ class TestAbstractNetworkAdapterParameterHandler:
         """Test compare_live_config_with_desired_config method."""
         adapter = Mock()
         adapter._live_object = None
+        adapter.adapter_vim_class = Mock
         parameter_handler.adapters = [adapter]
         parameter_handler.change_set.objects_to_add = []
         parameter_handler.change_set.objects_to_update = []
@@ -100,6 +97,7 @@ class TestAbstractNetworkAdapterParameterHandler:
         """Test link_vm_device method."""
         adapter = Mock()
         adapter._live_object = None
+        adapter.adapter_vim_class = Mock
         assert adapter._live_object is None
 
         parameter_handler.adapters = [adapter]
@@ -110,138 +108,6 @@ class TestAbstractNetworkAdapterParameterHandler:
         """Test link_vm_device method when no matching adapter is found."""
         adapter = Mock()
         adapter._live_object = Mock()
+        adapter.adapter_vim_class = Mock
         parameter_handler.adapters = [adapter]
-        with pytest.raises(Exception, match="Network adapter not found for device"):
-            parameter_handler.link_vm_device(Mock())
-
-
-class TestE1000NetworkAdapterParameterHandler:
-    @pytest.fixture
-    def parameter_handler(self):
-        """Create a E1000NetworkAdapterParameterHandler instance for testing."""
-        error_handler = Mock()
-        params = {}
-        change_set = Mock()
-        vm = Mock()
-        device_tracker = Mock()
-        vsphere_object_cache = Mock()
-
-        return E1000NetworkAdapterParameterHandler(
-            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
-        )
-
-    @patch(
-        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualE1000"
-    )
-    def test_vim_device_class(self, mock_virtual_e1000, parameter_handler):
-        assert parameter_handler.vim_device_class == mock_virtual_e1000
-
-
-class TestE1000eNetworkAdapterParameterHandler:
-    @pytest.fixture
-    def parameter_handler(self):
-        """Create a E1000eNetworkAdapterParameterHandler instance for testing."""
-        error_handler = Mock()
-        params = {}
-        change_set = Mock()
-        vm = Mock()
-        device_tracker = Mock()
-        vsphere_object_cache = Mock()
-
-        return E1000eNetworkAdapterParameterHandler(
-            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
-        )
-
-    @patch(
-        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualE1000e"
-    )
-    def test_vim_device_class(self, mock_virtual_e1000e, parameter_handler):
-        assert parameter_handler.vim_device_class == mock_virtual_e1000e
-
-
-class TestPcnet32NetworkAdapterParameterHandler:
-    @pytest.fixture
-    def parameter_handler(self):
-        """Create a Pcnet32NetworkAdapterParameterHandler instance for testing."""
-        error_handler = Mock()
-        params = {}
-        change_set = Mock()
-        vm = Mock()
-        device_tracker = Mock()
-        vsphere_object_cache = Mock()
-
-        return Pcnet32NetworkAdapterParameterHandler(
-            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
-        )
-
-    @patch(
-        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualPCNet32"
-    )
-    def test_vim_device_class(self, mock_virtual_pcnet32, parameter_handler):
-        assert parameter_handler.vim_device_class == mock_virtual_pcnet32
-
-
-class TestVmxnet2NetworkAdapterParameterHandler:
-    @pytest.fixture
-    def parameter_handler(self):
-        """Create a Vmxnet2NetworkAdapterParameterHandler instance for testing."""
-        error_handler = Mock()
-        params = {}
-        change_set = Mock()
-        vm = Mock()
-        device_tracker = Mock()
-        vsphere_object_cache = Mock()
-
-        return Vmxnet2NetworkAdapterParameterHandler(
-            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
-        )
-
-    @patch(
-        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualVmxnet2"
-    )
-    def test_vim_device_class(self, mock_virtual_vmxnet2, parameter_handler):
-        assert parameter_handler.vim_device_class == mock_virtual_vmxnet2
-
-
-class TestVmxnet3NetworkAdapterParameterHandler:
-    @pytest.fixture
-    def parameter_handler(self):
-        """Create a Vmxnet3NetworkAdapterParameterHandler instance for testing."""
-        error_handler = Mock()
-        params = {}
-        change_set = Mock()
-        vm = Mock()
-        device_tracker = Mock()
-        vsphere_object_cache = Mock()
-
-        return Vmxnet3NetworkAdapterParameterHandler(
-            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
-        )
-
-    @patch(
-        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualVmxnet3"
-    )
-    def test_vim_device_class(self, mock_virtual_vmxnet3, parameter_handler):
-        assert parameter_handler.vim_device_class == mock_virtual_vmxnet3
-
-
-class TestSriovNetworkAdapterParameterHandler:
-    @pytest.fixture
-    def parameter_handler(self):
-        """Create a SriovNetworkAdapterParameterHandler instance for testing."""
-        error_handler = Mock()
-        params = {}
-        change_set = Mock()
-        vm = Mock()
-        device_tracker = Mock()
-        vsphere_object_cache = Mock()
-
-        return SriovNetworkAdapterParameterHandler(
-            error_handler, params, change_set, vm, device_tracker, vsphere_object_cache
-        )
-
-    @patch(
-        "ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._network_adapters.vim.vm.device.VirtualSriovEthernetCard"
-    )
-    def test_vim_device_class(self, mock_virtual_sriov, parameter_handler):
-        assert parameter_handler.vim_device_class == mock_virtual_sriov
+        parameter_handler.link_vm_device(Mock())

--- a/tests/unit/plugins/module_utils/vm/services/test_vsphere_object_cache.py
+++ b/tests/unit/plugins/module_utils/vm/services/test_vsphere_object_cache.py
@@ -1,0 +1,67 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._vsphere_object_cache import (
+    VsphereObjectCache
+)
+
+from .....common.vmware_object_mocks import create_mock_vsphere_object
+
+
+class TestVsphereObjectCache:
+    """Test cases for VsphereObjectCache class."""
+
+    @pytest.fixture
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.services._vsphere_object_cache.ModulePyvmomiBase.__init__"
+    )
+    def object_cache(self, mock_init):
+        module = Mock()
+        module.params = {
+            "hostname": "hostname",
+            "username": "username",
+            "password": "password",
+        }
+        obj_cache = VsphereObjectCache(module)
+        obj_cache.module = module
+        obj_cache.params = module.params
+        return obj_cache
+
+    def test_get_portgroup(self, object_cache):
+        """Test get_portgroup method."""
+        mock_network = create_mock_vsphere_object()
+        object_cache.get_dvs_portgroup_by_name_or_moid = Mock(return_value=None)
+        object_cache.get_standard_portgroup_by_name_or_moid = Mock(return_value=mock_network)
+
+        output = object_cache.get_portgroup(mock_network.name)
+        object_cache.get_dvs_portgroup_by_name_or_moid.assert_called_once()
+        object_cache.get_standard_portgroup_by_name_or_moid.assert_called_once()
+        assert output is mock_network
+
+        object_cache.get_dvs_portgroup_by_name_or_moid.reset_mock()
+        object_cache.get_standard_portgroup_by_name_or_moid.reset_mock()
+        output = object_cache.get_portgroup(mock_network.name)
+        object_cache.get_dvs_portgroup_by_name_or_moid.assert_not_called()
+        object_cache.get_standard_portgroup_by_name_or_moid.assert_not_called()
+        assert output is mock_network
+
+        output = object_cache.get_portgroup(mock_network._moid)
+        object_cache.get_dvs_portgroup_by_name_or_moid.assert_not_called()
+        object_cache.get_standard_portgroup_by_name_or_moid.assert_not_called()
+        assert output is mock_network
+
+    def test_get_portgroup_branch(self, object_cache):
+        """Test get_portgroup method."""
+        mock_network = create_mock_vsphere_object()
+        object_cache.get_dvs_portgroup_by_name_or_moid = Mock(return_value=mock_network)
+        object_cache.get_standard_portgroup_by_name_or_moid = Mock(return_value=None)
+
+        output = object_cache.get_portgroup(mock_network.name)
+        object_cache.get_dvs_portgroup_by_name_or_moid.assert_called_once()
+        object_cache.get_standard_portgroup_by_name_or_moid.assert_not_called()
+        assert output is mock_network

--- a/tests/unit/plugins/module_utils/vm/test_change_set.py
+++ b/tests/unit/plugins/module_utils/vm/test_change_set.py
@@ -271,3 +271,17 @@ class TestParameterChangeSet:
             "cpu.cores", "config.hardware.fdsafdasfdsa"
         )
         assert change_set.are_changes_required() is True
+
+    def test_changes_output(self):
+        """Test changes output."""
+        params = {"cpu": {"cores": 4}}
+        vm = Mock()
+        error_handler = Mock()
+
+        change_set = ParameterChangeSet(params, vm, error_handler)
+        assert change_set.changes == {
+            "changed_parameters": {},
+            "objects_to_add": [],
+            "objects_to_update": [],
+            "objects_to_remove": [],
+        }

--- a/tests/unit/plugins/module_utils/vm/test_configuration_builder.py
+++ b/tests/unit/plugins/module_utils/vm/test_configuration_builder.py
@@ -140,15 +140,19 @@ class TestConfigurationBuilder:
             "ansible_collections.vmware.vmware.plugins.module_utils.vm._configuration_builder.ErrorHandler"
         ) as mock_error_handler_class, patch(
             "ansible_collections.vmware.vmware.plugins.module_utils.vm._configuration_builder.VmPlacement"
-        ) as mock_placement_class:
+        ) as mock_placement_class, patch(
+            "ansible_collections.vmware.vmware.plugins.module_utils.vm._configuration_builder.VsphereObjectCache"
+        ) as mock_vsphere_object_cache_class:
 
             mock_device_tracker = Mock()
             mock_error_handler = Mock()
             mock_placement = Mock()
+            mock_vsphere_object_cache = Mock()
 
             mock_device_tracker_class.return_value = mock_device_tracker
             mock_error_handler_class.return_value = mock_error_handler
             mock_placement_class.return_value = mock_placement
+            mock_vsphere_object_cache_class.return_value = mock_vsphere_object_cache
 
             builder = ConfigurationBuilder(mock_vm, mock_module, mock_registry)
 

--- a/tests/unit/plugins/module_utils/vm/test_configurator.py
+++ b/tests/unit/plugins/module_utils/vm/test_configurator.py
@@ -9,6 +9,9 @@ from ansible_collections.vmware.vmware.plugins.module_utils.vm._configurator imp
     Configurator,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.vm._change_set import ParameterChangeSet
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers._abstract import (
+    DeviceLinkError,
+)
 
 
 class TestConfigurator:
@@ -211,7 +214,7 @@ class TestConfigurator:
 
         handler = Mock()
         handler.vim_device_class = type(device)
-        handler.link_vm_device = Mock(side_effect=Exception("Link failed"))
+        handler.link_vm_device = Mock(side_effect=DeviceLinkError("Link failed"))
         configurator.all_handlers = [handler]
 
         result = configurator._link_vm_devices_to_handlers()
@@ -258,7 +261,7 @@ class TestConfigurator:
 
         handler2 = Mock()
         handler2.vim_device_class = type(device2)
-        handler2.link_vm_device = Mock(side_effect=Exception("Link failed"))
+        handler2.link_vm_device = Mock(side_effect=DeviceLinkError("Link failed"))
 
         configurator.all_handlers = [handler1, handler2]
 


### PR DESCRIPTION
##### SUMMARY
Adding the network adapter params to the vm stub module.
Also includes a new abstract class and method for showing diffs between changed devices. I will need to go back and update the other device type classes (disks, controllers) once this is merged so they all implement the same interface and can show up in the module output

I still need to add unit tests

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
_vm_stub

##### ADDITIONAL INFORMATION
I dont love that each adapter type has its own parameter tree, but that was the easiest way (I could think of) to process them all in the given framework