### PR TITLE
Added new `vm_snapshot_revert` module to meta/runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -37,6 +37,7 @@ action_groups:
         - vm_powerstate
         - vm_resource_info
         - vm_snapshot
+        - vm_snapshot_revert
         - vm
 
 plugin_routing:


### PR DESCRIPTION
##### SUMMARY
This PR adds the new `vm_snapshot_revert` module to the runtime.yml so [Ansible module defaults](https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_module_defaults.html) would work for it. 

Related to issue https://github.com/ansible-collections/vmware.vmware/issues/281 and PR https://github.com/ansible-collections/vmware.vmware/pull/296

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`vm_snapshot_revert`

##### ADDITIONAL INFORMATION
Ansible has a feature to define module defaults like this for the whole playbook/project/etc. so these keys don't need to be added to each module used.
```
vmware_defaults:
  hostname:
  username:
  password:
  ```
  
  Currently the new `vm_snapshot_revert` is not added to the collections meta/runtime.yml list for the module defaults to work. This PR adds it there.