### PR TITLE
Fix vm delete_from_inventory documentation semantics

### DIFF
--- a/changelogs/fragments/bugfix-322.yml
+++ b/changelogs/fragments/bugfix-322.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - vm - correct O(delete_from_inventory) documentation for C(state=absent) to match module behavior.
+    Fixes https://github.com/ansible-collections/vmware.vmware/issues/322

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -145,9 +145,9 @@ options:
 
     delete_from_inventory:
         description:
-            - Whether to delete the VM from the datastore when removing it, or just remove the VM from the vSphere inventory.
-            - If this is set to true, the VM will be deleted from the datastore when it is removed.
-            - If this is set to false, the VM will remain on the datastore when it is removed.
+            - Whether to remove the VM from the vSphere inventory only, or to also delete the VM and its files from the datastore.
+            - If this is set to true, the VM will only be removed from the vSphere inventory. Files will remain on the datastore.
+            - If this is set to false, the VM will be deleted from both the inventory and datastore.
             - This parameter is only used when O(state) is set to C(absent).
         type: bool
         required: false


### PR DESCRIPTION
##### SUMMARY

Correct the `vm` module documentation for `delete_from_inventory` when `state: absent` so it matches actual behavior. The docs now clarify that `delete_from_inventory: true` removes the VM from inventory only, while `false` deletes from inventory and datastore.

Fixes https://github.com/ansible-collections/vmware.vmware/issues/322

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

vm

##### ADDITIONAL INFORMATION

This change updates option documentation in `plugins/modules/vm.py` and adds a changelog fragment in `changelogs/fragments/bugfix-322.yml`.

Disclaimer: This PR description was generated with the help of AI.