### PR TITLE
automatically use system certs via truststore

### DIFF
--- a/plugins/module_utils/clients/pyvmomi.py
+++ b/plugins/module_utils/clients/pyvmomi.py
@@ -11,6 +11,12 @@ import atexit
 import traceback
 
 try:
+    import truststore
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
+
+try:
     # requests is required for exception handling of the ConnectionError
     import requests
     REQUESTS_IMP_ERR = None

--- a/plugins/module_utils/clients/rest.py
+++ b/plugins/module_utils/clients/rest.py
@@ -14,6 +14,12 @@ __metaclass__ = type
 import traceback
 
 try:
+    import truststore
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
+
+try:
     import requests
     REQUESTS_IMP_ERR = None
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyVmomi>=8.0.3.0.1
 vmware-vcenter
+truststore ; python_version >= "3.10"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`requests` defaults to using the certificate trust provided by `certifi`, which precludes the inclusion of custom trusted certificates. Rather than needing to set the `REQUESTS_CA_BUNDLE` environment variable in every shell/config, use [`truststore`](https://github.com/sethmlarson/truststore) to override the way certs are read and automatically use the system trust store.

This will only happen transparently in environments using [Python >= 3.10](https://github.com/sethmlarson/truststore/blob/main/src/truststore/__init__.py).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request