### PR TITLE
fix assertion in portgroup test to reflect lab changes

### DIFF
--- a/tests/integration/targets/vmware_vm_portgroup_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_portgroup_info/tasks/main.yml
@@ -34,7 +34,7 @@
         that:
           - __res.changed == False
           - __res.vm_portgroup_info[vm_name] | length == 1
-          - __res.vm_portgroup_info[vm_name][0]['portgroup_name'] == "Management Network"
+          - __res.vm_portgroup_info[vm_name][0]['portgroup_name'] == "vm_traffic"
           - __res.vm_portgroup_info[vm_name][0]['nic_type'] == "VMXNET3"
           - __res.vm_portgroup_info[vm_name][0]['type'] == "DISTRIBUTED_PORTGROUP"
 


### PR DESCRIPTION
##### SUMMARY
The vcenter lab where we run our tests recently had some networking changes. The template that the portgroup test uses switched networks, and now the tests are failing.

This change updates the test assertion to expect the new network name.

##### ISSUE TYPE
- Chore Pull Request
