### PR TITLE
deploy folder template lookup fix

### DIFF
--- a/changelogs/fragments/16122025-deploy-folder-template.yml
+++ b/changelogs/fragments/16122025-deploy-folder-template.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - deploy_folder_template - Fixed issue where the vm folder was being cached in the placement service, causing the module to skip the template folder lookup and fail.
+    Fixes https://github.com/ansible-collections/vmware.vmware/issues/292

--- a/plugins/modules/deploy_folder_template.py
+++ b/plugins/modules/deploy_folder_template.py
@@ -148,7 +148,15 @@ class VmwareFolderTemplate(ModuleVmDeployBase):
         if self.params['template_folder_id']:
             folder = self.get_folders_by_name_or_moid(self.params['template_folder_id'], fail_on_missing=True)[0]
         else:
+            # Lookup the template folder using the placement service. This service is also used for the vm folder, and
+            # the vm folder property in the ModuleVmDeployBase depends on that result being cached in the placement service.
+            # So we stash the current cached folder, lookup the template folder, and then restore the cached folder to
+            # maintain functionality.
+            cached_folder = self.placement_service._folder
+            self.placement_service._folder = None
             folder = self.placement_service.get_folder(folder_param='template_folder')
+            if cached_folder:
+                self.placement_service._folder = cached_folder
 
         return folder
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/292

When we switched this module to use the shared placement service, a bug was introduced. The module looks up the vm folder and caches the result. Then it goes to lookup the template folder but returns the cached vm folder instead. This change fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
deploy_folder_template

