### PR TITLE
use vm placement svc in deploy modules

### DIFF
--- a/changelogs/fragments/280-remove-redundant-placement.yml
+++ b/changelogs/fragments/280-remove-redundant-placement.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - module_deploy_vm_base - Removed redundant code by using new vm placement service methods in deploy modules

--- a/plugins/module_utils/vm/services/_placement.py
+++ b/plugins/module_utils/vm/services/_placement.py
@@ -49,6 +49,7 @@ def vm_placement_argument_spec(omit_params=None):
         datacenter=dict(type="str", required=False, aliases=["datacenter_name"]),
         datastore=dict(type="str", required=False),
         datastore_cluster=dict(type="str", required=False),
+        folder_paths_are_absolute=dict(type='bool', required=False, default=False),
     )
     for param in omit_params:
         if param in arg_spec:
@@ -193,7 +194,7 @@ class VmPlacement(ModulePyvmomiBase, AbstractService):
 
         return self._resource_pool
 
-    def get_folder(self, folder_param="folder", datacenter_param="datacenter"):
+    def get_folder(self, folder_param="folder", datacenter_param="datacenter", folder_paths_are_absolute_param="folder_paths_are_absolute"):
         """
         Get the target folder for VM placement.
 
@@ -217,6 +218,8 @@ class VmPlacement(ModulePyvmomiBase, AbstractService):
             fq_folder = format_folder_path_as_vm_fq_path(
                 "", self.params[datacenter_param]
             )
+        elif self.params.get(folder_paths_are_absolute_param):
+            fq_folder = self.params.get(folder_param)
         else:
             fq_folder = format_folder_path_as_vm_fq_path(
                 self.params.get(folder_param), self.params[datacenter_param]

--- a/plugins/modules/deploy_content_library_ovf.py
+++ b/plugins/modules/deploy_content_library_ovf.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 

--- a/plugins/modules/deploy_content_library_template.py
+++ b/plugins/modules/deploy_content_library_template.py
@@ -173,10 +173,7 @@ class VmwareContentDeployTemplate(ModuleVmDeployBase):
 
         placement_spec = TemplateLibraryItems.DeployPlacementSpec(folder=self.vm_folder._GetMoId())
         if self.params.get('esxi_host'):
-            placement_spec.host = self.get_esxi_host_by_name_or_moid(
-                self.params['esxi_host'],
-                fail_on_missing=True
-            )._GetMoId()
+            placement_spec.host = self.placement_service.get_esxi_host()._GetMoId()
 
         if self.resource_pool:
             placement_spec.resource_pool = self.resource_pool._GetMoId()

--- a/plugins/modules/deploy_folder_template.py
+++ b/plugins/modules/deploy_folder_template.py
@@ -128,7 +128,6 @@ from ansible_collections.vmware.vmware.plugins.module_utils._module_deploy_vm_ba
 from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
     base_argument_spec
 )
-from ansible_collections.vmware.vmware.plugins.module_utils._folder_paths import format_folder_path_as_vm_fq_path
 from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import RunningTaskMonitor, TaskError
 
 PYVMOMI_IMP_ERR = None
@@ -149,13 +148,8 @@ class VmwareFolderTemplate(ModuleVmDeployBase):
         if self.params['template_folder_id']:
             folder = self.get_folders_by_name_or_moid(self.params['template_folder_id'], fail_on_missing=True)[0]
         else:
-            if self.params.get("folder_paths_are_absolute"):
-                fq_folder_path = self.params.get("template_folder")
-            else:
-                fq_folder_path = format_folder_path_as_vm_fq_path(
-                    self.params.get("template_folder"), self.params.get("datacenter")
-                )
-            folder = self.get_folder_by_absolute_path(fq_folder_path, fail_on_missing=True)
+            folder = self.placement_service.get_folder(folder_param='template_folder')
+
         return folder
 
     def __lookup_template_from_name_and_folder(self):
@@ -226,10 +220,7 @@ class VmwareFolderTemplate(ModuleVmDeployBase):
             relo_spec.pool = self.resource_pool
 
         if self.params['esxi_host']:
-            relo_spec.host = self.get_esxi_host_by_name_or_moid(
-                self.params['esxi_host'],
-                fail_on_missing=True
-            )
+            relo_spec.host = self.placement_service.get_esxi_host()
 
         clone_spec = vim.vm.CloneSpec()
         clone_spec.location = relo_spec

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -115,6 +115,19 @@ options:
         type: str
         required: false
 
+    folder_paths_are_absolute:
+        description:
+            - If true, any folder path parameters are treated as absolute paths.
+            - If false, modules will try to intelligently determine if the path is absolute
+              or relative.
+            - This option is useful when your environment has a complex folder structure. By default,
+              modules will try to intelligently determine if the path is absolute or relative.
+              They may mistakenly prepend the datacenter name or other folder names, and this option
+              can be used to avoid this.
+        type: bool
+        required: false
+        default: false
+
     guest_id:
         description:
             - The guest ID of the VM.

--- a/tests/unit/plugins/module_utils/test_module_deploy_vm_base.py
+++ b/tests/unit/plugins/module_utils/test_module_deploy_vm_base.py
@@ -10,6 +10,7 @@ from ansible_collections.vmware.vmware.plugins.modules.deploy_folder_template im
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
     PyvmomiClient
 )
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._placement import VmPlacement
 
 from ...common.vmware_object_mocks import (
     MockVmwareObject
@@ -39,25 +40,25 @@ class TestDeployContentLibraryOvf():
         )
 
         mocker.patch.object(VmwareFolderTemplate, 'get_datacenter_by_name_or_moid', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_folder', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_datacenter', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_resource_pool', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_datastore', return_value=MockVmwareObject())
 
     def test_datastore(self, mocker):
         self.__prepare(mocker)
-        mocker.patch.object(VmwareFolderTemplate, 'get_datastore_by_name_or_moid', return_value=MockVmwareObject())
         test_module = VmwareFolderTemplate(self.mock_module)
         assert test_module.datastore._GetMoId()
 
     def test_resource_pool(self, mocker):
         self.__prepare(mocker)
-        mocker.patch.object(VmwareFolderTemplate, 'get_resource_pool_by_name_or_moid', return_value=MockVmwareObject())
         test_module = VmwareFolderTemplate(self.mock_module)
         assert test_module.resource_pool._GetMoId()
 
     def test_vm_folder(self, mocker):
         self.__prepare(mocker)
-        folder_obj = MockVmwareObject()
-        mocker.patch.object(VmwareFolderTemplate, 'get_folder_by_absolute_path', return_value=folder_obj)
         test_module = VmwareFolderTemplate(self.mock_module)
-        assert test_module.vm_folder is folder_obj
+        assert test_module.vm_folder._GetMoId()
 
     def test_get_deployed_vm(self, mocker):
         self.__prepare(mocker)

--- a/tests/unit/plugins/modules/test_deploy_content_library_ovf.py
+++ b/tests/unit/plugins/modules/test_deploy_content_library_ovf.py
@@ -14,6 +14,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import (
     VmwareRestClient
 )
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._placement import VmPlacement
 from ...common.utils import (
     run_module, ModuleTestCase
 )
@@ -33,10 +34,12 @@ class TestDeployContentLibraryOvf(ModuleTestCase):
         mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=mocker.Mock())
         self.test_vm = MockVmwareObject(name="test")
 
-        mocker.patch.object(VmwareContentDeployOvf, 'get_resource_pool_by_name_or_moid', return_value=MockVmwareObject())
-        mocker.patch.object(VmwareContentDeployOvf, 'get_datastore_by_name_or_moid', return_value=MockVmwareObject())
-        mocker.patch.object(VmwareContentDeployOvf, 'get_datacenter_by_name_or_moid', return_value=MockVmwareObject())
         mocker.patch.object(VmwareContentDeployOvf, 'deploy', return_value=self.test_vm._GetMoId())
+
+        mocker.patch.object(VmPlacement, 'get_folder', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_datacenter', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_resource_pool', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_datastore', return_value=MockVmwareObject())
 
     def test_present(self, mocker):
         self.__prepare(mocker)

--- a/tests/unit/plugins/modules/test_deploy_content_library_template.py
+++ b/tests/unit/plugins/modules/test_deploy_content_library_template.py
@@ -14,6 +14,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi impo
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import (
     VmwareRestClient
 )
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.services._placement import VmPlacement
 from ...common.utils import (
     run_module, ModuleTestCase
 )
@@ -33,10 +34,12 @@ class TestDeployContentLibraryTemplate(ModuleTestCase):
         mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=mocker.Mock())
         self.test_vm = MockVmwareObject(name="test")
 
-        mocker.patch.object(VmwareContentDeployTemplate, 'get_resource_pool_by_name_or_moid', return_value=MockVmwareObject())
-        mocker.patch.object(VmwareContentDeployTemplate, 'get_datastore_by_name_or_moid', return_value=MockVmwareObject())
-        mocker.patch.object(VmwareContentDeployTemplate, 'get_datacenter_by_name_or_moid', return_value=MockVmwareObject())
         mocker.patch.object(VmwareContentDeployTemplate, 'deploy', return_value=self.test_vm._GetMoId())
+
+        mocker.patch.object(VmPlacement, 'get_folder', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_datacenter', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_resource_pool', return_value=MockVmwareObject())
+        mocker.patch.object(VmPlacement, 'get_datastore', return_value=MockVmwareObject())
 
     def test_present(self, mocker):
         self.__prepare(mocker)


### PR DESCRIPTION
##### SUMMARY
Now that the VM module is released, the vm placement service is stable and can replace redundant code that is leveraged in other deployment modules.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/deploy_content_library_ovf
plugins/modules/deploy_content_library_template
plugins/modules/deploy_folder_template
plugins/module_utils/_module_deploy_vm_base
