### PR TITLE
fix flakey tests

### DIFF
--- a/.github/workflows/eco-vcenter-ci.yaml
+++ b/.github/workflows/eco-vcenter-ci.yaml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
+    # this environment requires approval to prevent abuse of the vCenter lab. It is used on this stage so you
+    # only need to approve the workflow once, and then can re-run the jobs if there are failures. If new changes
+    # are pushed, approval is required again.
+    environment: eco-vcenter-ci
     outputs:
       groups: ${{ steps.set-matrix.outputs.groups }}
     steps:
@@ -56,7 +60,6 @@ jobs:
     runs-on: [ "self-hosted", linux, X64 ]
     needs: prepare_matrix
     if: needs.prepare_matrix.outputs.groups != '[]'
-    environment: eco-vcenter
     strategy:
       fail-fast: false
       matrix:

--- a/tests/integration/targets/vmware_vm_apply_customization/tasks/test_cloud_init.yml
+++ b/tests/integration/targets/vmware_vm_apply_customization/tasks/test_cloud_init.yml
@@ -35,6 +35,10 @@
     state: absent
   retries: 3 # retry to help prevent race condition with other test runs
 
+- name: Wait for host to be ready
+  ansible.builtin.wait_for_connection:
+  delegate_to: "{{ test_vm_name }}"
+
 - name: Check for cloud-init.out file
   ansible.builtin.wait_for:
     path: /root/cloud-init.out
@@ -46,5 +50,6 @@
 - name: Assert cloud-init.out file exists
   ansible.builtin.assert:
     that:
-      - _cloud_init_out_stat.unreachable is not defined or _cloud_init_out_stat.unreachable is false
+      - _cloud_init_out_stat.unreachable is not defined or
+        _cloud_init_out_stat.unreachable is false
       - _cloud_init_out_stat is not ansible.builtin.failed

--- a/tests/integration/targets/vmware_vm_apply_customization/tasks/test_unix_prep.yml
+++ b/tests/integration/targets/vmware_vm_apply_customization/tasks/test_unix_prep.yml
@@ -36,6 +36,10 @@
     state: absent
   retries: 3 # retry to help prevent race condition with other test runs
 
+- name: Wait for host to be ready
+  ansible.builtin.wait_for_connection:
+  delegate_to: "{{ test_vm_name }}"
+
 - name: Check test VM
   block:
     - name: Check for unix_prep.post file
@@ -56,6 +60,8 @@
 - name: Assert pre and post files exist
   ansible.builtin.assert:
     that:
-      - _unix_prep_post_stat.unreachable is not defined or _unix_prep_post_stat.unreachable is false
-      - _unix_prep_pre_stat.unreachable is not defined or _unix_prep_pre_stat.unreachable is false
+      - _unix_prep_post_stat.unreachable is not defined or
+        _unix_prep_post_stat.unreachable is false
+      - _unix_prep_pre_stat.unreachable is not defined or
+        _unix_prep_pre_stat.unreachable is false
       - _unix_prep_pre_stat.stat.exists

--- a/tests/integration/targets/vmware_vm_powerstate/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_vm_powerstate/tasks/eco-vcenter.yml
@@ -2,8 +2,8 @@
 - name: Lookup Root Resource Pool ID
   ansible.builtin.set_fact:
     vcenter_rp_id: >-
-      {{ lookup('vmware.vmware.moid_from_path',
-      '/' + vcenter_datacenter + '/host/' + vcenter_cluster_name + '/' + vcenter_resource_pool,
+      {{ lookup('vmware.vmware.moid_from_path', '/' + vcenter_datacenter +
+      '/host/' + vcenter_cluster_name + '/' + vcenter_resource_pool,
       **vmware_rest_auth_vars) }}
 
 - name: Test
@@ -171,7 +171,7 @@
         folder: "{{ vm_folder }}"
         name: "{{ vm }}"
         state: powered-off
-        scheduled_at: "{{ '%d/%m/%Y %H:%M' | strftime((ansible_date_time.epoch | int) + 180)}}"
+        scheduled_at: "{{ '%d/%m/%Y %H:%M' | strftime(now().strftime('%s') + 180)}}"
         scheduled_task_name: "task_001"
         scheduled_task_description: "Sample task to poweroff VM"
         scheduled_task_enabled: true

--- a/tests/integration/targets/vmware_vm_powerstate/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_vm_powerstate/tasks/eco-vcenter.yml
@@ -171,7 +171,7 @@
         folder: "{{ vm_folder }}"
         name: "{{ vm }}"
         state: powered-off
-        scheduled_at: "{{ '%d/%m/%Y %H:%M' | strftime(now().strftime('%s') + 180)}}"
+        scheduled_at: "{{ '%d/%m/%Y %H:%M' | strftime((now().strftime('%s') | int) + 180) }}"
         scheduled_task_name: "task_001"
         scheduled_task_description: "Sample task to poweroff VM"
         scheduled_task_enabled: true


### PR DESCRIPTION
##### SUMMARY
Fixes for the more flakey tests:
- Adding steps to wait for hosts to be ready in the customization tests to ensure ssh is running
- Changing how we get the timestamp for the powerstate test to `now` instead of relying on the timestamp from when facts were gathered

##### ISSUE TYPE
- Bugfix Pull Request
