### PR TITLE
remove invalid ovf deploy option

### DIFF
--- a/changelogs/fragments/278-deploy-ovf-provisioning.yml
+++ b/changelogs/fragments/278-deploy-ovf-provisioning.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - deploy_content_library_ovf - Remove invalid storage provisioning option 'eagerzeroedthick' from module's argument spec.
+    (Fixes https://github.com/ansible-collections/vmware.vmware/issues/278)

--- a/plugins/modules/deploy_content_library_ovf.py
+++ b/plugins/modules/deploy_content_library_ovf.py
@@ -72,7 +72,7 @@ options:
             - Default storage provisioning type to use for all sections of type vmw:StorageSection in the OVF descriptor.
         type: str
         default: 'thin'
-        choices: [ thin, thick, eagerZeroedThick, eagerzeroedthick ]
+        choices: [ thin, thick, eagerZeroedThick ]
 
     # These are defined in the vmware.vmware.module_deploy_vm_base_options doc frag, so this section is just updating the
     # description of these options as needed
@@ -223,7 +223,7 @@ def main():
         library_id=dict(type='str', required=False),
         library_item_name=dict(type='str', required=False, aliases=['template_name']),
         library_item_id=dict(type='str', required=False, aliases=['template_id']),
-        storage_provisioning=dict(type='str', default='thin', choices=['thin', 'thick', 'eagerZeroedThick', 'eagerzeroedthick']),
+        storage_provisioning=dict(type='str', default='thin', choices=['thin', 'thick', 'eagerZeroedThick']),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/278

This module allows users to specify an invalid storage provisioning type. When the type is invalid, it is silently ignored. This removes the type, so users are alerted to the issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
deploy_content_library_ovf

