### PR TITLE
add deploy_folder_template to action group

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -14,6 +14,7 @@ action_groups:
         - content_template
         - deploy_content_library_ovf
         - deploy_content_library_template
+        - deploy_folder_template
         - esxi_connection
         - esxi_host
         - esxi_maintenance_mode


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `deploy_folder_template` module is missing from the `vmware` action group. This prevents the use of the module_defaults from feeding the module common default values that other modules are able to inherit.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`runtime.yml`