### PR TITLE
add param to use inven paths for group names in vm_list_group_by

### DIFF
--- a/changelogs/fragments/01192026-cluster-group.yml
+++ b/changelogs/fragments/01192026-cluster-group.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - vm_list_group_by_clusters_info - Add the ability to use the absolute path for the group name. This
+    can be used to avoid group name collisions. Fixes https://github.com/ansible-collections/vmware.vmware/issues/297

--- a/tests/integration/targets/vmware_vm_list_group_by_clusters_info/defaults/main.yml
+++ b/tests/integration/targets/vmware_vm_list_group_by_clusters_info/defaults/main.yml
@@ -1,15 +1,2 @@
 test_folder: "{{ tiny_prefix }}-folder"
-
-vm_name: "{{ tiny_prefix }}-vm"
-vm_cluster: "{{ vcenter_cluster_name }}"
-vm_datacenter: "{{ vcenter_datacenter }}"
-vm_folder: "/{{ vcenter_datacenter }}/vm/{{ test_folder }}"
-vm_guest_id: "rhel8_64Guest"
-vm_disk:
-  - size_gb: 10
-    type: thin
-    autoselect_datastore: true
-vm_hardware:
-  memory_mb: 2000
-  num_cpus: 2
-  boot_firmware: efi
+test_vm_name: "{{ tiny_prefix }}-vm"

--- a/tests/integration/targets/vmware_vm_list_group_by_clusters_info/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_vm_list_group_by_clusters_info/tasks/eco-vcenter.yml
@@ -1,0 +1,72 @@
+---
+- name: Test
+  environment: "{{ environment_auth_vars }}"
+
+  block:
+    - name: "Test setup: Create VM folder {{ test_folder }}"
+      vmware.vmware.folder:
+        datacenter: "{{ vcenter_datacenter }}"
+        relative_path: "{{ test_folder }}"
+        folder_type: vm
+        state: present
+      register: __create_folder
+
+    - name: "Test setup: Create VM guest {{ test_vm_name }}"
+      vmware.vmware.vm:
+        cluster: "{{ vcenter_cluster_name }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        folder: "{{ test_folder }}"
+        state: present
+        name: "{{ test_vm_name }}"
+        datastore: "{{ shared_storage_01 }}"
+        disks:
+          - size: 10gb
+            provisioning: thin
+            device_node: SCSI(0:0)
+        scsi_controllers:
+          - controller_type: paravirtual
+            bus_number: 0
+        guest_id: rhel8_64Guest
+        memory:
+          size_mb: 2000
+        cpu:
+          cores: 2
+      register: __create_vm
+
+    - name: VM list group by clusters and folders with default group name
+      vmware.vmware.vm_list_group_by_clusters_info:
+        detailed_vms: false
+      register: __res
+
+    - name: VM list group by clusters and folders with absolute path for group name
+      vmware.vmware.vm_list_group_by_clusters_info:
+        detailed_vms: false
+        use_absolute_path_for_group_name: true
+      register: __res_abs
+
+    - name: Assert values
+      ansible.builtin.assert:
+        that:
+          - __res.changed == False
+          - __res.vm_list_group_by_clusters_info[vcenter_cluster_name][test_folder] | length == 1
+          - __res.vm_list_group_by_clusters_info[vcenter_cluster_name][test_folder][0]['name'] == test_vm_name
+          - __res_abs.changed == False
+          - __res_abs.vm_list_group_by_clusters_info[__cluster_group_name][__folder_group_name] | length == 1
+          - __res_abs.vm_list_group_by_clusters_info[__cluster_group_name][__folder_group_name][0]['name'] == test_vm_name
+      vars:
+        __cluster_group_name: /{{ vcenter_datacenter }}/host/{{ vcenter_cluster_name }}
+        __folder_group_name: /{{ vcenter_datacenter }}/vm/{{ test_folder }}
+
+  always:
+    - name: "Test teardown: Destroy VM guest {{ test_vm_name }}"
+      vmware.vmware.vm:
+        moid: "{{ __create_vm.vm.moid }}"
+        state: absent
+      when: __create_vm.vm.moid is defined
+
+    - name: "Test teardown: Remove VM folder {{ test_folder }}"
+      vmware.vmware.folder:
+        datacenter: "{{ vcenter_datacenter }}"
+        relative_path: "{{ test_folder }}"
+        folder_type: vm
+        state: absent

