### PR TITLE
Replace ansible.module_utils._text

### DIFF
--- a/changelogs/fragments/268-replace_ansible.module_utils._text.yml
+++ b/changelogs/fragments/268-replace_ansible.module_utils._text.yml
@@ -1,0 +1,3 @@
+major_changes:
+  - Replace ``ansible.module_utils._text``
+    (https://github.com/ansible-collections/vmware.vmware/issues/268).

--- a/plugins/module_utils/_facts.py
+++ b/plugins/module_utils/_facts.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 import ansible.module_utils.common._collections_compat as collections_compat
 from ansible_collections.vmware.vmware.plugins.module_utils._folder_paths import get_folder_path_of_vsphere_object
 

--- a/plugins/module_utils/_vsphere_tasks.py
+++ b/plugins/module_utils/_vsphere_tasks.py
@@ -14,7 +14,7 @@ import time
 import traceback
 from random import randint
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 PYVMOMI_IMP_ERR = None
 try:

--- a/plugins/module_utils/clients/rest.py
+++ b/plugins/module_utils/clients/rest.py
@@ -36,7 +36,7 @@ except ImportError:
     except ImportError:
         HAS_URLLIB3 = False
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.errors import (
     ApiAccessError,
     MissingLibError

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -90,7 +90,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
     ModulePyvmomiBase

--- a/plugins/modules/cluster_dpm.py
+++ b/plugins/modules/cluster_dpm.py
@@ -131,7 +131,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._facts import (
     ClusterFacts
 )
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class VMwareCluster(ModulePyvmomiBase):

--- a/plugins/modules/cluster_drs.py
+++ b/plugins/modules/cluster_drs.py
@@ -159,7 +159,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._facts import (
 from ansible_collections.vmware.vmware.plugins.module_utils._advanced_settings import (
     AdvancedSettings
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class VMwareCluster(ModulePyvmomiBase):

--- a/plugins/modules/cluster_drs_recommendations.py
+++ b/plugins/modules/cluster_drs_recommendations.py
@@ -113,7 +113,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks impor
     TaskError,
     RunningTaskMonitor
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class VMwareCluster(ModulePyvmomiBase):

--- a/plugins/modules/cluster_vcls.py
+++ b/plugins/modules/cluster_vcls.py
@@ -144,7 +144,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
     ModulePyvmomiBase

--- a/plugins/modules/esxi_connection.py
+++ b/plugins/modules/esxi_connection.py
@@ -107,7 +107,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
     ModulePyvmomiBase

--- a/plugins/modules/esxi_host.py
+++ b/plugins/modules/esxi_host.py
@@ -178,7 +178,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
     ModulePyvmomiBase

--- a/plugins/modules/esxi_maintenance_mode.py
+++ b/plugins/modules/esxi_maintenance_mode.py
@@ -121,7 +121,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
     ModulePyvmomiBase

--- a/plugins/modules/vm_advanced_settings.py
+++ b/plugins/modules/vm_advanced_settings.py
@@ -171,7 +171,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
     ModulePyvmomiBase

--- a/plugins/modules/vm_powerstate.py
+++ b/plugins/modules/vm_powerstate.py
@@ -234,7 +234,7 @@ from random import randint
 from datetime import datetime, timedelta
 import time
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.common.text.converters import to_text, to_native
 
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
     ModulePyvmomiBase

--- a/plugins/modules/vm_snapshot.py
+++ b/plugins/modules/vm_snapshot.py
@@ -272,7 +272,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import RunningTaskMonitor
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.common.text.converters import to_text, to_native
 
 
 class VmSnapshotModule(ModulePyvmomiBase):

--- a/tests/unit/common/utils.py
+++ b/tests/unit/common/utils.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 def run_module(module_entry, module_args=None, expect_success=True):


### PR DESCRIPTION
Fixes #268

##### SUMMARY
Replace deprecated `ansible.module_utils._text`:

```
sed -i 's/from ansible.module_utils._text import /from ansible.module_utils.common.text.converters import /' plugins/modules/*.py plugins/module_utils/*.py plugins/module_utils/clients/*.py tests/unit/common/*.py
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/cluster_dpm.py
plugins/modules/cluster_drs.py
plugins/modules/cluster_drs_recommendations.py
plugins/modules/cluster.py
plugins/modules/cluster_vcls.py
plugins/modules/esxi_connection.py
plugins/modules/esxi_host.py
plugins/modules/esxi_maintenance_mode.py
plugins/modules/vm_advanced_settings.py
plugins/modules/vm_powerstate.py
plugins/modules/vm_snapshot.py
plugins/module_utils/clients/rest.py
plugins/module_utils/_facts.py
plugins/module_utils/_vsphere_tasks.py
tests/unit/common/utils.py

##### ADDITIONAL INFORMATION