### PR TITLE
add param to set ansible_host

### DIFF
--- a/changelogs/fragments/05022026-vms-ansible-host.yml
+++ b/changelogs/fragments/05022026-vms-ansible-host.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - vms - Add setting to disable population of ansible_host to the inventory
+    Fixes https://github.com/ansible-collections/vmware.vmware/pull/317

--- a/plugins/inventory/vms.py
+++ b/plugins/inventory/vms.py
@@ -48,6 +48,12 @@ options:
             - Looking up these values can add time to the inventory process.
         default: false
         type: bool
+    set_ansible_host: 
+        description:
+            - If true, ansible_host will be set
+            - If false, ansible_host will not be set
+        default: true
+        type: bool
 """
 
 EXAMPLES = r"""
@@ -370,7 +376,8 @@ class InventoryModule(VmwareInventoryBase):
             Args:
               vmware_host_object: EsxiInventoryHost, The host object that should be used
         """
-        self.inventory.set_variable(
-            vmware_host_object.inventory_hostname, "ansible_host",
-            vmware_host_object.guest_ip
-        )
+        if self.get_option("set_ansible_host"):
+            self.inventory.set_variable(
+                vmware_host_object.inventory_hostname, "ansible_host",
+                vmware_host_object.guest_ip
+            )

--- a/plugins/inventory/vms.py
+++ b/plugins/inventory/vms.py
@@ -48,7 +48,7 @@ options:
             - Looking up these values can add time to the inventory process.
         default: false
         type: bool
-    set_ansible_host: 
+    set_ansible_host:
         description:
             - If true, ansible_host will be set
             - If false, ansible_host will not be set


### PR DESCRIPTION
##### SUMMARY
We don't want the inventory plugin to always explicitly set the variable `ansible_host`, 
so we've made this configurable via a parameter.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
vmware.vmware.vms


