### PR TITLE
Feature/tag module

### DIFF
--- a/changelogs/fragments/247-add-modules-for-tags.yml.yml
+++ b/changelogs/fragments/247-add-modules-for-tags.yml.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - tags - Add module to manage tags
+  - tag_categories - Add module to manage tag categories

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -24,6 +24,8 @@ action_groups:
         - local_content_library
         - subscribed_content_library
         - import_content_library_ovf
+        - tags
+        - tag_categories
         - vcsa_backup_schedule
         - vcsa_backup_schedule_info
         - vcsa_settings

--- a/plugins/modules/tag_categories.py
+++ b/plugins/modules/tag_categories.py
@@ -1,0 +1,549 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: tag_categories
+short_description: Manage one or more VMware tag categories.
+description:
+    - This module allows you to create, update, and delete VMware tag categories.
+    - For better performance, use object IDs instead of names when possible.
+    - For better performance, manage many tag categories per module call (as opposed
+      to using a loop). See the examples for more details.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    state:
+        description:
+            - Whether ensure the tag categories are present or absent.
+        type: str
+        choices: [present, absent]
+        default: present
+
+    tag_categories:
+        description:
+            - A list of tag categories to manage.
+            - Providing the ID instead of the name will reduce the number of API calls, and
+              potentially speed up the module execution.
+        type: list
+        required: true
+        elements: dict
+        suboptions:
+            name:
+                description:
+                    - The name of the tag category.
+                    - At least one of O(tag_categories[].name) or O(tag_categories[].id) must be provided.
+                    - If only the name is provided, it will be used to search for the tag category.
+                      If a category cannot be found and O(state) is present, a new category will be created.
+                    - If both name and ID are provided, the ID will be used to search for the category. If
+                      If a category cannot be found and O(state) is present, an error will be raised.
+                      If a category can be found and O(state) is present, the category will be updated to use O(tag_categories[].name).
+                    - This value is required when creating a new tag category.
+                type: str
+                required: false
+            id:
+                description:
+                    - The id of the tag category to manage.
+                    - At least one of O(tag_categories[].name) or O(tag_categories[].id) must be provided.
+                    - Only applicable if the tag category already exists.
+                type: str
+                required: false
+            description:
+                description:
+                    - The description of the tag category.
+                type: str
+                required: false
+            cardinality:
+                description:
+                    - Controls if an object can be assigned to multiple tags in the category.
+                    - An example of a single cardinality category is "Operating System", with tags like "Windows", "Linux", "Mac OS".
+                    - An example of a multiple cardinality category is "Server", with tags like "AppServer", "DatabaseServer".
+                    - If this is not specified when creating a tag category, cardinality MULTIPLE will be used.
+                    - You cannot change the cardinality of a tag category from MULTIPLE to SINGLE.
+                type: str
+                required: false
+                choices: [SINGLE, MULTIPLE]
+            associable_types:
+                description:
+                    - A list of types of vSphere objects that can be assigned to the tag category.
+                    - When creating a category, at least one type must be specified. If this is parameter is not set or set
+                      an empty list, the category will be created with all types.
+                    - Due to a vSphere limitation, this list is additive. In other words, you cannot remove a type
+                      once it has been added to the category. Any types specified in this parameter will be added if they are missing.
+                type: list
+                required: false
+                elements: str
+                default: []
+                choices:
+                    - Folder
+                    - DistributedVirtualPortgroup
+                    - VmwareDistributedVirtualSwitch
+                    - Datacenter
+                    - com.vmware.content.Library
+                    - com.vmware.content.library.Item
+                    - Datastore
+                    - StoragePod
+                    - HostNetwork
+                    - Network
+                    - HostSystem
+                    - DistributedVirtualSwitch
+                    - VirtualMachine
+                    - VirtualApp
+                    - ResourcePool
+                    - ClusterComputeResource
+                    - OpaqueNetwork
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+    - vmware.vmware.additional_rest_options
+
+seealso:
+    - module: vmware.vmware.tags
+"""
+
+EXAMPLES = r"""
+- name: Create or update tag categories
+  vmware.vmware.tag_categories:
+    state: present
+    tags:
+      - name: my-test-category-1
+      - id: urn:vmomi:InventoryServiceCategory:00000000-0000-0000-0000-21b1f07e73cf:GLOBAL
+        name: my-test-category-2
+        description: "This is a test category"
+        cardinality: SINGLE
+        associable_types: [VirtualMachine]
+      - name: my-test-category-3
+        description: "This is a test category"
+        cardinality: MULTIPLE
+
+- name: Delete tag categories
+  vmware.vmware.tag_categories:
+    state: absent
+    tag_categories:
+      - name: my-test-category-1
+      - id: urn:vmomi:InventoryServiceCategory:00000000-0000-0000-0000-21b1f07e73cf:GLOBAL
+
+# For better performance, manage many tag categories per module call
+- name: Manage many categories
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories:
+      - name: my-test-category-1
+      - name: my-test-category-2
+      - name: my-test-category-3
+      - name: my-test-category-4
+
+# Do not use loops when possible
+- name: This will be very slow
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories: ["{{ item }}"]
+  loop:
+    - name: my-test-category-1
+    - name: my-test-category-2
+    - name: my-test-category-3
+    - name: my-test-category-4
+"""
+
+RETURN = r"""
+category_changes:
+    description:
+        - Comparison of the tag categories before and after the changes.
+        - Before is empty if the tag category was created.
+        - After is empty if the tag category was deleted.
+    returned: always
+    type: list
+    sample: [
+        {
+            "before": {
+                "id": "urn:vmomi:InventoryServiceCategory:00000000-0000-0000-0000-000000000000:GLOBAL",
+                "name": "cat1",
+                "description": "Description of cat1",
+                "cardinality": "MULTIPLE",
+                "associable_types": ["VirtualMachine", "Datastore"]
+            },
+            "after": {
+                "id": "urn:vmomi:InventoryServiceCategory:00000000-0000-0000-0000-000000000000:GLOBAL",
+                "name": "cat2",
+                "description": "Updated description of cat2",
+                "cardinality": "SINGLE",
+                "associable_types": ["VirtualMachine"]
+            }
+        },
+    ]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import (
+    ModuleRestBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    rest_compatible_argument_spec,
+)
+
+try:
+    from com.vmware.vapi.std.errors_client import NotFound
+except ImportError:
+    pass
+
+
+ALL_ASSOCIABLE_TYPES = [
+    "Folder",
+    "DistributedVirtualPortgroup",
+    "VmwareDistributedVirtualSwitch",
+    "Datacenter",
+    "com.vmware.content.Library",
+    "com.vmware.content.library.Item",
+    "Datastore",
+    "StoragePod",
+    "HostNetwork",
+    "Network",
+    "HostSystem",
+    "DistributedVirtualSwitch",
+    "VirtualMachine",
+    "VirtualApp",
+    "ResourcePool",
+    "ClusterComputeResource",
+    "OpaqueNetwork",
+]
+
+
+class TagCategoryChange:
+    """
+    A data class representing a change to a tag category.
+
+    This class encapsulates the before and after state of a tag category change,
+    providing methods to convert the change to module output format.
+
+    Attributes:
+        remote_def (object): Tag category model before the change (None for new categories)
+        param_def (dict): Tag category parameters after the change (None for deletions)
+    """
+
+    def __init__(self, remote_def: object = None, param_def: dict = None):
+        if param_def is None:
+            param_def = dict()
+        # before is always a tag model, after is a dict of parameters
+        self.remote_def = remote_def
+        self.param_def = param_def
+        if self.param_def.get("associable_types") is not None and self.remote_def is not None:
+            self.param_def["associable_types"] = list(set(self.param_def.get("associable_types", [])) | self.remote_def.associable_types)
+
+    def param_def_to_spec_args(self):
+        out = {
+            "name": self.param_def.get("name"),
+            "description": self.param_def.get("description"),
+            "cardinality": self.param_def.get("cardinality"),
+            "associable_types": set(self.param_def["associable_types"]),
+        }
+        return out
+
+    def to_module_output(self):
+        """
+        Convert the change to a dictionary format suitable for Ansible module output.
+
+        Returns:
+            dict: Dictionary with 'before' and 'after' keys containing tag category information
+        """
+        output = dict(before=dict(), after=dict())
+        if self.remote_def:
+            output["before"] = {
+                "name": self.remote_def.name,
+                "description": self.remote_def.description,
+                "id": self.remote_def.id,
+                "cardinality": self.remote_def.cardinality,
+                "associable_types": list(self.remote_def.associable_types),
+            }
+        if self.param_def:
+            output["after"] = {
+                "name": self.param_def.get("name") or output["before"].get("name"),
+                "id": self.param_def.get("id") or output["before"].get("id"),
+                "description": self.param_def.get("description") or output["before"].get("description"),
+                "cardinality": self.param_def.get("cardinality") or output["before"].get("cardinality"),
+                "associable_types": list(set(self.param_def["associable_types"]) | set(output["before"].get("associable_types", []))),
+            }
+        return output
+
+
+class VmwareTagCategoryModule(ModuleRestBase):
+    """
+    A specialized Ansible module for managing VMware tag categories using the vSphere REST API.
+
+    This class extends ModuleRestBase to provide comprehensive tag category management capabilities
+    including creation, updates, and deletion of VMware tag categories. It optimizes performance by
+    using different processing strategies based on whether parameters use IDs or names.
+
+    Attributes:
+        _params_only_use_ids (bool): True if all parameters use IDs, False otherwise
+
+    Example:
+        vmware_tag_category = VmwareTagCategoryModule(module)
+        category_changes = vmware_tag_category.determine_tag_category_changes()
+        vmware_tag_category.apply_tag_category_changes(category_changes)
+    """
+
+    def __init__(self, module):
+        super().__init__(module)
+        self._params_only_use_ids = all(
+            c.get("id") is not None for c in module.params["tag_categories"]
+        )
+
+    def determine_tag_category_changes(self):
+        tag_category_changes = []
+        if self._params_only_use_ids:
+            self._determine_tag_category_changes_by_ids_only(tag_category_changes)
+        else:
+            self._determine_tag_category_changes_by_names_and_ids(tag_category_changes)
+
+        return tag_category_changes
+
+    def _determine_tag_category_changes_by_ids_only(self, tag_category_changes):
+        """
+        Process tag category changes when all parameters use IDs.
+
+        This method is optimized for scenarios where all category parameters provide IDs,
+        allowing for direct lookups without needing to iterate through all remote categories.
+
+        Args:
+            tag_category_changes (list): List to append changes to
+
+        Raises:
+            AnsibleModule.fail_json: If an ID is provided for a new category creation
+        """
+        for param_category in self.module.params["tag_categories"]:
+            try:
+                remote_category = self.tag_category_service.get(
+                    param_category.get("id")
+                )
+            except NotFound:
+                remote_category = None
+
+            if remote_category is None and self.module.params["state"] == "present":
+                self.module.fail_json(
+                    msg="You cannot provide an ID when creating a new category.",
+                    violating_tag_category_param=param_category,
+                )
+
+            category_change = self._create_category_change(
+                param_category, remote_category
+            )
+            if category_change is not None:
+                tag_category_changes.append(category_change)
+
+    def _determine_tag_category_changes_by_names_and_ids(self, tag_category_changes):
+        """
+        Process tag category changes when parameters use names or mixed names/IDs.
+
+        This method iterates through all remote categories to find matches with parameters.
+        Looping through all tags once is required when parameters use names or mixed names/IDs.
+
+        Args:
+            tag_category_changes (list): List to append changes to
+        """
+        category_params_left_to_process = dict(
+            enumerate(self.module.params["tag_categories"])
+        )
+
+        # Cycle through all remote categories and find the ones that match the parameters. Determine
+        # what changes need to be made with them.
+        for remote_category_id in self.tag_category_service.list():
+            remote_category = self.tag_category_service.get(remote_category_id)
+            for index, param_category in category_params_left_to_process.copy().items():
+                if param_category.get(
+                    "id"
+                ) is not None and remote_category.id != param_category.get("id"):
+                    continue
+
+                if param_category.get(
+                    "id"
+                ) is None and remote_category.name != param_category.get("name"):
+                    continue
+
+                del category_params_left_to_process[index]
+                category_change = self._create_category_change(
+                    param_category, remote_category
+                )
+                if category_change is not None:
+                    tag_category_changes.append(category_change)
+                break
+
+            if len(category_params_left_to_process) == 0:
+                return
+
+        # Determine what to do with the parameters that were not found in the remote categories
+        for param_category in category_params_left_to_process.values():
+            category_change = self._create_category_change(param_category, None)
+            if category_change is not None:
+                tag_category_changes.append(category_change)
+
+    def _create_category_change(
+        self, param_category: dict, remote_category: object = None
+    ):
+        """
+        Create a TagCategoryChange object based on parameters and remote category state.
+
+        Args:
+            param_category (dict): Category parameters from user input
+            remote_category (object, optional): Current category model from VMware
+
+        Returns:
+            TagCategoryChange or None: Change object if action is needed, None otherwise
+        """
+        if self.module.params["state"] == "present":
+            if remote_category is None:
+                return TagCategoryChange(remote_def=None, param_def=param_category)
+
+            if self._does_tag_category_need_update(param_category, remote_category):
+                change = TagCategoryChange(remote_def=remote_category, param_def=param_category)
+                return change
+
+        else:
+            if remote_category is not None:
+                return TagCategoryChange(remote_def=remote_category, param_def=None)
+
+        return None
+
+    def _does_tag_category_need_update(
+        self, param_category: dict, remote_category: object = None
+    ):
+        """
+        Determine if a tag category requires an update based on parameter changes.
+
+        Args:
+            param_category (dict): Category parameters from user input
+            remote_category (object, optional): Current category model from VMware
+
+        Returns:
+            bool: True if update is needed, False otherwise
+        """
+        if remote_category is None:
+            return True
+        for attr in ["name", "description"]:
+            if param_category.get(attr) is None:
+                continue
+            elif param_category[attr] != getattr(remote_category, attr):
+                return True
+
+        if param_category.get("cardinality") is not None:
+            if param_category["cardinality"] != remote_category.cardinality:
+                if remote_category.cardinality == "MULTIPLE":
+                    self.module.fail_json(
+                        msg="You cannot change the cardinality of a tag category from MULTIPLE to SINGLE.",
+                        violating_tag_category_param=param_category,
+                    )
+                return True
+
+        if param_category.get("associable_types") is not None:
+            if not remote_category.associable_types.issuperset(set(param_category["associable_types"])):
+                return True
+
+        return False
+
+    def apply_tag_category_changes(self, tag_category_changes):
+        """
+        Apply the determined tag category changes to the VMware environment.
+
+        Args:
+            tag_category_changes (list[TagCategoryChange]): List of changes to apply
+
+        Operations performed:
+            - Create: Creates new tag categories with specified properties
+            - Update: Updates existing tag category properties
+            - Delete: Removes tag categories from the system
+        """
+        for tag_category_change in tag_category_changes:
+            if tag_category_change.remote_def is None:
+                new_category_id = self._create_tag_category(
+                    **tag_category_change.param_def_to_spec_args()
+                )
+                tag_category_change.param_def["id"] = new_category_id
+            elif not tag_category_change.param_def:
+                self.tag_category_service.delete(tag_category_change.remote_def.id)
+            else:
+                self._update_tag_category(
+                    tag_category_id=tag_category_change.remote_def.id,
+                    **tag_category_change.param_def_to_spec_args()
+                )
+
+    def _create_tag_category(self, name, description, cardinality, associable_types):
+        create_spec = self.tag_category_service.CreateSpec()
+        create_spec.name = name
+        create_spec.description = description or ""
+        create_spec.cardinality = cardinality or "MULTIPLE"
+        create_spec.associable_types = set(associable_types) or set(ALL_ASSOCIABLE_TYPES)
+        return self.tag_category_service.create(create_spec)
+
+    def _update_tag_category(
+        self, tag_category_id, name, description, cardinality, associable_types
+    ):
+        update_spec = self.tag_category_service.UpdateSpec(
+            name=name,
+            description=description,
+            cardinality=cardinality,
+            associable_types=associable_types,
+        )
+        return self.tag_category_service.update(tag_category_id, update_spec)
+
+
+def main():
+    argument_spec = rest_compatible_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", choices=["present", "absent"], default="present"),
+            tag_categories=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    name=dict(type="str", required=False),
+                    id=dict(type="str", required=False),
+                    description=dict(type="str", required=False),
+                    cardinality=dict(
+                        type="str", required=False, choices=["SINGLE", "MULTIPLE"]
+                    ),
+                    associable_types=dict(
+                        type="list",
+                        elements="str",
+                        default=[],
+                        required=False,
+                        choices=ALL_ASSOCIABLE_TYPES,
+                    ),
+                ),
+                required_one_of=[["name", "id"]],
+            ),
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    result = dict(changed=False, category_changes=[])
+
+    vmware_tag_category = VmwareTagCategoryModule(module)
+    tag_category_changes = vmware_tag_category.determine_tag_category_changes()
+    if not tag_category_changes:
+        module.exit_json(**result)
+
+    if not module.check_mode:
+        vmware_tag_category.apply_tag_category_changes(tag_category_changes)
+    result["changed"] = True
+    result["category_changes"] = [
+        tag_category_change.to_module_output()
+        for tag_category_change in tag_category_changes
+    ]
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/tags.py
+++ b/plugins/modules/tags.py
@@ -1,0 +1,284 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: tag
+short_description: Manage one or more VMware tags.
+description:
+    - This module allows you to create, update, and delete VMware tags.
+    - You can also specify a vSphere object, and manage the tags assigned to it.
+    - If no object is specified, the module will manage the tags at a global level.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    state:
+        description:
+            - Whether to create, update, or delete the tag(s).
+        type: str
+        required: True
+        choices: [present, absent, set]
+    object_moid:
+        description:
+            - The MOID of the vSphere object to manage.
+        type: str
+        required: False
+
+    tags:
+        description:
+            - A list of tags to manage.
+        type: list
+        required: True
+        elements: str
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+    - vmware.vmware.additional_rest_options
+'''
+
+EXAMPLES = r'''
+- name: Gather VM Resource Info
+  vmware.vmware.vm_resource_info:
+    moid: "{{ vm_id }}"
+
+- name: Gather VM Resource Info By Name
+  vmware.vmware.vm_resource_info:
+    name: "{{ vm_name }}"
+    name_match: first
+
+- name: Gather Just Resource Config Info
+  vmware.vmware.vm_resource_info:
+    moid: "{{ vm_id }}"
+    gather_cpu_stats: false
+    gather_memory_stats: false
+
+- name: Gather Just The Host and Resource Pool IDs For All VMs
+  vmware.vmware.vm_resource_info:
+    moid: "{{ vm_id }}"
+    gather_cpu_config: false
+    gather_memory_config: false
+    gather_cpu_stats: false
+    gather_memory_stats: false
+# Note: although all gather parameters are set to false in the previous example, the output keys will still be present in the results. For example:
+# "vms": [
+#     {
+#         "cpu": {},
+#         "esxi_host": {
+#             "moid": "host-64",
+#             "name": "10.10.10.129"
+#         },
+#         "memory": {},
+#         "moid": "vm-75373",
+#         "name": "ma1",
+#         "resource_pool": {
+#             "moid": "resgroup-35",
+#             "name": "Resources"
+#         },
+#         "stats": {
+#             "cpu": {},
+#             "memory": {}
+#         }
+#     }
+# ]
+'''
+
+RETURN = r'''
+vms:
+    description:
+        - Information about CPU and memory for the selected VMs.
+    returned: Always
+    type: list
+    sample: [
+        {
+            "cpu": {
+                "cores_per_socket": 1,
+                "hot_add_enabled": false,
+                "hot_remove_enabled": false,
+                "processor_count": 1
+            },
+            "esxi_host": {
+                "moid": "host-64",
+                "name": "10.10.10.129"
+            },
+            "memory": {
+                "hot_add_enabled": false,
+                "hot_add_increment": 0,
+                "hot_add_max_limit": 4096,
+                "size_mb": 4096
+            },
+            "moid": "vm-75373",
+            "name": "ma1",
+            "resource_pool": {
+                "moid": "resgroup-35",
+                "name": "Resources"
+            },
+            "stats": {
+                "cpu": {
+                    "demand_mhz": 68,
+                    "distributed_entitlement_mhz": 68,
+                    "readiness_mhz": 0,
+                    "static_entitlement_mhz": 1989,
+                    "usage_mhz": 68
+                },
+                "memory": {
+                    "active_mb": 81,
+                    "ballooned_mb": 0,
+                    "consumed_overhead_mb": 38,
+                    "distributed_entitlement_mb": 857,
+                    "guest_usage_mb": 81,
+                    "host_usage_mb": 1890,
+                    "static_entitlement_mb": 4406,
+                    "swapped_mb": 0
+                }
+            }
+        }
+    ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import ModuleRestBase
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    rest_compatible_argument_spec
+)
+
+
+
+class VmwareTag(ModuleRestBase):
+    def __init__(self, module):
+        super().__init__(module)
+        # self.dynamic_managed_object = DynamicID(type=self.object_type, id=managed_object_id)
+
+    def _main(self):
+        all_categories = self.tag_category_service.list()
+        for category_id in all_categories:
+            category_model = self.tag_category_service.get(category_id)
+            print("Category ID '{}', name '{}', description '{}'".format(
+                category_model.id, category_model.name, category_model.description
+            ))
+
+    def get_tags_to_change(self):
+        tags_to_create = []
+        tags_to_update = []
+        tags_to_delete = []
+
+        all_tags = self.tag_service.list()
+        for tag_id in all_tags:
+            tag_model = self.tag_service.get(tag_id)
+            if tag_model.name not in self.params['tags']:
+                tags_to_create.append(tag_model.name)
+                continue
+
+            if self.is_tag_model_different(tag_model):
+                tags_to_update.append(tag_model.name)
+                continue
+
+        return tags_to_create, tags_to_update, tags_to_delete
+
+    def is_tag_model_different(self, tag_model):
+        if tag_model.name not in self.params['tags']:
+            return True
+        if tag_model.description != self.params['tags'][tag_model.name]['description']:
+            return True
+        return False
+
+    # def tag_object(self, object_moid):
+    #     print('Tagging the cluster {0}...'.format(self.cluster_name))
+    #     self.dynamic_id = DynamicID(
+    #         type='ClusterComputeResource', id=self.cluster_moid)
+    #     self.client.tagging.TagAssociation.attach(
+    #         tag_id=self.tag_id, object_id=self.dynamic_id)
+    #     for tag_id in self.client.tagging.TagAssociation.list_attached_tags(
+    #             self.dynamic_id):
+    #         if tag_id == self.tag_id:
+    #             self.tag_attached = True
+    #             break
+    #     assert self.tag_attached
+    #     print('Tagged cluster: {0}'.format(self.cluster_moid))
+
+    def create_tag_category(self, name, description, cardinality):
+        """create a category. User who invokes this needs create category privilege."""
+        create_spec = self.tag_category_service.CreateSpec()
+        create_spec.name = name
+        create_spec.description = description
+        create_spec.cardinality = cardinality
+        associableTypes = set()
+        create_spec.associable_types = associableTypes
+        return self.tag_category_service.create(create_spec)
+
+    def delete_tag_category(self, category_id):
+        """Deletes an existing tag category; User who invokes this API needs
+        delete privilege on the tag category.
+        """
+        self.tag_category_service.delete(category_id)
+
+    def create_tag(self, name, description, category_id):
+        """Creates a Tag"""
+        create_spec = self.tag_service.CreateSpec()
+        create_spec.name = name
+        create_spec.description = description
+        create_spec.category_id = category_id
+        return self.tag_service.create(create_spec)
+
+    def update_tag(self, tag_id, description):
+        update_spec = self.tag_service.UpdateSpec()
+        update_spec.setDescription = description
+        self.tag_service.update(tag_id, update_spec)
+
+    def delete_tag(self, tag_id):
+        """Delete an existing tag.
+        User who invokes this API needs delete privilege on the tag."""
+        self.tag_service.delete(tag_id)
+
+def main():
+    argument_spec = rest_compatible_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type='str', choices=['present', 'absent', 'set'], required=True),
+            object_moid=dict(type='str', required=False),
+            tags=dict(type='list', elements='str', required=True),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[['name', 'uuid', 'moid']]
+    )
+
+    result = dict(
+        changed=False,
+        created_tags=[],
+        updated_tags=[],
+        deleted_tags=[]
+    )
+
+    vmware_tag = VmwareTag(module)
+    tags_to_create, tags_to_update, tags_to_delete = vmware_tag.get_tags_to_change()
+
+    if any([tags_to_create, tags_to_update, tags_to_delete]):
+        result['changed'] = True
+        result['created_tags'] = tags_to_create
+        result['updated_tags'] = tags_to_update
+        result['deleted_tags'] = tags_to_delete
+
+    for tag_id in tags_to_create:
+        vmware_tag.create_tag(tag_id)
+    for tag_id in tags_to_update:
+        vmware_tag.update_tag(tag_id)
+    for tag_id in tags_to_delete:
+        vmware_tag.delete_tag(tag_id)
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vmware_tags/defaults/main.yml
+++ b/tests/integration/targets/vmware_tags/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+test_tags:
+  - name: "{{ tiny_prefix }}-tags-test-1"
+    description: Test tag used by ansible vmware.vmware collection test
+
+  - name: "{{ tiny_prefix }}-tags-test-2"
+    description: Test tag used by ansible vmware.vmware collection test
+
+  - name: "{{ tiny_prefix }}-tags-test-3"
+
+test_tag_categories:
+  - name: "{{ tiny_prefix }}-tag-category-test-1"
+    description: Test tag used by ansible vmware.vmware collection test
+    cardinality: MULTIPLE
+    associable_types:
+      - VirtualMachine
+
+  - name: "{{ tiny_prefix }}-tag-category-test-2"
+
+  - name: "{{ tiny_prefix }}-tag-category-test-3"
+    description: Test tag used by ansible vmware.vmware collection test
+    cardinality: SINGLE
+    associable_types:
+      - Folder

