### PR TITLE
Fix stale loop variable in datastore validation error

### DIFF
--- a/changelogs/fragments/fix-datastore-error-param-name.yml
+++ b/changelogs/fragments/fix-datastore-error-param-name.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - vm - Fix incorrect parameter name in error when neither datastore nor
+    datastore_cluster is provided for VM creation.
+    Follow-up to https://github.com/ansible-collections/vmware.vmware/issues/334.

--- a/plugins/module_utils/vm/parameter_handlers/_metadata.py
+++ b/plugins/module_utils/vm/parameter_handlers/_metadata.py
@@ -72,7 +72,7 @@ class MetadataParameterHandler(AbstractParameterHandler):
                 "datastore_cluster"
             ):
                 self.error_handler.fail_with_parameter_error(
-                    parameter_name=param,
+                    parameter_name="datastore",
                     message="Either the datastore or datastore_cluster parameter must be provided for VM creation.",
                 )
 

--- a/tests/unit/plugins/module_utils/vm/parameter_handlers/test_metadata.py
+++ b/tests/unit/plugins/module_utils/vm/parameter_handlers/test_metadata.py
@@ -35,6 +35,28 @@ class TestMetadataParameterHandler:
         metadata_parameter_handler.verify_parameter_constraints()
         metadata_parameter_handler.error_handler.fail_with_parameter_error.assert_not_called()
 
+    def test_verify_parameter_constraints_datastore_cluster(self, metadata_parameter_handler):
+        metadata_parameter_handler.vm = None
+        metadata_parameter_handler.params = {
+            "name": "test",
+            "guest_id": "test",
+            "datastore_cluster": "test-cluster",
+        }
+        metadata_parameter_handler.verify_parameter_constraints()
+        metadata_parameter_handler.error_handler.fail_with_parameter_error.assert_not_called()
+
+    def test_verify_parameter_constraints_no_storage_reports_datastore(self, metadata_parameter_handler):
+        metadata_parameter_handler.vm = None
+        metadata_parameter_handler.params = {
+            "name": "test",
+            "guest_id": "test",
+        }
+        metadata_parameter_handler.verify_parameter_constraints()
+        metadata_parameter_handler.error_handler.fail_with_parameter_error.assert_called_once_with(
+            parameter_name="datastore",
+            message="Either the datastore or datastore_cluster parameter must be provided for VM creation.",
+        )
+
     def test_compare_live_config_with_desired_config(self, metadata_parameter_handler):
         metadata_parameter_handler.compare_live_config_with_desired_config()
         assert (


### PR DESCRIPTION
##### SUMMARY

Follow-up to #334 / PR #339.

The datastore/datastore_cluster validation added in PR #339 references the stale loop variable `param` (which holds `"guest_id"`) instead of `"datastore"`. This causes the error response to report `parameter_name: "guest_id"` when neither `datastore` nor `datastore_cluster` is provided for VM creation.

**Fix:** Change `parameter_name=param` to `parameter_name="datastore"`.

**Tests added:**
- Verify `datastore_cluster` alone satisfies the storage requirement (no error)
- Verify the error reports `parameter_name="datastore"` when neither is provided

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`plugins/module_utils/vm/parameter_handlers/_metadata.py`

##### ADDITIONAL INFORMATION

The one-line fix changes line 75 of `_metadata.py`:
```diff
-                    parameter_name=param,
+                    parameter_name="datastore",
```