--- a/tests/integration/targets/vmware_vm_list_group_by_clusters_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_list_group_by_clusters_info/tasks/main.yml
@@ -1,65 +1,10 @@
 ---
-- name: Test
-  environment: "{{ environment_auth_vars }}"
+- name: Test On Simulator
+  ansible.builtin.include_tasks:
+    file: simulator.yml
+  when: not run_on_vcenter
 
-  block:
-    - name: "Test setup: Create VM folder {{ test_folder }}"
-      community.vmware.vcenter_folder:
-        datacenter: "{{ vm_datacenter }}"
-        folder_name: "{{ test_folder }}"
-        folder_type: vm
-        state: present
-      when: run_on_vcenter
-
-    - name: "Test setup: Create VM guest {{ vm_name }}"
-      community.vmware.vmware_guest:
-        cluster: "{{ vm_cluster }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "{{ vm_folder }}"
-        state: present
-        name: "{{ vm_name }}"
-        disk: "{{ vm_disk }}"
-        guest_id: "{{ vm_guest_id }}"
-        hardware: "{{ vm_hardware }}"
-      when: run_on_vcenter
-
-    - name: VM list group by clusters and folders
-      vmware.vmware.vm_list_group_by_clusters_info:
-        detailed_vms: false
-      register: __res
-
-    - name: Assert values
-      ansible.builtin.assert:
-        that:
-          - __res.changed == False
-          - __res.vm_list_group_by_clusters_info | length == 1
-          - __res.vm_list_group_by_clusters_info['cluster1'] | length == 1
-          - __res.vm_list_group_by_clusters_info['cluster1']['folder1'] | length == 1
-      when: not run_on_vcenter
-
-    - name: Assert values
-      ansible.builtin.assert:
-        that:
-          - __res.changed == False
-          - __res.vm_list_group_by_clusters_info[vm_cluster][test_folder] | length == 1
-          - __res.vm_list_group_by_clusters_info[vm_cluster][test_folder][0]['name'] == vm_name
-      when: run_on_vcenter
-
-  always:
-    - name: "Test teardown: Destroy VM guest {{ vm_name }}"
-      community.vmware.vmware_guest:
-        cluster: "{{ vm_cluster }}"
-        datacenter: "{{ vm_datacenter }}"
-        folder: "{{ vm_folder }}"
-        state: absent
-        force: true
-        name: "{{ vm_name }}"
-      when: run_on_vcenter
-
-    - name: "Test teardown: Remove VM folder {{ test_folder }}"
-      community.vmware.vcenter_folder:
-        datacenter: "{{ vm_datacenter }}"
-        folder_name: "{{ test_folder }}"
-        folder_type: vm
-        state: absent
-      when: run_on_vcenter
+- name: Test On VCenter
+  ansible.builtin.include_tasks:
+    file: eco-vcenter.yml
+  when: run_on_vcenter

--- a/tests/integration/targets/vmware_vm_list_group_by_clusters_info/tasks/simulator.yml
+++ b/tests/integration/targets/vmware_vm_list_group_by_clusters_info/tasks/simulator.yml
@@ -1,0 +1,17 @@
+---
+- name: Test on simulator
+  environment: "{{ environment_auth_vars }}"
+
+  block:
+    - name: VM list group by clusters and folders
+      vmware.vmware.vm_list_group_by_clusters_info:
+        detailed_vms: false
+      register: __res
+
+    - name: Assert values
+      ansible.builtin.assert:
+        that:
+          - __res.changed == False
+          - __res.vm_list_group_by_clusters_info | length == 1
+          - __res.vm_list_group_by_clusters_info['cluster1'] | length == 1
+          - __res.vm_list_group_by_clusters_info['cluster1']['folder1'] | length == 1

--- a/tests/unit/plugins/modules/test_vm_list_group_by_clusters_info.py
+++ b/tests/unit/plugins/modules/test_vm_list_group_by_clusters_info.py
@@ -4,10 +4,20 @@ __metaclass__ = type
 import sys
 import pytest
 
