### PR TITLE
add recurse search and dc errors to cluster info

### DIFF
--- a/changelogs/fragments/09012026-cluster-info.yml
+++ b/changelogs/fragments/09012026-cluster-info.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - cluster_info - When a user specifies a datacenter name, the module will now fail if that datacenter is not
+    found instead of silently continuing. Fixes https://github.com/ansible-collections/vmware.vmware/issues/303
+  - cluster_info - When a user does not specify a cluster name, the module will now search recursively for
+    clusters in the datacenter. Fixes https://github.com/ansible-collections/vmware.vmware/issues/303

--- a/plugins/modules/cluster_info.py
+++ b/plugins/modules/cluster_info.py
@@ -183,7 +183,7 @@ class ClusterInfo(ModulePyvmomiBase):
         """
         datacenter, search_folder = None, None
         if self.params.get('datacenter'):
-            datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=False)
+            datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
             search_folder = datacenter.hostFolder
 
         if self.params.get('cluster'):
@@ -193,7 +193,7 @@ class ClusterInfo(ModulePyvmomiBase):
             _clusters = self.get_all_objs_by_type(
                 [vim.ClusterComputeResource],
                 folder=search_folder,
-                recurse=False
+                recurse=True
             )
             return _clusters
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/303

This change makes the module throw an error when the user specifies a datacenter and it is not found. This is more in line with other modules, and I think what most users would expect.

This also makes cluster searches recursive. Without this change, this only reports on clusters immediately under a datacenter or root folder. People frequently nest their clusters under other folders to help keep things organized. Again, I think this is what most users would expect

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cluster_info