### PR TITLE
Fix issue #330, traverse snapshot tree correctly in vm_snapshot_revert

### DIFF
--- a/changelogs/fragments/bugfix-330.yml
+++ b/changelogs/fragments/bugfix-330.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - vm_snapshot_revert - search the snapshot tree fully to find a matching snapshot
+    Fixes https://github.com/ansible-collections/vmware.vmware/issues/330

--- a/plugins/modules/vm_snapshot_revert.py
+++ b/plugins/modules/vm_snapshot_revert.py
@@ -189,9 +189,10 @@ class VmSnapshotRevertModule(ModulePyvmomiBase):
             if snapidentifier == snapshot.id or snapidentifier == snapshot.name:
                 return snapshot
             else:
-                return self._get_snapshot_by_identifier_recursively(
+                if child_match := self._get_snapshot_by_identifier_recursively(
                     snapshot.childSnapshotList, snapidentifier
-                )
+                ):
+                    return child_match
         return None
 
     def revert_to_snapshot(self):


### PR DESCRIPTION
vm_snaphot_revert/_get_snapshot_by_identifier_recursively: Don't return  None until all snapshots from list argument are exhausted.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue #330 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vm_snapshot_revert

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The previous form of _get_snapshot_by_identifier_recursively never iterates over the list that is passed into the function, because both branches of the `if..else` construct issue a `return`.

Fix tested with ansible 2.20, applied to vmware collection 2.7.0

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