-from ansible_collections.vmware.vmware.plugins.modules import vm_list_group_by_clusters_info
-
+from ansible_collections.vmware.vmware.plugins.modules.vm_list_group_by_clusters_info import (
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import (
+    VmwareRestClient
+)
 from ...common.utils import (
     run_module, ModuleTestCase
+)
+from ...common.vmware_object_mocks import (
+    create_mock_vsphere_object
 )
 
 pytestmark = pytest.mark.skipif(
@@ -15,25 +25,77 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-class TestVMList(ModuleTestCase):
+def create_mock_cluster():
+    cluster = create_mock_vsphere_object(name="cluster1")
+    cluster.cluster = cluster._moid
+    return cluster
+
+
+def create_mock_folder():
+    folder = create_mock_vsphere_object(name="folder1")
+    folder.folder = folder._moid
+    return folder
+
+
+class TestVmwareVMList(ModuleTestCase):
 
     def __prepare(self, mocker):
-        init_mock = mocker.patch.object(vm_list_group_by_clusters_info.VmwareVMList, "__init__")
-        init_mock.return_value = None
+        self.rest_client = mocker.Mock()
+        mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=self.rest_client)
+        self.rest_client.vcenter.Cluster.list.return_value = [create_mock_cluster()]
+        self.rest_client.vcenter.Folder.list.return_value = [create_mock_folder()]
+        self.mock_vm = create_mock_vsphere_object(name="vm1")
+        self.rest_client.vcenter.VM.list.return_value = [self.mock_vm]
+        self.rest_client.vcenter.VM.get.return_value = self.mock_vm
+        self.rest_client.vcenter.Host.list.return_value = [create_mock_vsphere_object()]
 
-        vm_list_group_by_clusters_info.VmwareVMList.content = mocker.Mock()
-        vm_list_group_by_clusters_info.VmwareVMList.module = mocker.Mock()
-        vm_list_group_by_clusters_info.VmwareVMList.module.check_mode = False
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        mocker.patch(
+            "ansible_collections.vmware.vmware.plugins.modules.vm_list_group_by_clusters_info.ModulePyvmomiBase.get_cluster_by_name_or_moid",
+            return_value=create_mock_cluster(),
+        )
+        mocker.patch(
+            "ansible_collections.vmware.vmware.plugins.modules.vm_list_group_by_clusters_info.ModulePyvmomiBase.get_folders_by_name_or_moid",
+            return_value=[create_mock_folder()],
+        )
+        mocker.patch(
+            "ansible_collections.vmware.vmware.plugins.modules.vm_list_group_by_clusters_info.get_folder_path_of_vsphere_object",
+            return_value="",
+        )
 
-        vm_list_group_by_clusters_info.VmwareVMList.params = {
-            'detailed_vms': False,
-        }
-
-        list_of_vms = mocker.patch.object(vm_list_group_by_clusters_info.VmwareVMList, "get_vm_list_group_by_clusters")
-        list_of_vms.return_value = {}
-
-    def test_gather(self, mocker):
+    def test_defaults(self, mocker):
         self.__prepare(mocker)
 
-        result = run_module(module_entry=vm_list_group_by_clusters_info.main, module_args={})
+        module_args = dict(
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+
         assert result["changed"] is False
+        assert result["vm_list_group_by_clusters_info"] != {}
+
+    def test_use_absolute_path_for_group_name(self, mocker):
+        self.__prepare(mocker)
+
+        module_args = dict(
+            use_absolute_path_for_group_name=True
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+
+        assert result["changed"] is False
+        assert result["vm_list_group_by_clusters_info"] != {}
+        assert result["vm_list_group_by_clusters_info"]["/cluster1"]["/folder1"][0]["name"] == self.mock_vm.name
+
+    def test_detailed_vms(self, mocker):
+        self.__prepare(mocker)
+
+        module_args = dict(
+            detailed_vms=True
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+
+        assert result["changed"] is False
+        assert result["vm_list_group_by_clusters_info"] != {}
+        assert result["vm_list_group_by_clusters_info"]["cluster1"]["folder1"][0]["name"] == self.mock_vm.name


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/297

Object names are not required to be unique, so there are conflicts when we try to create groups based on cluster or folder names. This change adds a param that allows users to use the unique inventory path of an object as the group name.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vm_list_group_by_clusters_info

##### ADDITIONAL INFO
This is one of the older modules so I updated the tests to increase coverage and match the other tests in format
