### PR TITLE
Shard eco vCenter integration CI via target matrix groups

### DIFF
--- a/.github/workflows/eco-vcenter-ci.yaml
+++ b/.github/workflows/eco-vcenter-ci.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   prepare_matrix:
-    runs-on: [ "self-hosted", linux, X64 ]
+    runs-on: [ "unbuntu-latest" ]
     outputs:
       groups: ${{ steps.set-matrix.outputs.groups }}
     steps:

--- a/.github/workflows/eco-vcenter-ci.yaml
+++ b/.github/workflows/eco-vcenter-ci.yaml
@@ -2,19 +2,65 @@
 name: Ansible Eco vCenter Integration Test
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
   push:
     branches:
       - main
-      - 'release-\d.\d'
+      - "release-\\d.\\d"
 
 permissions:
   contents: read
 
 jobs:
+  prepare_matrix:
+    runs-on: [ "self-hosted", linux, X64 ]
+    outputs:
+      groups: ${{ steps.set-matrix.outputs.groups }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Build target groups matrix
+        id: set-matrix
+        run: |
+          set -euo pipefail
+          python3 << 'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path("tests/integration/targets")
+          targets = sorted(
+              p.name
+              for p in root.iterdir()
+              if p.is_dir() and p.name.startswith("vmware_")
+          )
+          chunk = 5
+          groups = [
+              {"group": i // chunk, "targets": " ".join(targets[i : i + chunk])}
+              for i in range(0, len(targets), chunk)
+          ]
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh_out:
+              gh_out.write(
+                  "groups<<JSON_GROUPS_EOF\n"
+                  f"{json.dumps(groups)}\n"
+                  "JSON_GROUPS_EOF\n"
+              )
+          PY
+        env:
+          PYTHONIOENCODING: utf-8
+
   ansible_integration_test:
-    runs-on: ["self-hosted", linux, X64]
+    runs-on: [ "self-hosted", linux, X64 ]
+    needs: prepare_matrix
+    if: needs.prepare_matrix.outputs.groups != '[]'
     environment: eco-vcenter
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare_matrix.outputs.groups) }}
     steps:
       - name: Update pip, git
         if: runner.os == 'Linux' && startsWith(runner.name, 'ubuntu')
@@ -26,7 +72,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Generate integration config
         run: |
@@ -36,11 +82,11 @@ jobs:
           VCENTER_USERNAME: ${{ secrets.VCENTER_USERNAME }}
           VCENTER_PASSWORD: ${{ secrets.VCENTER_PASSWORD }}
 
-      - name: Run integration tests
+      - name: Run integration tests (group ${{ matrix.group }})
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          make eco-vcenter-ci
+          make eco-vcenter-ci ECO_VCENTER_CI_TARGETS='${{ matrix.targets }}'
         env:
           ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}"
           VCENTER_HOSTNAME: ${{ secrets.VCENTER_HOSTNAME }}

--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ eco-vcenter-ci: tests/integration/integration_config.yml install-integration-req
 	chmod +x tests/integration/run_eco_vcenter_ci.sh; \
 	ANSIBLE_ROLES_PATH=~/.ansible/collections/ansible_collections/vmware/vmware/tests/integration/targets \
 		ANSIBLE_COLLECTIONS_PATH=~/.ansible/collections/ansible_collections \
-		./tests/integration/run_eco_vcenter_ci.sh
+		./tests/integration/run_eco_vcenter_ci.sh "$(ECO_VCENTER_CI_TARGETS)"

--- a/tests/integration/run_eco_vcenter_ci.sh
+++ b/tests/integration/run_eco_vcenter_ci.sh
@@ -35,7 +35,15 @@ total=0
     echo "==============="
 } >> "$TEST_OUTPUT_LOG"
 
-for target in $(ansible-test integration --list-target | grep 'vmware_'); do
+if [ -n "${1:-}" ]; then
+    read -ra target_list <<<"$1"
+elif [ -n "${ECO_VCENTER_CI_TARGETS:-}" ]; then
+    read -ra target_list <<<"${ECO_VCENTER_CI_TARGETS}"
+else
+    target_list=($(ansible-test integration --list-target | grep 'vmware_'))
+fi
+
+for target in "${target_list[@]}"; do
     echo "Running integration test for $target"
     total=$((total + 1))
     if ansible-test integration $target --skip-tags force-simulator-run; then

--- a/tests/integration/run_eco_vcenter_ci.sh
+++ b/tests/integration/run_eco_vcenter_ci.sh
@@ -40,7 +40,7 @@ if [ -n "${1:-}" ]; then
 elif [ -n "${ECO_VCENTER_CI_TARGETS:-}" ]; then
     read -ra target_list <<<"${ECO_VCENTER_CI_TARGETS}"
 else
-    target_list=($(ansible-test integration --list-target | grep 'vmware_'))
+    mapfile -t target_list < <(ansible-test integration --list-target | grep 'vmware_')
 fi
 
 for target in "${target_list[@]}"; do


### PR DESCRIPTION
##### SUMMARY

Split the Eco vCenter integration workflow into parallel matrix legs. A new `prepare_matrix` job discovers `vmware_*` targets under `tests/integration/targets`, groups them five at a time (sorted), and passes each group's space-separated names to `make eco-vcenter-ci` via `ECO_VCENTER_CI_TARGETS`.

The Makefile and `tests/integration/run_eco_vcenter_ci.sh` honor that variable (or a positional argument) while preserving existing behavior when unset (discover targets with `ansible-test integration --list-target` filtered by `vmware_`). Checkout now uses `github.event.pull_request.head.sha || github.sha` so pushes to tracked branches resolve a valid ref.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`eco-vcenter-ci.yaml` / `run_eco_vcenter_ci.sh` / `Makefile`

##### ADDITIONAL INFORMATION

The matrix uses `fail-fast: false`. The integration test job is skipped if there are no `vmware_*` targets (empty groups JSON).

Disclaimer: This PR description was generated with the help of AI.