### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -78,6 +78,8 @@ jobs:
           - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
+          - stable-2.21
           - devel
         # - milestone
     runs-on: ubuntu-latest

--- a/.github/workflows/ansible-unit.yml
+++ b/.github/workflows/ansible-unit.yml
@@ -54,6 +54,8 @@ jobs:
         versions:
           # Testing all ansible and python versions is impractical. Only test the newest and
           # oldest versions of each that we support
+          - { python: 3.14, ansible: stable-2.20 }
+          - { python: 3.12, ansible: stable-2.20 }
           - { python: 3.13, ansible: stable-2.19 }
           - { python: 3.8, ansible: stable-2.19 }
           - { python: 3.12, ansible: stable-2.16 }

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,2 +1,0 @@
-plugins/inventory/esxi_hosts.py yamllint:unparsable-with-libyaml   # inventory examples are technically multiple yaml docs, which the linter in versions <2.17 does not like
-plugins/inventory/vms.py yamllint:unparsable-with-libyaml   # inventory examples are technically multiple yaml docs, which the linter in versions <2.17 does not like


### PR DESCRIPTION
##### SUMMARY
I think it's overdue to add ansible-core 2.20 to the sanity tests. It's time to add sanity tests for 2.21, too.

While I'm at it, I've also added unit tests for 2.20 which are missing. I've added tests with Python 3.12 and 3.14, which are the oldest and newest version that ansible-core 2.20 [supports](https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix).

Additionally, I've removed tests/sanity/ignore-2.15.txt since vmware.vmware doesn't support ansible-core 2.15 anymore and there aren't any sanity tests for 2.15, either, since #146.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
.github/workflows/ansible-sanity.yml
.github/workflows/ansible-unit.yml
tests/sanity/ignore-2.15.txt

##### ADDITIONAL INFORMATION
https://forum.ansible.com/t/45646
ansible-collections/community.vmware#2551