### PR TITLE
mention moid option in placement docs

### DIFF
--- a/changelogs/fragments/281-add-moid-to-placement-docs.yml
+++ b/changelogs/fragments/281-add-moid-to-placement-docs.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Updated common VM deployment module docs to mention that name or MOID can be used for the resource pool, cluster, datastore, and datastore cluster parameters.
+    This allows users to work around issues where the name is not unique. Fixes https://github.com/ansible-collections/vmware.vmware/issues/239

--- a/plugins/doc_fragments/module_deploy_vm_base_options.py
+++ b/plugins/doc_fragments/module_deploy_vm_base_options.py
@@ -17,7 +17,7 @@ class ModuleDocFragment(object):
 options:
     datacenter:
         description:
-            - The name of the datacenter to use when searching for and deploying resources.
+            - The name or MOID of the datacenter to use when searching for and deploying resources.
         type: str
         required: true
         aliases: [datacenter_name]
@@ -53,14 +53,14 @@ options:
         default: false
     resource_pool:
         description:
-            - The name of a resource pool into which the virtual machine should be deployed.
+            - The name or MOID of a resource pool into which the virtual machine should be deployed.
             - Changing this option will not result in the VM being redeployed (it does not affect idempotency).
             - O(resource_pool) and O(cluster) are mutually exclusive.
         type: str
         required: false
     cluster:
         description:
-            - The name of the cluster where the VM should be deployed.
+            - The name or MOID of the cluster where the VM should be deployed.
             - Changing this option will not result in the VM being redeployed (it does not affect idempotency).
             - O(resource_pool) and O(cluster) are mutually exclusive.
         type: str
@@ -68,13 +68,13 @@ options:
         aliases: [cluster_name]
     datastore:
         description:
-            - Name of the datastore to store deployed VM and disk.
+            - Name or MOID of the datastore to store deployed VM and disk.
             - O(datastore) and O(datastore_cluster) are mutually exclusive.
         type: str
         required: false
     datastore_cluster:
         description:
-            - Name of the datastore cluster to store deployed VM and disk.
+            - Name or MOID of the datastore cluster to store deployed VM and disk.
             - Please make sure Storage DRS is active for recommended datastore from the given datastore cluster.
             - If Storage DRS is not enabled, datastore with largest free storage space is selected.
             - O(datastore) and O(datastore_cluster) are mutually exclusive.

--- a/tests/integration/targets/vmware_deploy_content_library_ovf/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_deploy_content_library_ovf/tasks/eco-vcenter.yml
@@ -23,7 +23,7 @@
         library_item_name: "{{ rhel9_content_library_ovf }}"
         library_name: "{{ ci_resources_content_library }}"
         vm_name: "{{ test_vm_name }}"
-        resource_pool: "{{ test_resource_pool }}"
+        resource_pool: "{{ _test_rp.id }}" #"{{ test_resource_pool }}"
       register: _deploy
 
     - name: Deploy VM Again - Idempotency


### PR DESCRIPTION
##### SUMMARY
This fixes https://github.com/ansible-collections/vmware.vmware/issues/239

A user mentioned that they are unable to use the modules to deploy VMs due to a name conflict in their environment. The modules have an undocumented work-around for this.
This change mentions that option in the docs. Users can use the object MOID or the objects name

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
deploy_*
vm
