### PR TITLE
fix object name lookup error in tag assoc

### DIFF
--- a/changelogs/fragments/27012026-tag-assoc-name.yml
+++ b/changelogs/fragments/27012026-tag-assoc-name.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - tag_associations - Fix error when using the object_name parameter to lookup an object
+    Fixes - https://github.com/ansible-collections/vmware.vmware/issues/315

--- a/plugins/module_utils/_module_pyvmomi_base.py
+++ b/plugins/module_utils/_module_pyvmomi_base.py
@@ -59,7 +59,6 @@ class ModulePyvmomiBase(PyvmomiClient):
         Returns:
             list(object) or list() if no matches are found
         """
-
         identifier = name
         if not search_root_folder:
             search_root_folder = self.content.rootFolder

--- a/plugins/module_utils/_module_pyvmomi_base.py
+++ b/plugins/module_utils/_module_pyvmomi_base.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
-from tkinter import E
 
 __metaclass__ = type
 

--- a/plugins/module_utils/_module_pyvmomi_base.py
+++ b/plugins/module_utils/_module_pyvmomi_base.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+from tkinter import E
 
 __metaclass__ = type
 
@@ -59,6 +60,7 @@ class ModulePyvmomiBase(PyvmomiClient):
         Returns:
             list(object) or list() if no matches are found
         """
+
         identifier = name
         if not search_root_folder:
             search_root_folder = self.content.rootFolder

--- a/plugins/modules/tag_associations.py
+++ b/plugins/modules/tag_associations.py
@@ -252,12 +252,21 @@ class VmwareTagAssociationsModule(ModuleRestBase):
         else:
             folder_object = pyv.content.rootFolder
 
+        object_vim_type = getattr(vim, self.params.get("object_type"))
+        if object_vim_type is None:
+            # This should get caught by the developer, if they add a new type that isn't
+            # supported by pyvmomi/vmware
+            self.module.fail_json(
+                msg="Unsupported vim object type specified: %s" % self.params.get("object_type")
+            )
+
         object_result = pyv.get_objs_by_name_or_moid(
-            vim[self.params.get("object_type")],
+            object_vim_type,
             self.params.get("object_name"),
             return_all=True,
             search_root_folder=folder_object,
         )
+
         if len(object_result) > 1:
             self.module.fail_json(
                 msg="Multiple vSphere objects found with the name %s and type %s. Consider using the object_moid or object_search_folder_path parameters."

--- a/tests/integration/targets/vmware_tags/tasks/test_association.yml
+++ b/tests/integration/targets/vmware_tags/tasks/test_association.yml
@@ -25,7 +25,7 @@
 - name: Attach tags to a VM
   vmware.vmware.tag_associations: &tag_associations_present
     state: present
-    object_moid: "{{ _test_association_vm.vm.moid }}"
+    object_name: "{{ _test_association_vm.vm.name }}"
     object_type: VirtualMachine
     tags:
       - "{{ test_tags_association[0] }}"


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/vmware.vmware/issues/315

When a user tries to look up an object by name in the tag_associations module, the module incorrectly accesses the `vim` object to get the object type.
This change adjusts how the `vim` object is accessed, and adds a check to help prevent unexpected behavior if the object type is not found.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tag_associations
