### PR TITLE
docs: Update example inventory file name in esxi_hosts.py

### DIFF
--- a/plugins/inventory/esxi_hosts.py
+++ b/plugins/inventory/esxi_hosts.py
@@ -34,7 +34,7 @@ options:
 
 EXAMPLES = r"""
 # Below are examples of inventory configuration files that can be used with this plugin.
-# To test these and see the resulting inventory, save the snippet in a file named hosts.vmware_esxi.yml and run:
+# To test these and see the resulting inventory, save the snippet in a file named esxi_hosts.yml and run:
 # ansible-inventory -i esxi_hosts.yml --list
 
 


### PR DESCRIPTION
##### SUMMARY

Documentation update:

The esxi_hosts inventory plugin was using outdated documentation that probably wasn't updated during the migration from community.vmware to the vmware.vmware collection

The inventory filename hosts.vmware_esxi.yml does not work for the plugin and will be updated to esxi_hosts.yml

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
esxi_hosts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