--- a/tests/integration/targets/vmware_tags/meta/main.yml
+++ b/tests/integration/targets/vmware_tags/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_vars

--- a/tests/integration/targets/vmware_tags/tasks/main.yml
+++ b/tests/integration/targets/vmware_tags/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Test On VCenter
+  environment: "{{ environment_auth_vars }}"
+  when: run_on_vcenter
+  block:
+    - name: Include category tests
+      ansible.builtin.include_tasks:
+        file: test_categories.yml
+    - name: Include tag tests
+      ansible.builtin.include_tasks:
+        file: test_tags.yml
+  always:
+    - name: Destroy Test Tags
+      vmware.vmware.tags:
+        state: absent
+        tags: "{{ test_tags }}"
+      ignore_errors: true
+    - name: Destroy Test Tag Categories
+      vmware.vmware.tag_categories:
+        state: absent
+        tag_categories: "{{ test_tag_categories }}"

--- a/tests/integration/targets/vmware_tags/tasks/test_categories.yml
+++ b/tests/integration/targets/vmware_tags/tasks/test_categories.yml
@@ -1,0 +1,87 @@
+---
+- name: Create Categories
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories: "{{ test_tag_categories }}"
+  register: _tag_categories
+
+- name: Update category dict with IDs so this is faster
+  ansible.builtin.set_fact:
+    _temp_test_tag_categories: >-
+      {{ _temp_test_tag_categories | default([]) + [new_category_def] }}
+  vars:
+    new_category_def: >-
+      {{ test_tag_categories[item] | combine({'id': _tag_categories.category_changes[item].after.id}) }}
+  loop: "{{ range(0, test_tag_categories | length) | list }}"
+
+- name: Reassign temp var to test_tag_categories
+  ansible.builtin.set_fact:
+    test_tag_categories: "{{ _temp_test_tag_categories }}"
+
+- name: Create Categories - idempotency
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories: "{{ test_tag_categories }}"
+  register: _tag_categories_idem
+
+- name: Check Categories output
+  ansible.builtin.assert:
+    that:
+      - _tag_categories is changed
+      - _tag_categories_idem is not changed
+      - _tag_categories.category_changes | length == test_tag_categories | length
+
+- name: Update Category Description
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories:
+      - id: "{{ test_tag_categories[2].id }}"
+        description: "Updated description of tag3"
+  register: _update_description
+
+- name: Update Category Types
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories:
+      - id: "{{ test_tag_categories[2].id }}"
+        associable_types:
+          - VirtualMachine
+          - Datastore
+  register: _update_types
+
+- name: Update Category Cardinality
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories:
+      - id: "{{ test_tag_categories[2].id }}"
+        cardinality: MULTIPLE
+  register: _update_cardinality
+
+- name: Update Category Name
+  vmware.vmware.tag_categories:
+    state: present
+    tag_categories:
+      - id: "{{ test_tag_categories[2].id }}"
+        name: "{{ tiny_prefix }}-tag-category-test-3-updated"
+  register: _update_name
+
+- name: Remove Category
+  vmware.vmware.tag_categories:
+    state: absent
+    tag_categories:
+      - id: "{{ test_tag_categories[2].id }}"
+  register: _remove_category
+
+- name: Check Category output
+  ansible.builtin.assert:
+    that:
+      - _update_description is changed
+      - _update_types is changed
+      - _update_cardinality is changed
+      - _update_name is changed
+      - _remove_category is changed
+      - _remove_category.category_changes | length == 1
+      - _remove_category.category_changes[0].before.name == tiny_prefix + "-tag-category-test-3-updated"
+      - _remove_category.category_changes[0].before.description == "Updated description of tag3"
+      - _remove_category.category_changes[0].before.cardinality == "MULTIPLE"
+      - _remove_category.category_changes[0].before.associable_types | length == 3

