### PR TITLE
fix vault strings in inven plugin auth config

### DIFF
--- a/changelogs/fragments/09012026-inven-vault.yml
+++ b/changelogs/fragments/09012026-inven-vault.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - inventory plugins - fix handling of encrypted strings in inventory plugin username and password options for ansible-core<=2.19
+    fixes https://github.com/ansible-collections/vmware.vmware/issues/304


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/304

The inventory plugins check the username/password specified in config files to see if they are strings or encrypted values. In ansible-core 2.19+, the class for encrypted strings changed. The fix provides a backwards compatible approach to handling the new encryption type

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vms
esxi_hosts

##### ADDITIONAL INFO
Tested with core 2.18, 19, and 20