--- a/tests/integration/targets/vmware_tags/tasks/test_tags.yml
+++ b/tests/integration/targets/vmware_tags/tasks/test_tags.yml
@@ -1,0 +1,74 @@
+---
+- name: Assign tag category IDs to tags
+  ansible.builtin.set_fact:
+    _temp_test_tags_category: >-
+      {{ _temp_test_tags_category | default([]) + [new_tag_def] }}
+  vars:
+    new_tag_def: >-
+      {{ test_tags[item] | combine({'category_id': test_tag_categories[[0,1] | random].id}) }}
+  loop: "{{ range(0, test_tags | length) | list }}"
+
+- name: Reassign temp var to test_tags
+  ansible.builtin.set_fact:
+    test_tags: "{{ _temp_test_tags_category }}"
+
+- name: Create tags
+  vmware.vmware.tags:
+    state: present
+    tags: "{{ test_tags }}"
+  register: _tags
+
+- name: Update tag dict with IDs so this is faster
+  ansible.builtin.set_fact:
+    _temp_test_tags: >-
+      {{ _temp_test_tags | default([]) + [new_tag_def] }}
+  vars:
+    new_tag_def: >-
+      {{ test_tags[item] | combine({'id': _tags.tag_changes[item].after.id}) }}
+  loop: "{{ range(0, test_tags | length) | list }}"
+
+- name: Reassign temp var to test_tags
+  ansible.builtin.set_fact:
+    test_tags: "{{ _temp_test_tags }}"
+
+- name: Create tags - idempotency
+  vmware.vmware.tags:
+    state: present
+    tags: "{{ test_tags }}"
+  register: _tags_idem
+
+- name: Check tags output
+  ansible.builtin.assert:
+    that:
+      - _tags is changed
+      - _tags_idem is not changed
+      - (_tags.tag_changes | length) == (test_tags | length)
+
+- name: Update tag name
+  vmware.vmware.tags:
+    state: present
+    tags:
+      - id: "{{ test_tags[2].id }}"
+        name: "{{ tiny_prefix }}-tags-test-3-updated"
+  register: _tags_name_update
+
+- name: Update tag description
+  vmware.vmware.tags:
+    state: present
+    tags:
+      - id: "{{ test_tags[2].id }}"
+        description: "{{ tiny_prefix }}-tags-test-3-updated"
+  register: _tags_name_update
+
+- name: Remove tag
+  vmware.vmware.tags:
+    state: absent
+    tags:
+      - id: "{{ test_tags[2].id }}"
+  register: _tags_remove
+
+- name: Check tags output
+  ansible.builtin.assert:
+    that:
+      - _tags_name_update is changed
+      - _tags_remove is changed

--- a/tests/unit/plugins/modules/test_tag_categories.py
+++ b/tests/unit/plugins/modules/test_tag_categories.py
@@ -1,0 +1,160 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+from unittest import mock
+
+from ansible_collections.vmware.vmware.plugins.modules.tag_categories import (
+    TagCategoryChange,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import (
+    VmwareRestClient
+)
+from ...common.utils import (
+    run_module, ModuleTestCase
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestTagCategoryChange():
+    def test_to_module_output(self):
+        tc = TagCategoryChange(remote_def=None, param_def=None)
+        assert tc.to_module_output() == {
+            'before': {},
+            'after': {}
+        }
+
+        remote_def = mock.Mock(description='1.2', id='1.3', associable_types={'1.4'}, cardinality='1.5')
+        remote_def.name = '1.1'
+        param_def = {
+            'name': '2.1',
+            'description': '2.2',
+            'associable_types': ['2.4'],
+            'cardinality': '2.5'
+        }
+        tc = TagCategoryChange(remote_def=remote_def, param_def=param_def)
+        output = tc.to_module_output()
+        assert output['before']['name'] == '1.1'
+        assert output['after']['name'] == '2.1'
+        assert output['before']['description'] == '1.2'
+        assert output['after']['description'] == '2.2'
+        assert output['before']['id'] == '1.3'
+        assert output['after']['id'] == '1.3'
+        assert set(output['before']['associable_types']) == {'1.4'}
+        assert set(output['after']['associable_types']) == {'1.4', '2.4'}
+        assert output['before']['cardinality'] == '1.5'
+        assert output['after']['cardinality'] == '2.5'
+
+        param_def['id'] = '2.3'
+        tc = TagCategoryChange(remote_def=remote_def, param_def=param_def)
+        output = tc.to_module_output()
+        assert output['before']['name'] == '1.1'
+        assert output['after']['name'] == '2.1'
+        assert output['before']['description'] == '1.2'
+        assert output['after']['description'] == '2.2'
+        assert output['before']['id'] == '1.3'
+        assert output['after']['id'] == '2.3'
+        assert set(output['before']['associable_types']) == {'1.4'}
+        assert set(output['after']['associable_types']) == {'1.4', '2.4'}
+        assert output['before']['cardinality'] == '1.5'
+        assert output['after']['cardinality'] == '2.5'
+
+
+class TestVmwareTagCategoryModule(ModuleTestCase):
+
+    def get_category_side_effect(self, *args, **kwargs):
+        try:
+            return self.mock_remote_categories[int(args[0]) - 1]
+        except IndexError:
+            return None
+
+    def __prepare(self, mocker):
+        self.rest_client = mocker.Mock()
+        self.mock_tag_category_service = mocker.Mock()
+        mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=self.rest_client)
+        self.rest_client.tagging.Category = self.mock_tag_category_service
+
+        self.mock_remote_categories = [
+            mock.Mock(description='test1', id='1', associable_types=set(), cardinality='SINGLE'),
+            mock.Mock(description='test2', id='2', associable_types=set(), cardinality='SINGLE'),
+            mock.Mock(description='test3', id='3', associable_types=set(), cardinality='SINGLE')
+        ]
+
+        for mock_item in self.mock_remote_categories:
+            mock_item.name = f'test{mock_item.id}'
+
+        self.mock_tag_category_service.list.return_value = [m.id for m in self.mock_remote_categories]
+        self.mock_tag_category_service.get.side_effect = self.get_category_side_effect
+
+    def test_present_no_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            tag_categories=[
+                {
+                    'name': 'test1',
+                    'description': 'test1'
+                },
+                {
+                    'id': '2'
+                },
+                {
+                    'name': 'test3'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["category_changes"] == []
+        assert result['changed'] is False
+
+    def test_present_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            tag_categories=[
+                {
+                    'name': 'testfoo',
+                    'id': '1'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert len(result["category_changes"]) == 1
+        assert result['changed'] is True
+
+    def test_absent_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            state='absent',
+            tag_categories=[
+                {
+                    'name': 'test1',
+                    'id': '1'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert len(result["category_changes"]) == 1
+        assert result['changed'] is True
+
+    def test_absent_no_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            state='absent',
+            tag_categories=[
+                {
+                    'name': 'test4',
+                    'id': '4'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["category_changes"] == []
+        assert result['changed'] is False

--- a/tests/unit/plugins/modules/test_tags.py
+++ b/tests/unit/plugins/modules/test_tags.py
@@ -1,0 +1,193 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+from unittest import mock
+
+from ansible_collections.vmware.vmware.plugins.modules.tags import (
+    TagChange,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import (
+    VmwareRestClient
+)
+from ...common.utils import (
+    run_module, ModuleTestCase
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestTagChange():
+    def test_to_module_output(self):
+        tc = TagChange(remote_def=None, param_def=None)
+        assert tc.to_module_output() == {
+            'before': {},
+            'after': {}
+        }
+
+        before = mock.Mock(description='1.2', id='1.3', category_id='1.4')
+        before.name = '1.1'
+        after = {
+            'name': '2.1',
+            'description': '2.2',
+            'category_id': '2.4'
+        }
+        tc = TagChange(remote_def=before, param_def=after)
+        assert tc.to_module_output() == {
+            'before': {
+                'name': '1.1',
+                'description': '1.2',
+                'id': '1.3',
+                'category_id': '1.4'
+            },
+            'after': {
+                'name': '2.1',
+                'description': '2.2',
+                'id': '1.3',
+                'category_id': '2.4'
+            }
+        }
+        after['id'] = '2.3'
+        tc = TagChange(remote_def=before, param_def=after)
+        assert tc.to_module_output() == {
+            'before': {
+                'name': '1.1',
+                'description': '1.2',
+                'id': '1.3',
+                'category_id': '1.4'
+            },
+            'after': {
+                'name': '2.1',
+                'description': '2.2',
+                'id': '2.3',
+                'category_id': '2.4'
+            }
+        }
+
+
+class TestVmwareTagModule(ModuleTestCase):
+
+    def get_category_side_effect(self, *args, **kwargs):
+        try:
+            return self.mock_remote_categories[int(args[0]) - 1]
+        except IndexError:
+            return None
+
+    def get_tag_side_effect(self, *args, **kwargs):
+        try:
+            return self.mock_remote_tags[int(args[0]) - 1]
+        except IndexError:
+            return None
+
+    def list_tags_for_category_side_effect(self, *args, **kwargs):
+        try:
+            return [tag.id for tag in self.mock_remote_categories[int(args[0]) - 1].tags]
+        except IndexError:
+            return None
+
+    def __prepare(self, mocker):
+        self.rest_client = mocker.Mock()
+        self.mock_tag_category_service = mocker.Mock()
+        self.mock_tag_service = mocker.Mock()
+        mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=self.rest_client)
+        self.rest_client.tagging.Tag = self.mock_tag_category_service
+        self.rest_client.tagging.Category = self.mock_tag_category_service
+
+        self.mock_remote_tags = [
+            mock.Mock(description='test', id='1', category_id='1'),
+            mock.Mock(description='test', id='2', category_id='2'),
+            mock.Mock(description='test', id='3', category_id='3'),
+        ]
+        self.mock_remote_categories = [
+            mock.Mock(description='test', id='1', tags=[self.mock_remote_tags[0]]),
+            mock.Mock(description='test', id='2', tags=[self.mock_remote_tags[1]]),
+            mock.Mock(description='test', id='3', tags=[self.mock_remote_tags[2]])
+        ]
+
+        for mock_item in self.mock_remote_tags + self.mock_remote_categories:
+            mock_item.name = f'test{mock_item.id}'
+
+        self.mock_tag_category_service.list.return_value = [m.id for m in self.mock_remote_categories]
+        self.mock_tag_category_service.get.side_effect = self.get_category_side_effect
+        self.mock_tag_service.list.return_value = [m.id for m in self.mock_remote_tags]
+        self.mock_tag_service.get.side_effect = self.get_tag_side_effect
+        self.mock_tag_category_service.list_tags_for_category.side_effect = self.list_tags_for_category_side_effect
+
+    def test_present_no_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            tags=[
+                {
+                    'name': 'test1',
+                    'category_name': 'test1'
+                },
+                {
+                    'name': 'test2',
+                    'category_name': 'test2'
+                },
+                {
+                    'name': 'test3',
+                    'category_name': 'test3'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["tag_changes"] == []
+        assert result['changed'] is False
+
+    def test_present_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            tags=[
+                {
+                    'name': 'test1',
+                    'category_id': '1'
+                },
+                {
+                    'id': '2',
+                    'category_name': 'test2',
+                    'description': 'foo'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert len(result["tag_changes"]) == 1
+        assert result['changed'] is True
+
+    def test_absent_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            state='absent',
+            tags=[
+                {
+                    'name': 'test1',
+                    'category_id': '1'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert len(result["tag_changes"]) == 1
+        assert result['changed'] is True
+
+    def test_absent_no_change(self, mocker):
+        self.__prepare(mocker)
+        module_args = dict(
+            state='absent',
+            tags=[
+                {
+                    'name': 'test4',
+                    'category_id': '1'
+                }
+            ]
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["tag_changes"] == []
+        assert result['changed'] is False


### PR DESCRIPTION
##### SUMMARY
Adds modules to manage tag categories and tags. Replaces community.vmware.vmware_tag

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
tags
tag_categories

##### ADDITIONAL INFORMATION
Users complained about the speed and duplicated api calls when managing tags one at a time, so I made these modules process lists of tags/categories without needing to loop/call the module multiple times