### PR TITLE
feat: add cluster_ha_vm_overrides modules and shared HA settings utils

### DIFF
--- a/changelogs/fragments/aca-2283-cluster-ha-vm-overrides.yml
+++ b/changelogs/fragments/aca-2283-cluster-ha-vm-overrides.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - cluster_ha_vm_overrides - add module to manage HA VM override settings on vSphere clusters
+  - cluster_ha_vm_overrides_info - add module to gather HA VM override settings for a cluster

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -32,3 +32,4 @@ build_ignore:
   - .gemini/
   - .claude/
   - .ansible-lint
+  - .ansible/

--- a/plugins/module_utils/_cluster_settings.py
+++ b/plugins/module_utils/_cluster_settings.py
@@ -37,10 +37,16 @@ class ClusterSettingsRemapper:
             param_value: Truthy to restart VMs after APD clears; falsy to take no reaction.
 
         Returns:
-            ``reset`` if ``param_value`` is true, else ``none``.
+            ``reset`` if ``param_value`` is true, ``none`` if false, or ``None`` if unset
+            (caller should omit the API field when ``None``).
         """
+        # return None if the param was not set, to preserve user input
+        if param_value is None:
+            return None
+
         if param_value:
             return "reset"
+
         return "none"
 
 
@@ -80,6 +86,7 @@ class BaseVmOverrideChangeTracker(ABC):
         """
         if getattr(desired_spec, attribute_name) is None:
             return False
+
         return getattr(desired_spec, attribute_name) != getattr(
             current_spec, attribute_name
         )

--- a/plugins/module_utils/_cluster_settings.py
+++ b/plugins/module_utils/_cluster_settings.py
@@ -1,0 +1,153 @@
+"""
+Helpers for cluster HA and HA/DRS VM override modules: value remapping for the vSphere API
+and a shared change tracker for desired vs current per-VM override specs.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ClusterSettingsRemapper:
+    """
+    Remap cluster settings from the common module parameter values to the expected
+    vSphere API values.
+    This is done to provide a consistent and intuitive interface for the module(s).
+    """
+
+    @staticmethod
+    def storage_pdl_response_mode(param_value):
+        """
+        Map module PDL storage protection parameter values to vim API enum strings.
+
+        Args:
+            param_value: User-facing value such as ``restart``, ``warning``, or ``disabled``.
+
+        Returns:
+            ``restartAggressive`` when ``param_value`` is ``restart``; otherwise ``param_value`` unchanged.
+        """
+        if param_value == "restart":
+            return "restartAggressive"
+        return param_value
+
+    @staticmethod
+    def storage_apd_restart_vms(param_value):
+        """
+        Map the boolean ``restart_vms`` module option to ``vmReactionOnAPDCleared`` API values.
+
+        Args:
+            param_value: Truthy to restart VMs after APD clears; falsy to take no reaction.
+
+        Returns:
+            ``reset`` if ``param_value`` is true, else ``none``.
+        """
+        if param_value:
+            return "reset"
+        return "none"
+
+
+class BaseVmOverrideChangeTracker(ABC):
+    """
+    Compare desired VM overrides (by VM MoID) to current cluster overrides.
+    """
+
+    def __init__(self, current_vm_override_specs, param_vm_override_specs):
+        """
+        Args:
+            current_vm_override_specs: Mapping of VM MoID to current ``vim.cluster.*VmConfigInfo`` (or compatible).
+            param_vm_override_specs: Mapping of VM MoID to desired override spec objects from module parameters.
+                                     Should also be ``vim.cluster.*VmConfigInfo`` (or compatible).
+        """
+        self.current_vm_overrides = current_vm_override_specs
+        self.param_vm_overrides = param_vm_override_specs
+        self.to_add = {}
+        self.to_update = {}
+        self.to_remove = {}
+        self._final_override_moids = set()
+
+    @staticmethod
+    def _is_desired_set_and_different_from_current(
+        desired_spec, current_spec, attribute_name
+    ):
+        """
+        Return whether ``desired_spec`` sets ``attribute_name`` to a non-None value that differs from ``current_spec``.
+
+        Args:
+            desired_spec: Desired override object (pyVmomi spec or info).
+            current_spec: Current cluster override object for the same VM.
+            attribute_name: Attribute to compare on both objects.
+
+        Returns:
+            False if the desired attribute is unset (None); otherwise True if values differ.
+        """
+        if getattr(desired_spec, attribute_name) is None:
+            return False
+        return getattr(desired_spec, attribute_name) != getattr(
+            current_spec, attribute_name
+        )
+
+    @abstractmethod
+    def _overrides_differ(self, desired, current):
+        """Return True if the desired override should replace the current one for this VM."""
+        pass
+
+    def has_changes(self):
+        """Return True if any VM is slated for add, update, or remove."""
+        return (
+            len(self.to_add) > 0 or len(self.to_update) > 0 or len(self.to_remove) > 0
+        )
+
+    def process_absent_changes(self):
+        """
+        Populate ``to_remove`` for VMs listed in ``param_vm_overrides`` that still have overrides on the cluster.
+
+        Tracks ``_final_override_moids`` as current MoIDs minus those removed.
+        """
+        self._final_override_moids = set(self.current_vm_overrides.keys())
+        for moid in self.param_vm_overrides.keys():
+            if moid in self.current_vm_overrides:
+                self.to_remove[moid] = self.current_vm_overrides[moid]
+                self._final_override_moids.remove(moid)
+
+    def process_present_changes(self, append=True):
+        """
+        Classify desired overrides into ``to_add``, ``to_update``, and optionally ``to_remove``.
+
+        With ``append`` true, existing cluster overrides not mentioned in the desired set are left unchanged.
+        With ``append`` false, any current override whose MoID is not in the desired set is marked for removal.
+
+        Args:
+            append: If false, enforce an exact match: remove cluster overrides not in ``param_vm_overrides``.
+        """
+        if append:
+            self._final_override_moids = set(self.current_vm_overrides.keys())
+
+        for moid, desired in self.param_vm_overrides.items():
+            if moid not in self.current_vm_overrides:
+                self.to_add[moid] = desired
+
+            elif self._overrides_differ(desired, self.current_vm_overrides[moid]):
+                self.to_update[moid] = desired
+
+            self._final_override_moids.add(moid)
+
+        if append:
+            return
+
+        for moid, current in self.current_vm_overrides.items():
+            if moid not in self._final_override_moids:
+                self.to_remove[moid] = current
+
+    @staticmethod
+    def format_override_specs_for_json(change_list):
+        """
+        Reduce pyVmomi override objects to JSON-serializable dicts for module return values.
+
+        Args:
+            change_list: Iterable of specs whose ``key`` is the VM managed object (``name``, ``_GetMoId()``).
+
+        Returns:
+            List of dicts with ``vm_moid`` and ``vm_name`` keys only.
+        """
+        return [
+            {"vm_moid": change.key._GetMoId(), "vm_name": change.key.name}
+            for change in change_list
+        ]

--- a/plugins/module_utils/_cluster_settings.py
+++ b/plugins/module_utils/_cluster_settings.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Note: This utility is considered private, and can only be referenced from inside the vmware.vmware collection.
+#       It may be made public at a later date
 """
 Helpers for cluster HA and HA/DRS VM override modules: value remapping for the vSphere API
 and a shared change tracker for desired vs current per-VM override specs.
@@ -64,6 +72,12 @@ class BaseVmOverrideChangeTracker(ABC):
         """
         self.current_vm_overrides = current_vm_override_specs
         self.param_vm_overrides = param_vm_override_specs
+        self._initialize_tracking_attributes()
+
+    def _initialize_tracking_attributes(self):
+        """
+        Initialize the tracking attributes.
+        """
         self.to_add = {}
         self.to_update = {}
         self.to_remove = {}
@@ -105,9 +119,13 @@ class BaseVmOverrideChangeTracker(ABC):
     def process_absent_changes(self):
         """
         Populate ``to_remove`` for VMs listed in ``param_vm_overrides`` that still have overrides on the cluster.
+        Call exactly one of ``process_absent_changes`` or ``process_present_changes`` per tracker instance.
+        Tracking attributes are reset at the start of each call; a second call replaces rather than merges
+        results from a prior call.
 
         Tracks ``_final_override_moids`` as current MoIDs minus those removed.
         """
+        self._initialize_tracking_attributes()
         self._final_override_moids = set(self.current_vm_overrides.keys())
         for moid in self.param_vm_overrides.keys():
             if moid in self.current_vm_overrides:
@@ -117,6 +135,9 @@ class BaseVmOverrideChangeTracker(ABC):
     def process_present_changes(self, append=True):
         """
         Classify desired overrides into ``to_add``, ``to_update``, and optionally ``to_remove``.
+        Call exactly one of ``process_absent_changes`` or ``process_present_changes`` per tracker instance.
+        Tracking attributes are reset at the start of each call; a second call replaces rather than merges
+        results from a prior call.
 
         With ``append`` true, existing cluster overrides not mentioned in the desired set are left unchanged.
         With ``append`` false, any current override whose MoID is not in the desired set is marked for removal.
@@ -124,6 +145,7 @@ class BaseVmOverrideChangeTracker(ABC):
         Args:
             append: If false, enforce an exact match: remove cluster overrides not in ``param_vm_overrides``.
         """
+        self._initialize_tracking_attributes()
         if append:
             self._final_override_moids = set(self.current_vm_overrides.keys())
 

--- a/plugins/modules/cluster_drs_vm_overrides.py
+++ b/plugins/modules/cluster_drs_vm_overrides.py
@@ -6,10 +6,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: cluster_drs_vm_overrides
 short_description: Manage Distributed Resource Scheduler (DRS) VM override settings.
@@ -19,8 +20,15 @@ description:
     - You must enable DRS VM override settings before you can use them. See m(vmware.vmware.cluster_drs).
     - VMs must exist in the cluster before you can set their override settings.
     - When a VM is removed from the cluster, its override settings are also automatically removed.
+    - Although VM overrides are shown in a unified view in vCenter, this module only manages the DRS override settings.
+      Removing a VM override does not remove all overrides, just the DRS related ones.
 author:
     - Ansible Cloud Team (@ansible-collections)
+
+seealso:
+    - module: vmware.vmware.cluster_drs
+    - module: vmware.vmware.cluster_ha_vm_overrides
+    - module: vmware.vmware.cluster_drs_vm_overrides_info
 
 options:
     cluster:
@@ -67,7 +75,7 @@ options:
                     - Using the MOID is recommended as the name lookup takes longer and cannot handle duplicate names.
                 type: str
                 required: true
-            drs_behavior:
+            behavior:
                 description:
                     - The DRS behavior for the virtual machine.
                     - If set to V(fullyAutomated), then vCenter automates both the migration of the virtual machine
@@ -80,18 +88,18 @@ options:
                 required: false
                 default: fullyAutomated
                 choices: [ fullyAutomated, manual, partiallyAutomated ]
-            enable:
+            enabled:
                 description:
-                    - Whether to enable the override settings for the virtual machine.
+                    - Whether the override settings are enabled for the virtual machine.
                 type: bool
                 required: false
                 default: true
 
 extends_documentation_fragment:
     - vmware.vmware.base_options
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Enable DRS
   vmware.vmware.cluster_drs:
     hostname: '{{ vcenter_hostname }}'
@@ -102,6 +110,7 @@ EXAMPLES = r'''
     enable: true
   delegate_to: localhost
 
+# Use the lookup plugin to get the VM MOID when names are ambiguous
 - name: Ensure a VM override is present
   vmware.vmware.cluster_drs_vm_overrides:
     datacenter: DC01
@@ -110,8 +119,8 @@ EXAMPLES = r'''
     append: true
     vm_overrides:
       - virtual_machine: "{{ lookup('vmware.vmware.moid_from_path', '/DC01/vm/MyVirtualMachine') }}"
-        drs_behavior: fullyAutomated
-        enable: true
+        behavior: fullyAutomated
+        enabled: true
 
 - name: Ensure a VM override is absent
   vmware.vmware.cluster_drs_vm_overrides:
@@ -137,56 +146,56 @@ EXAMPLES = r'''
     append: false
     vm_overrides:
       - virtual_machine: MyVirtualMachine
-        drs_behavior: fullyAutomated
-        enable: true
+        behavior: fullyAutomated
+        enabled: true
       - virtual_machine: MyOtherVirtualMachine
-        drs_behavior: manual
-        enable: false
-'''
+        behavior: manual
+        enabled: false
 
-RETURN = r'''
+- name: Change only behavior for an existing override (enabled defaults stay cluster-default)
+  vmware.vmware.cluster_drs_vm_overrides:
+    datacenter: DC01
+    cluster: Cluster01
+    state: present
+    vm_overrides:
+      - virtual_machine: vm-42
+        behavior: manual
+"""
+
+RETURN = r"""
 cluster:
-    description:
-        - Information about the target cluster
-    returned: On success
+    description: Display name and MOID of the cluster that was configured.
+    returned: success
     type: dict
     sample:
-        moid: cluster-79828,
-        name: test-cluster
+        name: Cluster01
+        moid: cluster-21
 overrides_removed:
     description:
-        - Information about the VM overrides that were removed
-        - Each entry has the virtual machine MOID, name, behavior, and enabled state
-    returned: On success
+        - One entry per VM whose DRS override was removed in this run.
+        - Each entry only contains C(vm_moid) and C(vm_name); use M(vmware.vmware.cluster_drs_vm_overrides_info) to read behavior and enabled before/after.
+    returned: success
     type: list
     sample:
-        - virtual_machine_moid: vm-1234567890
-          virtual_machine_name: MyVirtualMachine
-          behavior: fullyAutomated
-          enabled: true
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
 overrides_added:
     description:
-        - Information about the VM overrides that were added
-        - Each entry has the virtual machine MOID, name, behavior, and enabled state
-    returned: On success
+        - One entry per VM whose DRS override was added. Each entry only contains C(vm_moid) and C(vm_name).
+    returned: success
     type: list
     sample:
-        - virtual_machine_moid: vm-1234567890
-          virtual_machine_name: MyVirtualMachine
-          behavior: fullyAutomated
-          enabled: true
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
 overrides_updated:
     description:
-        - Information about the VM overrides that were updated
-        - Each entry has the virtual machine MOID, name, behavior, and enabled state
-    returned: On success
+        - One entry per VM whose DRS override was changed. Each entry only contains C(vm_moid) and C(vm_name).
+    returned: success
     type: list
     sample:
-        - virtual_machine_moid: vm-1234567890
-          virtual_machine_name: MyVirtualMachine
-          behavior: fullyAutomated
-          enabled: true
-'''
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
+"""
 
 try:
     from pyVmomi import vim, vmodl
@@ -195,105 +204,31 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
-    ModulePyvmomiBase
+    ModulePyvmomiBase,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
-    base_argument_spec
+    base_argument_spec,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import (
     TaskError,
-    RunningTaskMonitor
+    RunningTaskMonitor,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._cluster_settings import (
+    BaseVmOverrideChangeTracker,
 )
 from ansible.module_utils.common.text.converters import to_native
 
 
-class VmOverrideChangeTracker:
-    """
-    Compare desired VM override dicts (by VM MoID) to current cluster overrides.
-
-    current_vm_overrides and param_vm_overrides are dicts:
-        moid -> {'virtual_machine': vim.VirtualMachine, 'behavior': str, 'enabled': bool}
-    """
-
+class DrsVmOverrideChangeTracker(BaseVmOverrideChangeTracker):
     def __init__(self, current_vm_overrides, param_vm_overrides):
-        """
-        Load the live cluster overrides and the module's desired overrides.
+        super().__init__(current_vm_overrides, param_vm_overrides)
 
-        Populates to_add, to_update, to_remove, and final_overrides when process_* methods run.
-        to_add, to_update, and to_remove show which overrides need to be added, updated, and removed.
-        final_overrides is the complete set of overrides that should exist after processing. Mainly used
-        when state is present and append is false.
-        """
-        self.current_vm_overrides = current_vm_overrides
-        self.param_vm_overrides = param_vm_overrides
-        self.to_add = {}
-        self.to_update = {}
-        self.to_remove = {}
-        self.final_overrides = {}
-
-    @staticmethod
-    def _overrides_differ(desired, current):
-        """
-        Compare desired and current override dicts for the same VM.
-
-        Returns True when behavior or enabled differs; used to decide whether an existing override needs an update.
-        """
-        return (
-            desired.get('behavior') != current.get('behavior') or
-            desired.get('enabled') != current.get('enabled')
+    def _overrides_differ(self, desired, current):
+        return BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+            desired, current, "behavior"
+        ) or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+            desired, current, "enabled"
         )
-
-    def has_changes(self):
-        """
-        Return True after process_absent_changes or process_present_changes if work is pending.
-
-        Check this before applying API calls so check mode and idempotency stay correct.
-        """
-        return (
-            len(self.to_add) > 0 or
-            len(self.to_update) > 0 or
-            len(self.to_remove) > 0
-        )
-
-    def process_absent_changes(self):
-        """
-        Used when module state is absent: remove overrides only for VMs named in the task.
-
-        Starts from current cluster overrides, then records removals and drops those keys from final_overrides.
-        """
-        self.final_overrides = self.current_vm_overrides.copy()
-        for moid in self.param_vm_overrides.keys():
-            if moid in self.current_vm_overrides:
-                self.to_remove[moid] = self.current_vm_overrides[moid]
-                del self.final_overrides[moid]
-
-        return
-
-    def process_present_changes(self, append=True):
-        """
-        Used when module state is present: merge desired overrides into the cluster view.
-
-        With append True, existing overrides not listed in the task are kept. With append False, final_overrides
-        matches the task exactly and extra cluster overrides are marked for removal.
-        """
-        if append:
-            self.final_overrides = self.current_vm_overrides.copy()
-
-        for moid, desired in self.param_vm_overrides.items():
-            if moid not in self.current_vm_overrides:
-                self.to_add[moid] = desired
-
-            elif self._overrides_differ(desired, self.current_vm_overrides[moid]):
-                self.to_update[moid] = desired
-
-            self.final_overrides[moid] = desired
-
-        if append:
-            return
-
-        for moid, current in self.current_vm_overrides.items():
-            if moid not in self.final_overrides:
-                self.to_remove[moid] = current
 
 
 class VMwareDrsVmOverrides(ModulePyvmomiBase):
@@ -305,50 +240,64 @@ class VMwareDrsVmOverrides(ModulePyvmomiBase):
         """
         super().__init__(module)
 
-        datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
-        self.cluster = self.get_cluster_by_name_or_moid(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
+        datacenter = self.get_datacenter_by_name_or_moid(
+            self.params.get("datacenter"), fail_on_missing=True
+        )
+        self.cluster = self.get_cluster_by_name_or_moid(
+            self.params.get("cluster"), fail_on_missing=True, datacenter=datacenter
+        )
         try:
             current_drs_config = self.cluster.configurationEx.drsConfig
         except AttributeError:
-            self.module.fail_json(msg="DRS configuration is not available on the cluster. Please enable DRS before using this module.")
-        if (not current_drs_config.enableVmBehaviorOverrides):
-            self.module.fail_json(msg="DRS VM override settings are not enabled on the cluster. Please enable them before using this module.")
-        if (not current_drs_config.enabled):
-            self.module.fail_json(msg="DRS is not enabled on the cluster. Please enable it before using this module.")
+            self.module.fail_json(
+                msg="DRS configuration is not available on the cluster. Please enable DRS before using this module."
+            )
+        if not current_drs_config.enableVmBehaviorOverrides:
+            self.module.fail_json(
+                msg="DRS VM override settings are not enabled on the cluster. Please enable them before using this module."
+            )
+        if not current_drs_config.enabled:
+            self.module.fail_json(
+                msg="DRS is not enabled on the cluster. Please enable it before using this module."
+            )
 
     def _lookup_vms_in_param_overrides(self):
         """
         Look up each virtual_machine from vm_overrides and key the result by VM MoID.
 
-        Each value holds the vim.VirtualMachine, desired DRS behavior, and enabled flag. Missing VMs fail the module.
+        Returns a dict keyed by VM MoID. Each value is a dict with the virtual machine object, and any desired override settings.
         """
         remapped_vm_overrides = dict()
-        for vm_override in self.params.get('vm_overrides'):
-            search_results = self.get_objs_by_name_or_moid([vim.VirtualMachine], vm_override.get('virtual_machine'), return_all=False)
+        for vm_override in self.params.get("vm_overrides"):
+            search_results = self.get_objs_by_name_or_moid(
+                [vim.VirtualMachine],
+                vm_override.get("virtual_machine"),
+                return_all=False,
+            )
             if len(search_results) == 0:
-                self.module.fail_json(msg="Unable to find virtual machine with name or MOID %s" % vm_override.get('virtual_machine'))
+                self.module.fail_json(
+                    msg="Unable to find virtual machine with name or MOID %s"
+                    % vm_override.get("virtual_machine")
+                )
 
             vm = search_results[0]
-            remapped_vm_overrides[vm._GetMoId()] = {
-                'virtual_machine': vm,
-                'behavior': vm_override.get('drs_behavior'),
-                'enabled': vm_override.get('enable')
-            }
+            drs_config_spec = vim.cluster.DrsVmConfigInfo(key=vm)
+            if "behavior" in vm_override:
+                drs_config_spec.behavior = vm_override["behavior"]
+            if "enabled" in vm_override:
+                drs_config_spec.enabled = vm_override["enabled"]
+            remapped_vm_overrides[vm._GetMoId()] = drs_config_spec
         return remapped_vm_overrides
 
     def _lookup_current_vm_overrides(self):
         """
         Read cluster.configurationEx.drsVmConfig into a dict keyed by VM MoID.
 
-        Values mirror the structure used for desired overrides (VM object, behavior, enabled).
+        Returns a dict keyed by VM MoID. Each value is a vim.cluster.DrsVmConfigInfo object.
         """
         current_vm_overrides = dict()
         for vm_override in self.cluster.configurationEx.drsVmConfig:
-            current_vm_overrides[vm_override.key._GetMoId()] = {
-                'virtual_machine': vm_override.key,
-                'behavior': vm_override.behavior,
-                'enabled': vm_override.enabled
-            }
+            current_vm_overrides[vm_override.key._GetMoId()] = vm_override
         return current_vm_overrides
 
     def get_overrides_changes(self):
@@ -357,14 +306,14 @@ class VMwareDrsVmOverrides(ModulePyvmomiBase):
 
         Dispatches to process_absent_changes or process_present_changes based on state and append.
         """
-        change_tracker = VmOverrideChangeTracker(
+        change_tracker = DrsVmOverrideChangeTracker(
             current_vm_overrides=self._lookup_current_vm_overrides(),
-            param_vm_overrides=self._lookup_vms_in_param_overrides()
+            param_vm_overrides=self._lookup_vms_in_param_overrides(),
         )
-        if self.params.get('state') == 'absent':
+        if self.params.get("state") == "absent":
             change_tracker.process_absent_changes()
-        elif self.params.get('state') == 'present':
-            change_tracker.process_present_changes(append=self.params.get('append'))
+        elif self.params.get("state") == "present":
+            change_tracker.process_present_changes(append=self.params.get("append"))
 
         return change_tracker
 
@@ -378,15 +327,13 @@ class VMwareDrsVmOverrides(ModulePyvmomiBase):
         cluster_config_spec.drsVmConfigSpec = []
         kwargs = dict(operation=operation)
         for vm_override in vm_overrides:
-            if operation == 'remove':
-                kwargs['removeKey'] = vm_override['virtual_machine']
+            if operation == "remove":
+                kwargs["removeKey"] = vm_override.key
             else:
-                kwargs['info'] = vim.cluster.DrsVmConfigInfo(
-                    key=vm_override['virtual_machine'],
-                    behavior=vm_override['behavior'],
-                    enabled=vm_override['enabled']
-                )
-            cluster_config_spec.drsVmConfigSpec.append(vim.cluster.DrsVmConfigSpec(**kwargs))
+                kwargs["info"] = vm_override
+            cluster_config_spec.drsVmConfigSpec.append(
+                vim.cluster.DrsVmConfigSpec(**kwargs)
+            )
 
         return cluster_config_spec
 
@@ -399,45 +346,52 @@ class VMwareDrsVmOverrides(ModulePyvmomiBase):
         cluster_config_spec = self._create_drs_vm_config_spec(vm_overrides, operation)
 
         try:
-            task = self.cluster.ReconfigureComputeResource_Task(cluster_config_spec, True)
-            _, task_result = RunningTaskMonitor(task).wait_for_completion()   # pylint: disable=disallowed-name
-        except (vmodl.RuntimeFault, vmodl.MethodFault)as vmodl_fault:
+            task = self.cluster.ReconfigureComputeResource_Task(
+                cluster_config_spec, True
+            )
+            _, task_result = RunningTaskMonitor(  # pylint: disable=disallowed-name
+                task
+            ).wait_for_completion()
+        except (vmodl.RuntimeFault, vmodl.MethodFault) as vmodl_fault:
             self.module.fail_json(msg=to_native(vmodl_fault.msg))
         except TaskError as task_e:
             self.module.fail_json(msg=to_native(task_e))
         except Exception as generic_exc:
-            self.module.fail_json(msg="Failed to update cluster due to exception %s" % to_native(generic_exc))
+            self.module.fail_json(
+                msg="Failed to update cluster due to exception %s"
+                % to_native(generic_exc)
+            )
 
         return task_result
-
-
-def format_change_list_for_json(change_list):
-    return [
-        {
-            'virtual_machine_moid': change['virtual_machine']._GetMoId(),
-            'virtual_machine_name': change['virtual_machine'].name,
-            'behavior': change['behavior'],
-            'enabled': change['enabled']
-        }
-        for change in change_list
-    ]
 
 
 def main():
     module = AnsibleModule(
         argument_spec={
-            **base_argument_spec(), **dict(
-                cluster=dict(type='str', required=True, aliases=['cluster_name']),
-                datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
-                state=dict(type='str', choices=['present', 'absent'], default='present'),
-                append=dict(type='bool', required=False, default=True),
+            **base_argument_spec(),
+            **dict(
+                cluster=dict(type="str", required=True, aliases=["cluster_name"]),
+                datacenter=dict(type="str", required=True, aliases=["datacenter_name"]),
+                state=dict(
+                    type="str", choices=["present", "absent"], default="present"
+                ),
+                append=dict(type="bool", required=False, default=True),
                 vm_overrides=dict(
-                    type='list', required=True, elements='dict', options=dict(
-                        virtual_machine=dict(type='str', required=True),
-                        drs_behavior=dict(type='str', required=False, default='fullyAutomated', choices=['fullyAutomated', 'manual', 'partiallyAutomated']),
-                        enable=dict(type='bool', required=False, default=True),
-                    )),
-            )
+                    type="list",
+                    required=True,
+                    elements="dict",
+                    options=dict(
+                        virtual_machine=dict(type="str", required=True),
+                        behavior=dict(
+                            type="str",
+                            required=False,
+                            default="fullyAutomated",
+                            choices=["fullyAutomated", "manual", "partiallyAutomated"],
+                        ),
+                        enabled=dict(type="bool", required=False, default=True),
+                    ),
+                ),
+            ),
         },
         supports_check_mode=True,
     )
@@ -451,27 +405,43 @@ def main():
     )
 
     cluster_drs = VMwareDrsVmOverrides(module)
-    result['cluster']['name'] = cluster_drs.cluster.name
-    result['cluster']['moid'] = cluster_drs.cluster._GetMoId()
+    result["cluster"]["name"] = cluster_drs.cluster.name
+    result["cluster"]["moid"] = cluster_drs.cluster._GetMoId()
 
     change_tracker = cluster_drs.get_overrides_changes()
     if change_tracker.has_changes():
-        result['changed'] = True
-        result['overrides_removed'] = format_change_list_for_json(change_tracker.to_remove.values())
-        result['overrides_added'] = format_change_list_for_json(change_tracker.to_add.values())
-        result['overrides_updated'] = format_change_list_for_json(change_tracker.to_update.values())
+        result["changed"] = True
+        result["overrides_removed"] = (
+            BaseVmOverrideChangeTracker.format_override_specs_for_json(
+                change_tracker.to_remove.values()
+            )
+        )
+        result["overrides_added"] = (
+            BaseVmOverrideChangeTracker.format_override_specs_for_json(
+                change_tracker.to_add.values()
+            )
+        )
+        result["overrides_updated"] = (
+            BaseVmOverrideChangeTracker.format_override_specs_for_json(
+                change_tracker.to_update.values()
+            )
+        )
         if not module.check_mode:
-            if change_tracker.to_add or change_tracker.to_update:
+            if change_tracker.to_add:
                 cluster_drs.apply_drs_configuration(
-                    list(change_tracker.to_add.values()) + list(change_tracker.to_update.values()),
-                    operation="add"
+                    change_tracker.to_add.values(), operation="add"
                 )
-
+            if change_tracker.to_update:
+                cluster_drs.apply_drs_configuration(
+                    change_tracker.to_update.values(), operation="edit"
+                )
             if change_tracker.to_remove:
-                cluster_drs.apply_drs_configuration(change_tracker.to_remove.values(), operation="remove")
+                cluster_drs.apply_drs_configuration(
+                    change_tracker.to_remove.values(), operation="remove"
+                )
 
     module.exit_json(**result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/cluster_drs_vm_overrides.py
+++ b/plugins/modules/cluster_drs_vm_overrides.py
@@ -86,14 +86,12 @@ options:
                         for the placement with a host, then automatically implements placement recommendations at power on.
                 type: str
                 required: false
-                default: fullyAutomated
                 choices: [ fullyAutomated, manual, partiallyAutomated ]
             enabled:
                 description:
                     - Whether the override settings are enabled for the virtual machine.
                 type: bool
                 required: false
-                default: true
 
 extends_documentation_fragment:
     - vmware.vmware.base_options
@@ -385,10 +383,9 @@ def main():
                         behavior=dict(
                             type="str",
                             required=False,
-                            default="fullyAutomated",
                             choices=["fullyAutomated", "manual", "partiallyAutomated"],
                         ),
-                        enabled=dict(type="bool", required=False, default=True),
+                        enabled=dict(type="bool", required=False),
                     ),
                 ),
             ),

--- a/plugins/modules/cluster_drs_vm_overrides_info.py
+++ b/plugins/modules/cluster_drs_vm_overrides_info.py
@@ -6,17 +6,24 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: cluster_drs_vm_overrides_info
 short_description: Get Distributed Resource Scheduler (DRS) VM override settings.
 description:
     - Gets DRS VM override settings on VMware vSphere clusters.
+    - Although VM overrides are shown in a unified view in vCenter, this module only gets the DRS override settings.
 author:
     - Ansible Cloud Team (@ansible-collections)
+
+seealso:
+    - module: vmware.vmware.cluster_drs
+    - module: vmware.vmware.cluster_ha_vm_overrides_info
+    - module: vmware.vmware.cluster_drs_vm_overrides
 
 options:
     cluster:
@@ -34,25 +41,23 @@ options:
 
 extends_documentation_fragment:
     - vmware.vmware.base_options
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Gather VM override settings for a cluster
   vmware.vmware.cluster_drs_vm_overrides_info:
     datacenter: DC01
     cluster: Cluster01
-  register: _out
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 cluster:
-    description:
-        - Information about the target cluster
-    returned: On success
+    description: Display name and MOID of the cluster that was queried.
+    returned: success
     type: dict
     sample:
-        moid: cluster-79828,
-        name: test-cluster
+        name: Cluster01
+        moid: cluster-21
 vm_overrides:
     description:
         - Information about the VM overrides for the cluster
@@ -60,18 +65,18 @@ vm_overrides:
     returned: On success
     type: list
     sample:
-        - virtual_machine_moid: vm-1234567890
-          virtual_machine_name: MyVirtualMachine
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
           behavior: fullyAutomated
           enabled: true
-'''
+"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
-    ModulePyvmomiBase
+    ModulePyvmomiBase,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
-    base_argument_spec
+    base_argument_spec,
 )
 
 
@@ -84,8 +89,12 @@ class VMwareDrsVmOverridesInfo(ModulePyvmomiBase):
         """
         super().__init__(module)
 
-        datacenter = self.get_datacenter_by_name_or_moid(self.params.get('datacenter'), fail_on_missing=True)
-        self.cluster = self.get_cluster_by_name_or_moid(self.params.get('cluster'), fail_on_missing=True, datacenter=datacenter)
+        datacenter = self.get_datacenter_by_name_or_moid(
+            self.params.get("datacenter"), fail_on_missing=True
+        )
+        self.cluster = self.get_cluster_by_name_or_moid(
+            self.params.get("cluster"), fail_on_missing=True, datacenter=datacenter
+        )
 
     def lookup_current_vm_overrides(self):
         """
@@ -93,24 +102,13 @@ class VMwareDrsVmOverridesInfo(ModulePyvmomiBase):
 
         Returns an empty dict if DRS config is missing, DRS is off, or VM behavior overrides are disabled on the cluster.
         """
-        try:
-            current_drs_config = self.cluster.configurationEx.drsConfig
-        except AttributeError:
-            return {}
-
-        if (not current_drs_config.enableVmBehaviorOverrides):
-            return {}
-
-        if (not current_drs_config.enabled):
-            return {}
-
         current_vm_overrides = dict()
-        for vm_override in self.cluster.configurationEx.drsVmConfig:
+        for vm_override in getattr(self.cluster.configurationEx, "drsVmConfig", []):
             current_vm_overrides[vm_override.key._GetMoId()] = {
-                'virtual_machine_moid': vm_override.key._GetMoId(),
-                'virtual_machine_name': vm_override.key.name,
-                'behavior': vm_override.behavior,
-                'enabled': vm_override.enabled
+                "vm_moid": vm_override.key._GetMoId(),
+                "vm_name": vm_override.key.name,
+                "behavior": vm_override.behavior,
+                "enabled": vm_override.enabled,
             }
         return current_vm_overrides
 
@@ -118,10 +116,11 @@ class VMwareDrsVmOverridesInfo(ModulePyvmomiBase):
 def main():
     module = AnsibleModule(
         argument_spec={
-            **base_argument_spec(), **dict(
-                cluster=dict(type='str', required=True, aliases=['cluster_name']),
-                datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
-            )
+            **base_argument_spec(),
+            **dict(
+                cluster=dict(type="str", required=True, aliases=["cluster_name"]),
+                datacenter=dict(type="str", required=True, aliases=["datacenter_name"]),
+            ),
         },
         supports_check_mode=True,
     )
@@ -133,12 +132,12 @@ def main():
     )
 
     cluster_drs = VMwareDrsVmOverridesInfo(module)
-    result['cluster']['name'] = cluster_drs.cluster.name
-    result['cluster']['moid'] = cluster_drs.cluster._GetMoId()
-    result['vm_overrides'] = list(cluster_drs.lookup_current_vm_overrides().values())
+    result["cluster"]["name"] = cluster_drs.cluster.name
+    result["cluster"]["moid"] = cluster_drs.cluster._GetMoId()
+    result["vm_overrides"] = list(cluster_drs.lookup_current_vm_overrides().values())
 
     module.exit_json(**result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/cluster_ha.py
+++ b/plugins/modules/cluster_ha.py
@@ -306,6 +306,9 @@ from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks impor
 from ansible_collections.vmware.vmware.plugins.module_utils._advanced_settings import (
     AdvancedSettings
 )
+from ansible_collections.vmware.vmware.plugins.module_utils._cluster_settings import (
+    ClusterSettingsRemapper
+)
 from ansible.module_utils.common.text.converters import to_native
 
 
@@ -323,9 +326,7 @@ class VmwareCluster(ModulePyvmomiBase):
 
     @property
     def storage_pdl_response_mode(self):
-        if self.params['storage_pdl_response_mode'] == 'restart':
-            return 'restartAggressive'
-        return self.params['storage_pdl_response_mode']
+        return ClusterSettingsRemapper.storage_pdl_response_mode(self.params['storage_pdl_response_mode'])
 
     @property
     def host_failure_response_restart_vms(self):
@@ -335,9 +336,7 @@ class VmwareCluster(ModulePyvmomiBase):
 
     @property
     def storage_apd_restart_vms(self):
-        if self.params['storage_apd_response']['restart_vms']:
-            return 'reset'
-        return 'none'
+        return ClusterSettingsRemapper.storage_apd_restart_vms(self.params['storage_apd_response']['restart_vms'])
 
     @property
     def ac_failover_hosts(self):

--- a/plugins/modules/cluster_ha_vm_overrides.py
+++ b/plugins/modules/cluster_ha_vm_overrides.py
@@ -328,6 +328,12 @@ class HaVmOverrideChangeTracker(BaseVmOverrideChangeTracker):
         super().__init__(current_vm_overrides, param_vm_overrides)
 
     def _overrides_differ(self, desired, current):
+        if not getattr(desired, "dasSettings"):
+            return False
+
+        if not getattr(current, "dasSettings"):
+            return True
+
         desired = desired.dasSettings
         current = current.dasSettings
         if (
@@ -405,6 +411,8 @@ class HaVmOverrideChangeTracker(BaseVmOverrideChangeTracker):
             )
         ):
             return True
+
+        return False
 
 
 class VMwareHaVmOverrides(ModulePyvmomiBase):

--- a/plugins/modules/cluster_ha_vm_overrides.py
+++ b/plugins/modules/cluster_ha_vm_overrides.py
@@ -106,8 +106,9 @@ options:
                     use_cluster_settings:
                         description:
                             - If true, use cluster-wide monitoring settings; other keys in this section are ignored.
+                            - If this is not set but the vm_monitoring dictionary is defined, the module will default it to false
+                              (meaning custom VM settings will be used).
                         type: bool
-                        default: true
                     mode:
                         description:
                             - Sets the state of the virtual machine health monitoring service.
@@ -462,7 +463,7 @@ class VMwareHaVmOverrides(ModulePyvmomiBase):
             )
         if (
             override_params.get("storage_apd_response") is not None
-            or override_params.get("storage_pdl_response") is not None
+            or override_params.get("storage_pdl_response_mode") is not None
         ):
             das_settings.vmComponentProtectionSettings = (
                 self._create_vm_component_protection_settings_spec(override_params)
@@ -618,7 +619,7 @@ def main():
                                 minimum_uptime=dict(type="int"),
                                 maximum_resets=dict(type="int"),
                                 maximum_resets_window=dict(type="int"),
-                                use_cluster_settings=dict(type="bool", default=True),
+                                use_cluster_settings=dict(type="bool"),
                             ),
                         ),
                         storage_apd_response=dict(

--- a/plugins/modules/cluster_ha_vm_overrides.py
+++ b/plugins/modules/cluster_ha_vm_overrides.py
@@ -1,0 +1,697 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: cluster_ha_vm_overrides
+short_description: Manage vSphere High Availability (HA) VM override settings.
+description:
+    - Manages HA VM override settings on VMware vSphere clusters.
+    - VM override settings override cluster-wide HA defaults for individual virtual machines.
+    - You must enable HA before you can rely on these settings. See module M(vmware.vmware.cluster_ha).
+    - VMs must exist in the cluster before you can set their override settings.
+    - When a VM is removed from the cluster, its override settings are also automatically removed.
+    - Although VM overrides are shown in a unified view in vCenter, this module only manages the HA override settings.
+      Removing a VM override does not remove all overrides, just the HA related ones.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+seealso:
+    - module: vmware.vmware.cluster_ha
+    - module: vmware.vmware.cluster_ha_vm_overrides_info
+    - module: vmware.vmware.cluster_drs_vm_overrides
+
+options:
+    cluster:
+        description:
+            - The name of the cluster to be managed.
+        type: str
+        required: true
+        aliases: [ cluster_name ]
+    datacenter:
+        description:
+            - The name of the datacenter.
+        type: str
+        required: true
+        aliases: [ datacenter_name ]
+    state:
+        description:
+            - The state of the VM override settings.
+            - If set to V(present) and O(append) is true, the VM override settings are added or updatedif needed.
+            - If set to V(present) and O(append) is false, the VM override settings in the cluster will be updated to match the desired configuration exactly.
+              Any existing VM (HA) override settings that are not present in the desired configuration will be reset to the vCenter default values.
+            - If set to V(absent), the VM override settings are removed from the cluster if they exist.
+        type: str
+        choices: [ present, absent ]
+        default: present
+    append:
+        description:
+            - Whether to add the VM override settings if they do not exist.
+            - If set to V(true), the VM override settings are added if needed and any existing VM override settings are not modified.
+            - If set to V(false), the VM override settings are updated to match the desired configuration exactly.
+            - This parameter is ignored if O(state) is set to V(absent).
+        type: bool
+        required: false
+        default: true
+    vm_overrides:
+        description:
+            - A list of virtual machine override settings to apply to the cluster.
+            - Each entry describes an override for one virtual machine.
+        type: list
+        elements: dict
+        required: true
+        suboptions:
+            virtual_machine:
+                description:
+                    - The name or MOID of the virtual machine for which to manage the override settings.
+                    - Using the MOID is recommended as the name lookup takes longer and cannot handle duplicate names.
+                type: str
+                required: true
+            restart_priority_timeout:
+                description:
+                    - Maximum time in seconds lower-priority VMs wait for higher-priority VMs to become ready during failover.
+                    - Use V(-1) to use the cluster default for this VM override.
+                type: int
+                required: false
+            restart_priority:
+                description:
+                    - Set the default priority HA gives to a virtual machine if sufficient capacity is not available
+                      to power on all failed virtual machines.
+                    - Used only when VM monitoring mode (at the cluster or VM level) is V(vmAndAppMonitoring) or V(vmMonitoringOnly).
+                type: str
+                choices: [ 'lowest', 'low', 'medium', 'high', 'highest' ]
+            host_isolation_response:
+                description:
+                    - Specify how VMs should be handled if an ESXi host determines it can no longer reach the rest of the cluster.
+                    - If set to V(none), no action is taken.
+                    - If set to V(powerOff), VMs are powered off via the hypervisor.
+                    - If set to V(shutdown), VMs are shut down via the guest operating system.
+                type: str
+                choices: ['none', 'powerOff', 'shutdown']
+            vm_monitoring:
+                description:
+                    - Configures VM health monitoring and automated responses when a VM is unhealthy.
+                type: dict
+                suboptions:
+                    use_cluster_settings:
+                        description:
+                            - If true, use cluster-wide monitoring settings; other keys in this section are ignored.
+                        type: bool
+                        default: true
+                    mode:
+                        description:
+                            - Sets the state of the virtual machine health monitoring service.
+                            - If set to V(vmAndAppMonitoring), HA will respond to both VM and vApp heartbeat failures.
+                            - If set to V(vmMonitoringDisabled), HA will only respond to vApp heartbeat failures.
+                            - If set to V(vmMonitoringOnly), HA will only respond to VM heartbeat failures.
+                        type: str
+                        choices: ['vmAndAppMonitoring', 'vmMonitoringOnly', 'vmMonitoringDisabled']
+                    failure_interval:
+                        description:
+                            - The number of seconds to wait after a VM heartbeat fails before declaring the VM as unhealthy.
+                            - Valid only when O(vm_overrides[].vm_monitoring.mode) is V(vmAndAppMonitoring) or V(vmMonitoringOnly).
+                        type: int
+                    minimum_uptime:
+                        description:
+                            - The number of seconds to wait for the VM's heartbeat to stabilize after it was powered reset.
+                            - Valid only when O(vm_overrides[].vm_monitoring.mode) is V(vmAndAppMonitoring) or V(vmMonitoringOnly).
+                        type: int
+                    maximum_resets:
+                        description:
+                            - The maximum number of automated resets allowed in response to a VM becoming unhealthy
+                            - Valid only when O(vm_overrides[].vm_monitoring.mode) is V(vmAndAppMonitoring) or V(vmMonitoringOnly).
+                        type: int
+                    maximum_resets_window:
+                        description:
+                            - The number of seconds during in which O(vm_overrides[].vm_monitoring.maximum_resets) resets
+                              can occur before automated responses stop.
+                            - Valid only when O(vm_overrides[].vm_monitoring.mode) is V(vmAndAppMonitoring) or V(vmMonitoringOnly).
+                            - The value of -1 specifies no window.
+                        type: int
+            storage_apd_response:
+                description:
+                    - Configures what steps are taken when storage All Paths Down (APD) events occur.
+                type: dict
+                suboptions:
+                    mode:
+                        description:
+                            - Set the response in the event of All Paths Down (APD) for storage.
+                            - APD differs from PDL, in that APD is assumed to be a transient outage and PDL is permanent.
+                            - V(disabled) means no action will be taken
+                            - V(warning) means no action will be taken, but events will be generated for logging purposes.
+                            - V(restartConservative) means VMs will be powered off if  HA determines another host can support the VM.
+                            - V(restartAggressive) means VMs will be powered off if HA determines the VM can be restarted on a different host,
+                              or if HA cannot detect the resources on other hosts because of network connectivity loss.
+                        type: str
+                        choices: [ 'disabled', 'warning', 'restartConservative', 'restartAggressive' ]
+                    delay:
+                        description:
+                            - Set the response recovery delay time in seconds if storage is in an APD failure state.
+                            - This is only used if O(vm_overrides[].storage_apd_response.mode) is V(restartConservative) or V(restartAggressive).
+                        type: int
+                    restart_vms:
+                        description:
+                            - If true, VMs will be restarted when possible if storage is in an APD failure state.
+                            - This is only used if O(vm_overrides[].storage_apd_response.mode) is V(restartConservative) V(restartAggressive).
+                        type: bool
+            storage_pdl_response_mode:
+                description:
+                    - Set the response in the event of permanent Device Loss (PDL) for storage.
+                    - APD differs from PDL, in that APD is assumed to be a transient outage and PDL is permanent.
+                    - V(disabled) means no action will be taken
+                    - V(warning) means no action will be taken, but events will be generated for logging purposes.
+                    - V(restart) means all VMs will be powered off. If hosts still have access to the datastore,
+                      affected VMs will be restarted on that host.
+                type: str
+                choices: ['disabled', 'warning', 'restart']
+
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+"""
+
+EXAMPLES = r"""
+- name: Enable HA
+  vmware.vmware.cluster_ha:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: DC01
+    cluster_name: Cluster01
+    enable: true
+  delegate_to: localhost
+
+- name: Ensure a VM HA override is present
+  vmware.vmware.cluster_ha_vm_overrides:
+    datacenter: DC01
+    cluster: Cluster01
+    state: present
+    append: true
+    vm_overrides:
+      - virtual_machine: "{{ lookup('vmware.vmware.moid_from_path', '/DC01/vm/MyVirtualMachine') }}"
+        restart_priority: high
+        host_isolation_response: shutdown
+  register: _ha_override_present
+
+- name: Ensure a VM HA override with monitoring and storage protection
+  vmware.vmware.cluster_ha_vm_overrides:
+    datacenter: DC01
+    cluster: Cluster01
+    state: present
+    append: true
+    vm_overrides:
+      - virtual_machine: MyVirtualMachine
+        restart_priority: low
+        host_isolation_response: powerOff
+        restart_priority_timeout: 120
+        vm_monitoring:
+          mode: vmAndAppMonitoring
+          failure_interval: 30
+          minimum_uptime: 120
+          maximum_resets: 3
+          maximum_resets_window: 180
+          use_cluster_settings: false
+        storage_apd_response:
+          mode: restartConservative
+          delay: 180
+          restart_vms: true
+        storage_pdl_response_mode: warning
+
+- name: Ensure a VM HA override is absent
+  vmware.vmware.cluster_ha_vm_overrides:
+    datacenter: DC01
+    cluster: Cluster01
+    state: absent
+    vm_overrides:
+      - virtual_machine: MyVirtualMachine
+
+- name: Clear all VM HA overrides
+  vmware.vmware.cluster_ha_vm_overrides:
+    datacenter: DC01
+    cluster: Cluster01
+    state: present
+    append: false
+    vm_overrides: []
+
+- name: Ensure only these HA overrides are present
+  vmware.vmware.cluster_ha_vm_overrides:
+    datacenter: DC01
+    cluster: Cluster01
+    state: present
+    append: false
+    vm_overrides:
+      - virtual_machine: MyVirtualMachine
+        restart_priority: high
+        host_isolation_response: powerOff
+      - virtual_machine: MyOtherVirtualMachine
+        restart_priority: low
+        host_isolation_response: none
+"""
+
+RETURN = r"""
+cluster:
+    description: Display name and MOID of the cluster that was configured.
+    returned: success
+    type: dict
+    sample:
+        name: Cluster01
+        moid: cluster-21
+overrides_removed:
+    description:
+        - One entry per VM whose HA override was removed in this run (for example C(state=absent), replace mode with
+          C(append=false), or clearing non-desired overrides).
+        - Each entry only contains C(vm_moid) and C(vm_name); it does not echo prior HA field values.
+    returned: success
+    type: list
+    sample:
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
+overrides_added:
+    description:
+        - One entry per VM whose HA override was added. Each entry only contains C(vm_moid) and C(vm_name).
+    returned: success
+    type: list
+    sample:
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
+overrides_updated:
+    description:
+        - One entry per VM whose HA override was changed. Each entry only contains C(vm_moid) and C(vm_name).
+    returned: success
+    type: list
+    sample:
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
+"""
+
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    base_argument_spec,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import (
+    TaskError,
+    RunningTaskMonitor,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._cluster_settings import (
+    ClusterSettingsRemapper,
+    BaseVmOverrideChangeTracker,
+)
+from ansible.module_utils.common.text.converters import to_native
+
+
+def set_if_defined_and_not_none(spec, key, value):
+    if value is not None:
+        setattr(spec, key, value)
+
+
+class HaVmOverrideChangeTracker(BaseVmOverrideChangeTracker):
+    def __init__(self, current_vm_overrides, param_vm_overrides):
+        super().__init__(current_vm_overrides, param_vm_overrides)
+
+    def _overrides_differ(self, desired, current):
+        desired = desired.dasSettings
+        current = current.dasSettings
+        if (
+            BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "restartPriority"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "isolationResponse"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "restartPriorityTimeout"
+            )
+        ):
+            return True
+
+        if self._vm_monitoring_differ(desired, current):
+            return True
+
+        if self._component_protection_settings_differ(desired, current):
+            return True
+
+        return False
+
+    def _vm_monitoring_differ(self, desired, current):
+        if not getattr(desired, "vmToolsMonitoringSettings"):
+            return False
+
+        desired = desired.vmToolsMonitoringSettings
+        current = current.vmToolsMonitoringSettings
+        if (
+            BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "vmMonitoring"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "failureInterval"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "minUpTime"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "maxFailures"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "maxFailureWindow"
+            )
+        ):
+            return True
+
+    def _component_protection_settings_differ(self, desired, current):
+        if not getattr(desired, "vmComponentProtectionSettings"):
+            return False
+
+        desired = desired.vmComponentProtectionSettings
+        current = current.vmComponentProtectionSettings
+        if (
+            BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "vmStorageProtectionForAPD"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "vmTerminateDelayForAPDSec"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "vmReactionOnAPDCleared"
+            )
+            or BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+                desired, current, "vmStorageProtectionForPDL"
+            )
+        ):
+            return True
+
+
+class VMwareHaVmOverrides(ModulePyvmomiBase):
+    def __init__(self, module):
+        super().__init__(module)
+
+        datacenter = self.get_datacenter_by_name_or_moid(
+            self.params.get("datacenter"), fail_on_missing=True
+        )
+        self.cluster = self.get_cluster_by_name_or_moid(
+            self.params.get("cluster"), fail_on_missing=True, datacenter=datacenter
+        )
+        try:
+            das_config = self.cluster.configurationEx.dasConfig
+        except AttributeError:
+            self.module.fail_json(
+                msg="HA configuration is not available on the cluster. Configure HA before using this module."
+            )
+        if not das_config.enabled:
+            self.module.fail_json(
+                msg="HA is not enabled on the cluster. Enable HA before using this module."
+            )
+
+    def _convert_param_overrides_to_das_setting_specs(self):
+        override_specs = dict()
+        for override_params in self.params.get("vm_overrides"):
+            search_results = self.get_objs_by_name_or_moid(
+                [vim.VirtualMachine],
+                override_params.get("virtual_machine"),
+                return_all=False,
+            )
+            if len(search_results) == 0:
+                self.module.fail_json(
+                    msg="Unable to find virtual machine with name or MOID %s"
+                    % override_params.get("virtual_machine")
+                )
+
+            vm = search_results[0]
+            override_specs[vm._GetMoId()] = vim.cluster.DasVmConfigInfo(
+                key=vm, dasSettings=self._create_das_settings_spec(override_params)
+            )
+        return override_specs
+
+    def _create_das_settings_spec(self, override_params):
+        das_settings = vim.cluster.DasVmSettings()
+        set_if_defined_and_not_none(
+            das_settings, "restartPriority", override_params.get("restart_priority")
+        )
+        set_if_defined_and_not_none(
+            das_settings,
+            "isolationResponse",
+            override_params.get("host_isolation_response"),
+        )
+        set_if_defined_and_not_none(
+            das_settings,
+            "restartPriorityTimeout",
+            override_params.get("restart_priority_timeout"),
+        )
+        if override_params.get("vm_monitoring") is not None:
+            das_settings.vmToolsMonitoringSettings = (
+                self._create_vm_monitoring_settings_spec(
+                    override_params["vm_monitoring"]
+                )
+            )
+        if (
+            override_params.get("storage_apd_response") is not None
+            or override_params.get("storage_pdl_response") is not None
+        ):
+            das_settings.vmComponentProtectionSettings = (
+                self._create_vm_component_protection_settings_spec(override_params)
+            )
+
+        return das_settings
+
+    def _create_vm_monitoring_settings_spec(self, monitoring_params):
+        spec = vim.cluster.VmToolsMonitoringSettings()
+        if monitoring_params.get("use_cluster_settings"):
+            spec.clusterSettings = True
+            return spec
+
+        spec.clusterSettings = False
+        set_if_defined_and_not_none(spec, "vmMonitoring", monitoring_params.get("mode"))
+        set_if_defined_and_not_none(
+            spec, "failureInterval", monitoring_params.get("failure_interval")
+        )
+        set_if_defined_and_not_none(
+            spec, "minUpTime", monitoring_params.get("minimum_uptime")
+        )
+        set_if_defined_and_not_none(
+            spec, "maxFailures", monitoring_params.get("maximum_resets")
+        )
+        set_if_defined_and_not_none(
+            spec, "maxFailureWindow", monitoring_params.get("maximum_resets_window")
+        )
+        return spec
+
+    def _create_vm_component_protection_settings_spec(self, override_params):
+        spec = vim.cluster.VmComponentProtectionSettings()
+        apd = override_params.get("storage_apd_response")
+        if apd:
+            set_if_defined_and_not_none(
+                spec, "vmStorageProtectionForAPD", apd.get("mode")
+            )
+            set_if_defined_and_not_none(
+                spec, "vmTerminateDelayForAPDSec", apd.get("delay")
+            )
+            set_if_defined_and_not_none(
+                spec,
+                "vmReactionOnAPDCleared",
+                ClusterSettingsRemapper.storage_apd_restart_vms(apd.get("restart_vms")),
+            )
+
+        set_if_defined_and_not_none(
+            spec,
+            "vmStorageProtectionForPDL",
+            ClusterSettingsRemapper.storage_pdl_response_mode(
+                override_params.get("storage_pdl_response_mode"),
+            ),
+        )
+        return spec
+
+    def _lookup_current_vm_overrides(self):
+        current_vm_overrides = dict()
+        for vm_override in getattr(self.cluster.configurationEx, "dasVmConfig", list()):
+            current_vm_overrides[vm_override.key._GetMoId()] = vm_override
+        return current_vm_overrides
+
+    def get_overrides_changes(self):
+        change_tracker = HaVmOverrideChangeTracker(
+            current_vm_overrides=self._lookup_current_vm_overrides(),
+            param_vm_overrides=self._convert_param_overrides_to_das_setting_specs(),
+        )
+        if self.params.get("state") == "absent":
+            change_tracker.process_absent_changes()
+        elif self.params.get("state") == "present":
+            change_tracker.process_present_changes(append=self.params.get("append"))
+
+        return change_tracker
+
+    def _create_ha_vm_config_spec(self, vm_override_specs, operation):
+        cluster_config_spec = vim.cluster.ConfigSpecEx()
+        cluster_config_spec.dasVmConfigSpec = []
+        for vm_override_spec in vm_override_specs:
+            if operation == "remove":
+                spec_kwargs = dict(operation=operation, removeKey=vm_override_spec.key)
+            else:
+                spec_kwargs = dict(
+                    operation=operation,
+                    info=vm_override_spec,
+                )
+            cluster_config_spec.dasVmConfigSpec.append(
+                vim.cluster.DasVmConfigSpec(**spec_kwargs)
+            )
+
+        return cluster_config_spec
+
+    def apply_ha_vm_overrides(self, vm_overrides, operation):
+        cluster_config_spec = self._create_ha_vm_config_spec(vm_overrides, operation)
+
+        try:
+            task = self.cluster.ReconfigureComputeResource_Task(
+                cluster_config_spec, True
+            )
+            _, task_result = RunningTaskMonitor(   # pylint: disable=disallowed-name
+                task
+            ).wait_for_completion()
+        except (vmodl.RuntimeFault, vmodl.MethodFault) as vmodl_fault:
+            self.module.fail_json(msg=to_native(vmodl_fault.msg))
+        except TaskError as task_e:
+            self.module.fail_json(msg=to_native(task_e))
+        except Exception as generic_exc:
+            self.module.fail_json(
+                msg="Failed to update cluster with %s operation due to exception %s"
+                % (operation, to_native(generic_exc))
+            )
+
+        return task_result
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **base_argument_spec(),
+            **dict(
+                cluster=dict(type="str", required=True, aliases=["cluster_name"]),
+                datacenter=dict(type="str", required=True, aliases=["datacenter_name"]),
+                state=dict(
+                    type="str", choices=["present", "absent"], default="present"
+                ),
+                append=dict(type="bool", required=False, default=True),
+                vm_overrides=dict(
+                    type="list",
+                    required=True,
+                    elements="dict",
+                    options=dict(
+                        virtual_machine=dict(type="str", required=True),
+                        restart_priority=dict(
+                            type="str",
+                            required=False,
+                            choices=["lowest", "low", "medium", "high", "highest"],
+                        ),
+                        host_isolation_response=dict(
+                            type="str",
+                            required=False,
+                            choices=["none", "powerOff", "shutdown"],
+                        ),
+                        restart_priority_timeout=dict(type="int", required=False),
+                        vm_monitoring=dict(
+                            type="dict",
+                            options=dict(
+                                mode=dict(
+                                    type="str",
+                                    choices=[
+                                        "vmAndAppMonitoring",
+                                        "vmMonitoringOnly",
+                                        "vmMonitoringDisabled",
+                                    ],
+                                ),
+                                failure_interval=dict(type="int"),
+                                minimum_uptime=dict(type="int"),
+                                maximum_resets=dict(type="int"),
+                                maximum_resets_window=dict(type="int"),
+                                use_cluster_settings=dict(type="bool", default=True),
+                            ),
+                        ),
+                        storage_apd_response=dict(
+                            type="dict",
+                            options=dict(
+                                mode=dict(
+                                    type="str",
+                                    choices=[
+                                        "disabled",
+                                        "warning",
+                                        "restartConservative",
+                                        "restartAggressive",
+                                    ],
+                                ),
+                                delay=dict(type="int"),
+                                restart_vms=dict(type="bool"),
+                            ),
+                        ),
+                        storage_pdl_response_mode=dict(
+                            type="str", choices=["disabled", "warning", "restart"]
+                        ),
+                    ),
+                ),
+            ),
+        },
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        cluster=dict(),
+        overrides_removed=[],
+        overrides_added=[],
+        overrides_updated=[],
+    )
+
+    cluster_ha = VMwareHaVmOverrides(module)
+    result["cluster"]["name"] = cluster_ha.cluster.name
+    result["cluster"]["moid"] = cluster_ha.cluster._GetMoId()
+
+    change_tracker = cluster_ha.get_overrides_changes()
+    if change_tracker.has_changes():
+        result["changed"] = True
+        result["overrides_removed"] = (
+            BaseVmOverrideChangeTracker.format_override_specs_for_json(
+                change_tracker.to_remove.values()
+            )
+        )
+        result["overrides_added"] = (
+            BaseVmOverrideChangeTracker.format_override_specs_for_json(
+                change_tracker.to_add.values()
+            )
+        )
+        result["overrides_updated"] = (
+            BaseVmOverrideChangeTracker.format_override_specs_for_json(
+                change_tracker.to_update.values()
+            )
+        )
+        if not module.check_mode:
+            if change_tracker.to_add:
+                cluster_ha.apply_ha_vm_overrides(
+                    change_tracker.to_add.values(), operation="add"
+                )
+            if change_tracker.to_update:
+                cluster_ha.apply_ha_vm_overrides(
+                    change_tracker.to_update.values(), operation="edit"
+                )
+            if change_tracker.to_remove:
+                cluster_ha.apply_ha_vm_overrides(
+                    change_tracker.to_remove.values(), operation="remove"
+                )
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cluster_ha_vm_overrides.py
+++ b/plugins/modules/cluster_ha_vm_overrides.py
@@ -47,7 +47,7 @@ options:
     state:
         description:
             - The state of the VM override settings.
-            - If set to V(present) and O(append) is true, the VM override settings are added or updatedif needed.
+            - If set to V(present) and O(append) is true, the VM override settings are added or updated if needed.
             - If set to V(present) and O(append) is false, the VM override settings in the cluster will be updated to match the desired configuration exactly.
               Any existing VM (HA) override settings that are not present in the desired configuration will be reset to the vCenter default values.
             - If set to V(absent), the VM override settings are removed from the cluster if they exist.
@@ -134,7 +134,7 @@ options:
                         type: int
                     maximum_resets_window:
                         description:
-                            - The number of seconds during in which O(vm_overrides[].vm_monitoring.maximum_resets) resets
+                            - The number of seconds during which O(vm_overrides[].vm_monitoring.maximum_resets) resets
                               can occur before automated responses stop.
                             - Valid only when O(vm_overrides[].vm_monitoring.mode) is V(vmAndAppMonitoring) or V(vmMonitoringOnly).
                             - The value of -1 specifies no window.
@@ -150,7 +150,7 @@ options:
                             - APD differs from PDL, in that APD is assumed to be a transient outage and PDL is permanent.
                             - V(disabled) means no action will be taken
                             - V(warning) means no action will be taken, but events will be generated for logging purposes.
-                            - V(restartConservative) means VMs will be powered off if  HA determines another host can support the VM.
+                            - V(restartConservative) means VMs will be powered off if HA determines another host can support the VM.
                             - V(restartAggressive) means VMs will be powered off if HA determines the VM can be restarted on a different host,
                               or if HA cannot detect the resources on other hosts because of network connectivity loss.
                         type: str
@@ -163,7 +163,7 @@ options:
                     restart_vms:
                         description:
                             - If true, VMs will be restarted when possible if storage is in an APD failure state.
-                            - This is only used if O(vm_overrides[].storage_apd_response.mode) is V(restartConservative) V(restartAggressive).
+                            - This is only used if O(vm_overrides[].storage_apd_response.mode) is V(restartConservative) or V(restartAggressive).
                         type: bool
             storage_pdl_response_mode:
                 description:
@@ -355,6 +355,9 @@ class HaVmOverrideChangeTracker(BaseVmOverrideChangeTracker):
         if not getattr(desired, "vmToolsMonitoringSettings"):
             return False
 
+        if not getattr(current, "vmToolsMonitoringSettings"):
+            return True
+
         desired = desired.vmToolsMonitoringSettings
         current = current.vmToolsMonitoringSettings
         if (
@@ -376,9 +379,14 @@ class HaVmOverrideChangeTracker(BaseVmOverrideChangeTracker):
         ):
             return True
 
+        return False
+
     def _component_protection_settings_differ(self, desired, current):
         if not getattr(desired, "vmComponentProtectionSettings"):
             return False
+
+        if not getattr(current, "vmComponentProtectionSettings"):
+            return True
 
         desired = desired.vmComponentProtectionSettings
         current = current.vmComponentProtectionSettings
@@ -503,6 +511,7 @@ class VMwareHaVmOverrides(ModulePyvmomiBase):
             set_if_defined_and_not_none(
                 spec, "vmTerminateDelayForAPDSec", apd.get("delay")
             )
+
             set_if_defined_and_not_none(
                 spec,
                 "vmReactionOnAPDCleared",

--- a/plugins/modules/cluster_ha_vm_overrides_info.py
+++ b/plugins/modules/cluster_ha_vm_overrides_info.py
@@ -1,0 +1,200 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: cluster_ha_vm_overrides_info
+short_description: Get vSphere High Availability (HA) VM override settings.
+description:
+    - Gets HA VM override settings on VMware vSphere clusters.
+    - Although VM overrides are shown in a unified view in vCenter, this module only gets the HA override settings.
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+seealso:
+    - module: vmware.vmware.cluster_ha
+    - module: vmware.vmware.cluster_ha_vm_overrides
+    - module: vmware.vmware.cluster_drs_vm_overrides_info
+
+options:
+    cluster:
+        description:
+            - The name of the cluster to get the VM override settings for.
+        type: str
+        required: true
+        aliases: [ cluster_name ]
+    datacenter:
+        description:
+            - The name of the datacenter.
+        type: str
+        required: true
+        aliases: [ datacenter_name ]
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+"""
+
+EXAMPLES = r"""
+- name: Gather HA VM override settings for a cluster
+  vmware.vmware.cluster_ha_vm_overrides_info:
+    datacenter: DC01
+    cluster: Cluster01
+"""
+
+RETURN = r"""
+cluster:
+    description: Display name and MOID of the cluster that was queried.
+    returned: success
+    type: dict
+    sample:
+        name: Cluster01
+        moid: cluster-21
+vm_overrides:
+    description:
+        - HA VM override entries from C(cluster.configurationEx.dasVmConfig).
+        - Each item always includes C(vm_moid), C(vm_name), C(storage_apd_response),
+          C(storage_pdl_response), and C(vm_monitoring).
+        - When settings are able to be retrieved, C(isolation_response), C(restart_priority), and C(restart_priority_timeout)
+          are included.
+    returned: success
+    type: list
+    sample:
+        - vm_moid: vm-42
+          vm_name: MyVirtualMachine
+          isolation_response: powerOff
+          restart_priority: medium
+          restart_priority_timeout: -1
+          storage_apd_response:
+            mode: restartConservative
+            delay: 180
+            restart_vms: reset
+          storage_pdl_response: warning
+          vm_monitoring:
+            mode: vmAndAppMonitoring
+            failure_interval: 30
+            minimum_uptime: 120
+            maximum_resets: 3
+            maximum_resets_window: 180
+            use_cluster_settings: false
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    base_argument_spec,
+)
+
+
+class VMwareHaVmOverridesInfo(ModulePyvmomiBase):
+    def __init__(self, module):
+        super().__init__(module)
+
+        datacenter = self.get_datacenter_by_name_or_moid(
+            self.params.get("datacenter"), fail_on_missing=True
+        )
+        self.cluster = self.get_cluster_by_name_or_moid(
+            self.params.get("cluster"), fail_on_missing=True, datacenter=datacenter
+        )
+
+    def _get_apd_response_settings(self, vm_component_protection_settings):
+        return dict(
+            mode=vm_component_protection_settings.vmStorageProtectionForAPD,
+            delay=vm_component_protection_settings.vmTerminateDelayForAPDSec,
+            restart_vms=(
+                True
+                if vm_component_protection_settings.vmReactionOnAPDCleared == "restart"
+                else False
+            ),
+        )
+
+    def _get_pdl_response_settings(self, vm_component_protection_settings):
+        return vm_component_protection_settings.vmStorageProtectionForPDL
+
+    def _get_vm_tools_monitoring_settings(self, vm_tools_monitoring_settings):
+        return dict(
+            mode=vm_tools_monitoring_settings.vmMonitoring,
+            failure_interval=vm_tools_monitoring_settings.failureInterval,
+            minimum_uptime=vm_tools_monitoring_settings.minUpTime,
+            maximum_resets=vm_tools_monitoring_settings.maxFailures,
+            maximum_resets_window=vm_tools_monitoring_settings.maxFailureWindow,
+            use_cluster_settings=vm_tools_monitoring_settings.clusterSettings,
+        )
+
+    def lookup_current_vm_overrides(self):
+        output = []
+        for vm_override in getattr(self.cluster.configurationEx, "dasVmConfig", []):
+            das_settings = getattr(vm_override, "dasSettings", None)
+            data = dict(
+                vm_moid=vm_override.key._GetMoId(),
+                vm_name=vm_override.key.name,
+                storage_apd_response=dict(),
+                storage_pdl_response=None,
+                vm_monitoring=dict(),
+            )
+            if das_settings is not None:
+                data["isolation_response"] = getattr(
+                    das_settings, "isolationResponse", None
+                )
+                data["restart_priority"] = getattr(
+                    das_settings, "restartPriority", None
+                )
+                data["restart_priority_timeout"] = getattr(
+                    das_settings, "restartPriorityTimeout", None
+                )
+
+                if hasattr(das_settings, "vmComponentProtectionSettings"):
+                    data["storage_apd_response"] = self._get_apd_response_settings(
+                        das_settings.vmComponentProtectionSettings
+                    )
+                    data["storage_pdl_response"] = self._get_pdl_response_settings(
+                        das_settings.vmComponentProtectionSettings
+                    )
+                if hasattr(das_settings, "vmToolsMonitoringSettings"):
+                    data["vm_monitoring"] = self._get_vm_tools_monitoring_settings(
+                        das_settings.vmToolsMonitoringSettings
+                    )
+
+            output.append(data)
+
+        return output
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **base_argument_spec(),
+            **dict(
+                cluster=dict(type="str", required=True, aliases=["cluster_name"]),
+                datacenter=dict(type="str", required=True, aliases=["datacenter_name"]),
+            ),
+        },
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        cluster=dict(),
+        vm_overrides=[],
+    )
+
+    cluster_ha = VMwareHaVmOverridesInfo(module)
+    result["cluster"]["name"] = cluster_ha.cluster.name
+    result["cluster"]["moid"] = cluster_ha.cluster._GetMoId()
+    result["vm_overrides"] = cluster_ha.lookup_current_vm_overrides()
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cluster_ha_vm_overrides_info.py
+++ b/plugins/modules/cluster_ha_vm_overrides_info.py
@@ -113,7 +113,7 @@ class VMwareHaVmOverridesInfo(ModulePyvmomiBase):
             delay=vm_component_protection_settings.vmTerminateDelayForAPDSec,
             restart_vms=(
                 True
-                if vm_component_protection_settings.vmReactionOnAPDCleared == "restart"
+                if vm_component_protection_settings.vmReactionOnAPDCleared == "reset"
                 else False
             ),
         )
@@ -153,14 +153,14 @@ class VMwareHaVmOverridesInfo(ModulePyvmomiBase):
                     das_settings, "restartPriorityTimeout", None
                 )
 
-                if hasattr(das_settings, "vmComponentProtectionSettings"):
+                if getattr(das_settings, "vmComponentProtectionSettings"):
                     data["storage_apd_response"] = self._get_apd_response_settings(
                         das_settings.vmComponentProtectionSettings
                     )
                     data["storage_pdl_response"] = self._get_pdl_response_settings(
                         das_settings.vmComponentProtectionSettings
                     )
-                if hasattr(das_settings, "vmToolsMonitoringSettings"):
+                if getattr(das_settings, "vmToolsMonitoringSettings"):
                     data["vm_monitoring"] = self._get_vm_tools_monitoring_settings(
                         das_settings.vmToolsMonitoringSettings
                     )

--- a/plugins/modules/cluster_ha_vm_overrides_info.py
+++ b/plugins/modules/cluster_ha_vm_overrides_info.py
@@ -76,7 +76,7 @@ vm_overrides:
           storage_apd_response:
             mode: restartConservative
             delay: 180
-            restart_vms: reset
+            restart_vms: true
           storage_pdl_response: warning
           vm_monitoring:
             mode: vmAndAppMonitoring

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,10 @@ sonar.python.version=3.12
 sonar.newCode.referenceBranch=main
 
 sonar.exclusions=tests/**,.tox/**
+
+
+# rules to ignore
+sonar.issue.ignore.multicriteria=e1
+# dont require literals when creating empty sets, lists, or dicts
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S7498
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py

--- a/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/meta/main.yml
+++ b/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_vars

--- a/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/tasks/eco-vcenter-cleanup.yml
+++ b/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/tasks/eco-vcenter-cleanup.yml
@@ -1,0 +1,31 @@
+---
+- name: Cleanup test cluster
+  environment: "{{ environment_auth_vars }}"
+  block:
+    - name: Remove test vm
+      vmware.vmware.vm:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        name: "{{ test_vm }}"
+        state: absent
+        allow_power_cycling: true
+
+    - name: Remove test cluster
+      vmware.vmware.cluster:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: absent
+
+    - name: Remove esxi host
+      vmware.vmware.vm:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ vcenter_cluster_name }}"
+        name: "{{ test_esxi_hostname }}"
+        state: absent
+        allow_power_cycling: true
+
+    - name: Remove resource pool
+      vmware.vmware_rest.vcenter_resourcepool:
+        resource_pool: "{{ _test_rp.id }}"
+        state: absent
+      when: _test_rp.id is defined

--- a/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/tasks/eco-vcenter-setup.yml
+++ b/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/tasks/eco-vcenter-setup.yml
@@ -1,0 +1,120 @@
+---
+- name: Lookup Root Resource Pool ID
+  ansible.builtin.set_fact:
+    vcenter_rp_id: >-
+      {{ lookup('vmware.vmware.moid_from_path', '/' + vcenter_datacenter +
+      '/host/' + vcenter_cluster_name + '/' + vcenter_resource_pool,
+      **vmware_rest_auth_vars) }}
+
+- name: Setup test cluster
+  environment: "{{ environment_auth_vars }}"
+  block:
+    - name: Create Test Cluster
+      vmware.vmware.cluster:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: present
+
+    - name: Set HA Settings In Test Cluster
+      vmware.vmware.cluster_ha:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        enable: true
+
+    - name: Create a test resource pool
+      vmware.vmware_rest.vcenter_resourcepool:
+        name: "{{ test_resource_pool }}"
+        parent: "{{ vcenter_rp_id }}"
+      register: _test_rp
+
+    - name: Gather Library Item Info
+      vmware.vmware.content_library_item_info:
+        library_item_name: "{{ esxi_content_library_template }}"
+        library_name: "{{ ci_resources_content_library }}"
+      register: _template
+
+    - name: Deploy Virtual ESXi Host
+      vmware.vmware_rest.vcenter_ovf_libraryitem:
+        ovf_library_item_id: "{{ (_template.library_item_info | first).id }}"
+        session_timeout: 10000
+        state: deploy
+        target:
+          resource_pool_id: "{{ _test_rp.id }}"
+        deployment_spec:
+          name: "{{ test_esxi_hostname }}"
+          accept_all_EULA: true
+          storage_provisioning: thin
+      register: _deploy
+
+    - name: Power On Host
+      vmware.vmware_rest.vcenter_vm_power:
+        state: start
+        vm: "{{ _deploy.value.resource_id.id }}"
+
+    - name: Wait For ESXi Host To Have IP
+      vmware.vmware.guest_info:
+        name: "{{ test_esxi_hostname }}"
+      register: _esxi_info
+      until: >-
+        _esxi_info.guests[0].ipv4 is defined and _esxi_info.guests[0].ipv4 is
+        truthy and not _esxi_info.guests[0].ipv4.startswith('169.254')
+      retries: 60
+      delay: 5
+
+    - name: Pause for 15 seconds to ensure host is ready
+      ansible.builtin.pause:
+        seconds: 15
+
+    - name: Join Hosts To Cluster
+      community.vmware.vmware_host:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
+        esxi_username: "{{ test_esxi_username }}"
+        esxi_password: "{{ test_esxi_password }}"
+        state: present
+
+    - name: Create Virtual Machine
+      vmware.vmware.vm:
+        name: "{{ test_vm }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        guest_id: rhel9_64Guest
+        datastore: "{{ shared_storage_02 }}"
+        cpu:
+          cores: 1
+        memory:
+          size_mb: 2048
+        scsi_controllers:
+          - controller_type: paravirtual
+            bus_number: 0
+        disks:
+          - size: 10gb
+            provisioning: thin
+            device_node: SCSI(0:0)
+      register: _create_vm
+
+  rescue:
+    - name: Remove test vm
+      vmware.vmware.vm:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        name: "{{ test_vm }}"
+        state: absent
+        allow_power_cycling: true
+    - name: Remove test cluster
+      vmware.vmware.cluster:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: absent
+    - name: Remove esxi host
+      vmware.vmware.vm:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ vcenter_cluster_name }}"
+        name: "{{ test_esxi_hostname }}"
+        state: absent
+        allow_power_cycling: true
+    - name: Remove resource pool
+      vmware.vmware_rest.vcenter_resourcepool:
+        resource_pool: "{{ _test_rp.id }}"
+        state: absent

--- a/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/tasks/main.yml
+++ b/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/tasks/main.yml
@@ -1,0 +1,200 @@
+---
+# Unable to test this module on the vCenter lab without some manual setup, since a datastore is required to create a VM
+# in the test cluster. This test is not run as part of the CI/CD pipeline.
+# We need a way to create a datastore on the esxi host that is created for the test cluster. Then this can be automated.
+- name: Test On VCenter
+  when: run_on_vcenter
+  environment: "{{ environment_auth_vars }}"
+
+  block:
+    # - name: Setup test cluster
+    #   ansible.builtin.include_tasks:
+    #     file: eco-vcenter-setup.yml
+
+    # change these to whatever you set up
+    - name: Set manual test facts
+      ansible.builtin.set_fact:
+        test_vm: "mmtest-ha-override"
+        test_cluster: "mmtest-ha-override"
+
+    - name: Apply a vm override
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: present
+        append: true
+        vm_overrides:
+          - virtual_machine: "{{ test_vm }}"
+            restart_priority: low
+            host_isolation_response: powerOff
+            restart_priority_timeout: 120
+            vm_monitoring:
+              mode: vmAndAppMonitoring
+              failure_interval: 30
+              minimum_uptime: 120
+              maximum_resets: 3
+              maximum_resets_window: 180
+              use_cluster_settings: false
+            storage_apd_response:
+              mode: restartConservative
+              delay: 180
+              restart_vms: true
+            storage_pdl_response_mode: warning
+      register: _present
+
+    - name: Apply a vm override - idempotence
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: present
+        append: true
+        vm_overrides:
+          - virtual_machine: "{{ test_vm }}"
+            restart_priority: low
+            host_isolation_response: powerOff
+            restart_priority_timeout: 120
+            vm_monitoring:
+              mode: vmAndAppMonitoring
+              failure_interval: 30
+              minimum_uptime: 120
+              maximum_resets: 3
+              maximum_resets_window: 180
+              use_cluster_settings: false
+            storage_apd_response:
+              mode: restartConservative
+              delay: 180
+              restart_vms: true
+            storage_pdl_response_mode: warning
+      register: _present_idem
+
+    - name: Get vm overrides
+      vmware.vmware.cluster_ha_vm_overrides_info:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+      register: _info
+
+    - name: Check vm overrides
+      ansible.builtin.assert:
+        that:
+          - _present is changed
+          - (_present.overrides_added | length) == 1
+          - _present_idem is not changed
+          - _override_info.storage_apd_response.delay == 180
+          - _override_info.storage_apd_response.mode == 'restartConservative'
+          - _override_info.storage_pdl_response_mode == 'warning'
+          - _override_info.vm_monitoring.mode == 'vmAndAppMonitoring'
+          - _override_info.vm_monitoring.failure_interval == 30
+          - _override_info.vm_monitoring.minimum_uptime == 120
+          - _override_info.vm_monitoring.maximum_resets == 3
+          - _override_info.vm_monitoring.maximum_resets_window == 180
+          - _override_info.vm_monitoring.use_cluster_settings == false
+      vars:
+        _override_info: "{{ _info.vm_overrides | selectattr('vm_name', 'equalto',
+          test_vm) | first }}"
+
+    - name: Update vm override
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: present
+        vm_overrides:
+          - virtual_machine: "{{ test_vm }}"
+            restart_priority_timeout: 240
+            vm_monitoring:
+              use_cluster_settings: true
+      register: _update
+
+    - name: Update vm override - idempotence
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: present
+        vm_overrides:
+          - virtual_machine: "{{ test_vm }}"
+            restart_priority_timeout: 240
+            vm_monitoring:
+              use_cluster_settings: true
+      register: _update_idem
+
+    - name: Get vm overrides info
+      vmware.vmware.cluster_ha_vm_overrides_info:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+      register: _info
+
+    - name: Check vm override updates
+      ansible.builtin.assert:
+        that:
+          - _update is changed
+          - (_update.overrides_updated | length) == 1
+          - _update_idem is not changed
+          - _override_info.vm_monitoring.use_cluster_settings == true
+          - _override_info.restart_priority_timeout == 240
+      vars:
+        _override_info: "{{ _info.vm_overrides | selectattr('vm_name', 'equalto',
+          test_vm) | first }}"
+
+    - name: Remove vm override
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: absent
+        vm_overrides:
+          - virtual_machine: "{{ test_vm }}"
+      register: _remove
+
+    - name: Remove vm override - idempotence
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: absent
+        vm_overrides:
+          - virtual_machine: "{{ (_info.vm_overrides | selectattr('vm_name', 'equalto',
+              test_vm) | first).vm_moid }}"
+      register: _remove_idem
+
+    - name: Get vm overrides info
+      vmware.vmware.cluster_ha_vm_overrides_info:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+      register: _info
+
+    - name: Check vm override removal
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+          - (_remove.overrides_removed | length) == 1
+          - _remove_idem is not changed
+          - _info.vm_overrides | selectattr('vm_name', 'equalto', test_vm) |
+            length == 0
+
+    - name: Apply a vm override
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: present
+        append: true
+        vm_overrides:
+          - virtual_machine: "{{ test_vm }}"
+            restart_priority_timeout: 240
+            vm_monitoring:
+              use_cluster_settings: true
+
+    - name: Set the vm overrides
+      vmware.vmware.cluster_ha_vm_overrides:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ test_cluster }}"
+        state: present
+        append: false
+        vm_overrides: []
+      register: _set
+
+    - name: Check set changed
+      ansible.builtin.assert:
+        that:
+          - _set is changed
+          - (_set.overrides_removed | length) == 1
+  # always:
+  #   - name: Teardown test cluster
+  #     ansible.builtin.include_tasks:
+  #       file: eco-vcenter-cleanup.yml

--- a/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/vars/main.yml
+++ b/tests/integration/targets/manual_vmware_cluster_ha_vm_overrides/vars/main.yml
@@ -1,0 +1,5 @@
+---
+test_vm: "{{ tiny_prefix }}_cluster_ha_vm_overrides_vm"
+test_cluster: "{{ tiny_prefix }}_cluster_ha_vm_overrides"
+test_esxi_hostname: "{{ tiny_prefix }}_cluster_ha_vm_overrides_esxi"
+test_resource_pool: "{{ tiny_prefix }}_cluster_ha_vm_overrides_rp"

--- a/tests/integration/targets/vmware_cluster_drs_vm_overrides/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs_vm_overrides/tasks/main.yml
@@ -15,9 +15,9 @@
         _starting_overrides: >-
           {{ _starting_overrides | default([]) + [
             {
-              'virtual_machine': item.virtual_machine_moid,
-              'drs_behavior': item.behavior,
-              'enable': item.enabled
+              'virtual_machine': item.vm_moid,
+              'behavior': item.behavior,
+              'enabled': item.enabled
             }
           ] }}
       loop: "{{ _starting_info.vm_overrides }}"
@@ -54,8 +54,8 @@
         append: true
         vm_overrides:
           - virtual_machine: "{{ _create_vm.vm.name }}"
-            drs_behavior: fullyAutomated
-            enable: true
+            behavior: fullyAutomated
+            enabled: true
       register: _present
 
     - name: Apply a vm override - idempotence
@@ -66,8 +66,8 @@
         append: true
         vm_overrides:
           - virtual_machine: "{{ _create_vm.vm.moid }}"
-            drs_behavior: fullyAutomated
-            enable: true
+            behavior: fullyAutomated
+            enabled: true
       register: _present_idem
 
     - name: Get vm overrides
@@ -85,8 +85,8 @@
           - _override_info.behavior == 'fullyAutomated'
           - _override_info.enabled == true
       vars:
-        _override_info: "{{ _info.vm_overrides | selectattr('virtual_machine_name',
-          'equalto', _create_vm.vm.name) | first }}"
+        _override_info: "{{ _info.vm_overrides | selectattr('vm_name', 'equalto',
+          _create_vm.vm.name) | first }}"
 
     - name: Update vm override
       vmware.vmware.cluster_drs_vm_overrides:
@@ -95,7 +95,7 @@
         state: present
         vm_overrides:
           - virtual_machine: "{{ _create_vm.vm.moid }}"
-            drs_behavior: manual
+            behavior: manual
       register: _update
 
     - name: Update vm override - idempotence
@@ -105,7 +105,7 @@
         state: present
         vm_overrides:
           - virtual_machine: "{{ _create_vm.vm.moid }}"
-            drs_behavior: manual
+            behavior: manual
       register: _update_idem
 
     - name: Get vm overrides info
@@ -123,8 +123,8 @@
           - _override_info.behavior == 'manual'
           - _override_info.enabled == true
       vars:
-        _override_info: "{{ _info.vm_overrides | selectattr('virtual_machine_name',
-          'equalto', _create_vm.vm.name) | first }}"
+        _override_info: "{{ _info.vm_overrides | selectattr('vm_name', 'equalto',
+          _create_vm.vm.name) | first }}"
 
     - name: Remove vm override
       vmware.vmware.cluster_drs_vm_overrides:
@@ -156,7 +156,7 @@
           - _remove is changed
           - (_remove.overrides_removed | length) == 1
           - _remove_idem is not changed
-          - _info.vm_overrides | selectattr('virtual_machine_name', 'equalto',
+          - _info.vm_overrides | selectattr('vm_name', 'equalto',
             _create_vm.vm.name) | length == 0
 
     - name: Apply a vm override
@@ -167,8 +167,8 @@
         append: true
         vm_overrides:
           - virtual_machine: "{{ _create_vm.vm.name }}"
-            drs_behavior: fullyAutomated
-            enable: true
+            behavior: fullyAutomated
+            enabled: true
 
     - name: Set the vm overrides
       vmware.vmware.cluster_drs_vm_overrides:

--- a/tests/unit/plugins/module_utils/test_cluster_settings.py
+++ b/tests/unit/plugins/module_utils/test_cluster_settings.py
@@ -44,7 +44,9 @@ class TestClusterSettingsRemapper:
 
     def test_storage_apd_restart_vms_falsey(self):
         assert ClusterSettingsRemapper.storage_apd_restart_vms(False) == "none"
-        assert ClusterSettingsRemapper.storage_apd_restart_vms(None) == "none"
+
+    def test_storage_apd_restart_vms_none_unchanged(self):
+        assert ClusterSettingsRemapper.storage_apd_restart_vms(None) is None
 
 
 class TestBaseVmOverrideChangeTrackerStatic:

--- a/tests/unit/plugins/module_utils/test_cluster_settings.py
+++ b/tests/unit/plugins/module_utils/test_cluster_settings.py
@@ -1,0 +1,170 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.vmware.vmware.plugins.module_utils._cluster_settings import (
+    BaseVmOverrideChangeTracker,
+    ClusterSettingsRemapper,
+)
+
+
+class _TestChangeTracker(BaseVmOverrideChangeTracker):
+    """Concrete tracker for unit tests; treats ``spec`` as the comparable field."""
+
+    def _overrides_differ(self, desired, current):
+        return getattr(desired, "spec", None) != getattr(current, "spec", None)
+
+
+def _make_spec(mocker, moid, spec_value, vm_name=None):
+    o = mocker.Mock()
+    o.spec = spec_value
+    o.key = mocker.Mock()
+    o.key._GetMoId.return_value = moid
+    o.key.name = vm_name if vm_name is not None else "name-%s" % moid
+    return o
+
+
+class TestClusterSettingsRemapper:
+    def test_storage_pdl_response_mode_restart_maps(self):
+        assert ClusterSettingsRemapper.storage_pdl_response_mode("restart") == (
+            "restartAggressive"
+        )
+
+    def test_storage_pdl_response_mode_passthrough(self):
+        assert ClusterSettingsRemapper.storage_pdl_response_mode("warning") == "warning"
+        assert (
+            ClusterSettingsRemapper.storage_pdl_response_mode("disabled") == "disabled"
+        )
+
+    def test_storage_pdl_response_mode_none(self):
+        assert ClusterSettingsRemapper.storage_pdl_response_mode(None) is None
+
+    def test_storage_apd_restart_vms_true(self):
+        assert ClusterSettingsRemapper.storage_apd_restart_vms(True) == "reset"
+
+    def test_storage_apd_restart_vms_falsey(self):
+        assert ClusterSettingsRemapper.storage_apd_restart_vms(False) == "none"
+        assert ClusterSettingsRemapper.storage_apd_restart_vms(None) == "none"
+
+
+class TestBaseVmOverrideChangeTrackerStatic:
+    def test_is_desired_set_and_different_from_current_desired_none(self, mocker):
+        d = mocker.Mock()
+        d.foo = None
+        c = mocker.Mock()
+        c.foo = "x"
+        assert not BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+            d, c, "foo"
+        )
+
+    def test_is_desired_set_and_different_from_current_same(self, mocker):
+        d = mocker.Mock()
+        d.foo = 1
+        c = mocker.Mock()
+        c.foo = 1
+        assert not BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+            d, c, "foo"
+        )
+
+    def test_is_desired_set_and_different_from_current_differs(self, mocker):
+        d = mocker.Mock()
+        d.foo = 2
+        c = mocker.Mock()
+        c.foo = 1
+        assert BaseVmOverrideChangeTracker._is_desired_set_and_different_from_current(
+            d, c, "foo"
+        )
+
+    def test_format_override_specs_for_json(self, mocker):
+        s = _make_spec(mocker, "vm-42", "a", vm_name="MyVM")
+        out = BaseVmOverrideChangeTracker.format_override_specs_for_json([s])
+        assert out == [{"vm_moid": "vm-42", "vm_name": "MyVM"}]
+
+
+class TestBaseVmOverrideChangeTrackerFlow:
+    def test_has_changes_false(self, mocker):
+        t = _TestChangeTracker({}, {})
+        assert not t.has_changes()
+
+    def test_has_changes_true_when_populated(self, mocker):
+        t = _TestChangeTracker({}, {})
+        t.to_add["x"] = mocker.Mock()
+        assert t.has_changes()
+
+    def test_process_absent_removes_listed_only(self, mocker):
+        cur_a = mocker.Mock()
+        cur_b = mocker.Mock()
+        current = {"a": cur_a, "b": cur_b}
+        param = {"a": mocker.Mock()}
+        t = _TestChangeTracker(current, param)
+        t.process_absent_changes()
+        assert t.to_remove == {"a": cur_a}
+        assert t._final_override_moids == {"b"}
+
+    def test_process_absent_param_not_on_cluster(self, mocker):
+        current = {"b": mocker.Mock()}
+        param = {"a": mocker.Mock()}
+        t = _TestChangeTracker(current, param)
+        t.process_absent_changes()
+        assert t.to_remove == {}
+        assert t._final_override_moids == {"b"}
+
+    def test_process_present_append_add(self, mocker):
+        desired = _make_spec(mocker, "new", "s1")
+        current = {}
+        param = {"new": desired}
+        t = _TestChangeTracker(current, param)
+        t.process_present_changes(append=True)
+        assert t.to_add == {"new": desired}
+        assert t.to_update == {}
+        assert t.to_remove == {}
+
+    def test_process_present_append_update_when_differs(self, mocker):
+        desired = _make_spec(mocker, "a", "v2")
+        existing = _make_spec(mocker, "a", "v1")
+        current = {"a": existing}
+        param = {"a": desired}
+        t = _TestChangeTracker(current, param)
+        t.process_present_changes(append=True)
+        assert t.to_add == {}
+        assert t.to_update == {"a": desired}
+        assert t.to_remove == {}
+
+    def test_process_present_append_no_update_when_same(self, mocker):
+        desired = _make_spec(mocker, "a", "v1")
+        existing = _make_spec(mocker, "a", "v1")
+        current = {"a": existing}
+        param = {"a": desired}
+        t = _TestChangeTracker(current, param)
+        t.process_present_changes(append=True)
+        assert t.to_add == {}
+        assert t.to_update == {}
+        assert t.to_remove == {}
+
+    def test_process_present_append_keeps_unmentioned_current(self, mocker):
+        orphan = _make_spec(mocker, "orphan", "x")
+        desired = _make_spec(mocker, "a", "v1")
+        current = {"a": _make_spec(mocker, "a", "v1"), "orphan": orphan}
+        param = {"a": desired}
+        t = _TestChangeTracker(current, param)
+        t.process_present_changes(append=True)
+        assert "orphan" not in t.to_remove
+
+    def test_process_present_replace_removes_unlisted(self, mocker):
+        keep = _make_spec(mocker, "a", "v1")
+        drop = _make_spec(mocker, "b", "y")
+        current = {"a": keep, "b": drop}
+        param = {"a": _make_spec(mocker, "a", "v1")}
+        t = _TestChangeTracker(current, param)
+        t.process_present_changes(append=False)
+        assert t.to_remove == {"b": drop}
+        assert t.to_add == {}
+        assert t.to_update == {}
+
+    def test_process_present_replace_empty_param_removes_all(self, mocker):
+        cur = _make_spec(mocker, "only", "x")
+        current = {"only": cur}
+        param = {}
+        t = _TestChangeTracker(current, param)
+        t.process_present_changes(append=False)
+        assert t.to_remove == {"only": cur}

--- a/tests/unit/plugins/modules/test_cluster_drs_vm_overrides.py
+++ b/tests/unit/plugins/modules/test_cluster_drs_vm_overrides.py
@@ -58,8 +58,8 @@ class TestVMwareDrsVmOverrides(ModuleTestCase):
             vm_overrides=[
                 {
                     "virtual_machine": "vm-1234567890",
-                    "drs_behavior": "fullyAutomated",
-                    "enable": True,
+                    "behavior": "fullyAutomated",
+                    "enabled": True,
                 }
             ],
         )
@@ -136,8 +136,8 @@ class TestVMwareDrsVmOverrides(ModuleTestCase):
                 "vm_overrides": [
                     {
                         "virtual_machine": existing_vm._GetMoId(),
-                        "drs_behavior": "fullyAutomated",
-                        "enable": True,
+                        "behavior": "fullyAutomated",
+                        "enabled": True,
                     }
                 ]
             },

--- a/tests/unit/plugins/modules/test_cluster_ha_vm_overrides.py
+++ b/tests/unit/plugins/modules/test_cluster_ha_vm_overrides.py
@@ -6,21 +6,14 @@ import sys
 import pytest
 from unittest.mock import Mock, patch
 
-from pyVmomi import vmodl
-
 from ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides import (
-    HaVmOverrideChangeTracker,
     VMwareHaVmOverrides,
     main as module_main,
-    set_if_defined_and_not_none,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
     PyvmomiClient,
 )
-from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import (
-    TaskError,
-)
-from ...common.utils import run_module, ModuleTestCase, AnsibleFailJson
+from ...common.utils import run_module, ModuleTestCase
 from ...common.vmware_object_mocks import MockCluster, create_mock_vsphere_object
 
 pytestmark = pytest.mark.skipif(

--- a/tests/unit/plugins/modules/test_cluster_ha_vm_overrides.py
+++ b/tests/unit/plugins/modules/test_cluster_ha_vm_overrides.py
@@ -1,0 +1,310 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import pytest
+from unittest.mock import Mock, patch
+
+from pyVmomi import vmodl
+
+from ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides import (
+    HaVmOverrideChangeTracker,
+    VMwareHaVmOverrides,
+    main as module_main,
+    set_if_defined_and_not_none,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import (
+    TaskError,
+)
+from ...common.utils import run_module, ModuleTestCase, AnsibleFailJson
+from ...common.vmware_object_mocks import MockCluster, create_mock_vsphere_object
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class MockDasVmConfigInfo(Mock):
+    pass
+
+
+class MockDasVmConfigSpec(Mock):
+    pass
+
+
+class TestVMwareHaVmOverrides(ModuleTestCase):
+
+    def _mock_ha_vm_config(self, mocker, vm=None, restart_priority="medium", isolation_response="none"):
+        mock_config = mocker.Mock()
+        if vm is None:
+            vm = create_mock_vsphere_object()
+        mock_config.key = vm
+        mock_das = mocker.Mock()
+        mock_das.restartPriority = restart_priority
+        mock_das.isolationResponse = isolation_response
+        mock_das.restartPriorityTimeout = None
+        mock_das.vmToolsMonitoringSettings = None
+        mock_das.vmComponentProtectionSettings = None
+        mock_config.dasSettings = mock_das
+        return mock_config
+
+    def __prepare(self, mocker):
+        mocker.patch.object(
+            PyvmomiClient, "connect_to_api", return_value=(mocker.Mock(), mocker.Mock())
+        )
+        self.test_cluster = MockCluster()
+        self.test_cluster.configurationEx.dasConfig = mocker.Mock()
+        self.test_cluster.configurationEx.dasConfig.enabled = True
+        self.test_cluster.configurationEx.dasVmConfig = []
+
+        self.base_args = dict(
+            datacenter="foo",
+            cluster=self.test_cluster.name,
+            state="present",
+            append=True,
+            vm_overrides=[
+                {
+                    "virtual_machine": "vm-1234567890",
+                    "restart_priority": "high",
+                    "host_isolation_response": "shutdown",
+                }
+            ],
+        )
+
+        mocker.patch.object(
+            VMwareHaVmOverrides,
+            "get_datacenter_by_name_or_moid",
+            return_value=mocker.Mock(),
+        )
+        mocker.patch.object(
+            VMwareHaVmOverrides,
+            "get_cluster_by_name_or_moid",
+            return_value=self.test_cluster,
+        )
+
+        self.test_vm = create_mock_vsphere_object()
+        mocker.patch.object(
+            VMwareHaVmOverrides,
+            "get_objs_by_name_or_moid",
+            return_value=[self.test_vm],
+        )
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigInfo",
+        new=MockDasVmConfigInfo,
+    )
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigSpec",
+        new=MockDasVmConfigSpec,
+    )
+    def test_present_no_existing_config(self, mocker):
+        self.__prepare(mocker)
+        module_args = self.base_args
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+        module_args = {**self.base_args, **{"vm_overrides": []}}
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+
+        module_args = {**self.base_args, **{"state": "present", "append": False}}
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigInfo",
+        new=MockDasVmConfigInfo,
+    )
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigSpec",
+        new=MockDasVmConfigSpec,
+    )
+    def test_present_with_existing_config(self, mocker):
+        self.__prepare(mocker)
+        existing_vm = create_mock_vsphere_object(name="foo", moid="vm-1234567890")
+        self.test_cluster.configurationEx.dasVmConfig = [
+            self._mock_ha_vm_config(mocker, existing_vm)
+        ]
+
+        module_args = self.base_args
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+        module_args = {**self.base_args, **{"append": False}}
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+        module_args = {
+            **self.base_args,
+            **{
+                "vm_overrides": [
+                    {
+                        "virtual_machine": existing_vm._GetMoId(),
+                        "restart_priority": "high",
+                        "host_isolation_response": "shutdown",
+                    }
+                ]
+            },
+        }
+        mocker.patch.object(
+            VMwareHaVmOverrides, "get_objs_by_name_or_moid", return_value=[existing_vm]
+        )
+        self.test_cluster.configurationEx.dasVmConfig = [
+            self._mock_ha_vm_config(
+                mocker,
+                existing_vm,
+                restart_priority="high",
+                isolation_response="shutdown",
+            )
+        ]
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigInfo",
+        new=MockDasVmConfigInfo,
+    )
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigSpec",
+        new=MockDasVmConfigSpec,
+    )
+    def test_absent_with_existing_config(self, mocker):
+        self.__prepare(mocker)
+        existing_vm = create_mock_vsphere_object(name="foo", moid="vm-1234567890")
+        self.test_cluster.configurationEx.dasVmConfig = [
+            self._mock_ha_vm_config(mocker, existing_vm)
+        ]
+
+        module_args = {**self.base_args, **{"state": "absent"}}
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+
+        module_args = {
+            **self.base_args,
+            **{
+                "state": "absent",
+                "vm_overrides": [{"virtual_machine": existing_vm._GetMoId()}],
+            },
+        }
+        mocker.patch.object(
+            VMwareHaVmOverrides, "get_objs_by_name_or_moid", return_value=[existing_vm]
+        )
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigInfo",
+        new=MockDasVmConfigInfo,
+    )
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigSpec",
+        new=MockDasVmConfigSpec,
+    )
+    def test_present_add_with_monitoring_and_storage_options(self, mocker):
+        self.__prepare(mocker)
+        module_args = {
+            **self.base_args,
+            "vm_overrides": [
+                {
+                    "virtual_machine": "vm-1234567890",
+                    "restart_priority": "low",
+                    "host_isolation_response": "powerOff",
+                    "restart_priority_timeout": 90,
+                    "vm_monitoring": {
+                        "use_cluster_settings": True,
+                    },
+                    "storage_apd_response": {
+                        "mode": "restartConservative",
+                        "delay": 60,
+                        "restart_vms": True,
+                    },
+                    "storage_pdl_response_mode": "restart",
+                }
+            ],
+        }
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigInfo",
+        new=MockDasVmConfigInfo,
+    )
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigSpec",
+        new=MockDasVmConfigSpec,
+    )
+    def test_present_add_with_vm_monitoring_custom_fields(self, mocker):
+        self.__prepare(mocker)
+        module_args = {
+            **self.base_args,
+            "vm_overrides": [
+                {
+                    "virtual_machine": "vm-1234567890",
+                    "restart_priority": "high",
+                    "vm_monitoring": {
+                        "use_cluster_settings": False,
+                        "mode": "vmAndAppMonitoring",
+                        "failure_interval": 20,
+                        "minimum_uptime": 60,
+                        "maximum_resets": 2,
+                        "maximum_resets_window": 120,
+                    },
+                }
+            ],
+        }
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigInfo",
+        new=MockDasVmConfigInfo,
+    )
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigSpec",
+        new=MockDasVmConfigSpec,
+    )
+    def test_present_triggers_update_apply(self, mocker):
+        self.__prepare(mocker)
+        existing_vm = create_mock_vsphere_object(name="foo", moid="vm-1234567890")
+        self.test_cluster.configurationEx.dasVmConfig = [
+            self._mock_ha_vm_config(mocker, existing_vm)
+        ]
+        mocker.patch.object(
+            VMwareHaVmOverrides, "get_objs_by_name_or_moid", return_value=[existing_vm]
+        )
+        apply_mock = mocker.patch.object(VMwareHaVmOverrides, "apply_ha_vm_overrides")
+        module_args = {
+            **self.base_args,
+            "vm_overrides": [
+                {
+                    "virtual_machine": existing_vm._GetMoId(),
+                    "restart_priority": "high",
+                    "host_isolation_response": "shutdown",
+                }
+            ],
+        }
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        apply_mock.assert_called_once()
+        assert apply_mock.call_args[1]["operation"] == "edit"
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigInfo",
+        new=MockDasVmConfigInfo,
+    )
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides.vim.cluster.DasVmConfigSpec",
+        new=MockDasVmConfigSpec,
+    )
+    def test_check_mode_skips_apply(self, mocker):
+        self.__prepare(mocker)
+        apply_mock = mocker.patch.object(VMwareHaVmOverrides, "apply_ha_vm_overrides")
+        module_args = {**self.base_args, "_ansible_check_mode": True}
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is True
+        apply_mock.assert_not_called()

--- a/tests/unit/plugins/modules/test_cluster_ha_vm_overrides_info.py
+++ b/tests/unit/plugins/modules/test_cluster_ha_vm_overrides_info.py
@@ -64,7 +64,7 @@ class TestVMwareHaVmOverridesInfo(ModuleTestCase):
         )
         mock_das_settings.vmComponentProtectionSettings.vmTerminateDelayForAPDSec = 180
         mock_das_settings.vmComponentProtectionSettings.vmReactionOnAPDCleared = (
-            "restart"
+            "reset"
         )
         mock_das_settings.vmComponentProtectionSettings.vmStorageProtectionForPDL = (
             "warning"

--- a/tests/unit/plugins/modules/test_cluster_ha_vm_overrides_info.py
+++ b/tests/unit/plugins/modules/test_cluster_ha_vm_overrides_info.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.cluster_ha_vm_overrides_info import (
+    VMwareHaVmOverridesInfo,
+    main as module_main,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient,
+)
+from ...common.utils import run_module, ModuleTestCase
+from ...common.vmware_object_mocks import MockCluster, create_mock_vsphere_object
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestVMwareHaVmOverridesInfo(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        mocker.patch.object(
+            PyvmomiClient, "connect_to_api", return_value=(mocker.Mock(), mocker.Mock())
+        )
+        self.test_cluster = MockCluster()
+        self.test_cluster.configurationEx.dasConfig = mocker.Mock()
+        self.test_cluster.configurationEx.dasConfig.enabled = True
+        self.test_cluster.configurationEx.dasVmConfig = []
+
+        self.base_args = dict(
+            datacenter="foo",
+            cluster=self.test_cluster.name,
+        )
+
+        mocker.patch.object(
+            VMwareHaVmOverridesInfo,
+            "get_datacenter_by_name_or_moid",
+            return_value=mocker.Mock(),
+        )
+        mocker.patch.object(
+            VMwareHaVmOverridesInfo,
+            "get_cluster_by_name_or_moid",
+            return_value=self.test_cluster,
+        )
+
+    def test_gather(self, mocker):
+        self.__prepare(mocker)
+        module_args = self.base_args
+
+        existing_vm = create_mock_vsphere_object(name="foo", moid="vm-1234567890")
+        mock_das_vm_config = mocker.Mock()
+        mock_das_vm_config.key = existing_vm
+        mock_das_settings = mocker.Mock()
+        mock_das_settings.isolationResponse = "shutdown"
+        mock_das_settings.restartPriority = "high"
+        mock_das_settings.restartPriorityTimeout = -1
+        mock_das_settings.vmComponentProtectionSettings = mocker.Mock()
+        mock_das_settings.vmComponentProtectionSettings.vmStorageProtectionForAPD = (
+            "restartConservative"
+        )
+        mock_das_settings.vmComponentProtectionSettings.vmTerminateDelayForAPDSec = 180
+        mock_das_settings.vmComponentProtectionSettings.vmReactionOnAPDCleared = (
+            "restart"
+        )
+        mock_das_settings.vmComponentProtectionSettings.vmStorageProtectionForPDL = (
+            "warning"
+        )
+        mock_das_settings.vmToolsMonitoringSettings = mocker.Mock()
+        mock_das_settings.vmToolsMonitoringSettings.vmMonitoring = "vmAndAppMonitoring"
+        mock_das_settings.vmToolsMonitoringSettings.failureInterval = 30
+        mock_das_settings.vmToolsMonitoringSettings.minUpTime = 120
+        mock_das_settings.vmToolsMonitoringSettings.maxFailures = 3
+        mock_das_settings.vmToolsMonitoringSettings.maxFailureWindow = 180
+        mock_das_settings.vmToolsMonitoringSettings.clusterSettings = False
+        mock_das_vm_config.dasSettings = mock_das_settings
+        self.test_cluster.configurationEx.dasVmConfig = [mock_das_vm_config]
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+        assert result["changed"] is False
+        assert len(result["vm_overrides"]) == 1
+        row = result["vm_overrides"][0]
+        assert row["vm_moid"] == "vm-1234567890"
+        assert row["vm_name"] == "foo"
+        assert row["isolation_response"] == "shutdown"
+        assert row["restart_priority"] == "high"
+        assert row["restart_priority_timeout"] == -1
+        assert row["storage_apd_response"]["mode"] == "restartConservative"
+        assert row["storage_apd_response"]["delay"] == 180
+        assert row["storage_apd_response"]["restart_vms"] is True
+        assert row["storage_pdl_response"] == "warning"
+        assert row["vm_monitoring"]["mode"] == "vmAndAppMonitoring"
+        assert row["vm_monitoring"]["failure_interval"] == 30
+        assert row["vm_monitoring"]["minimum_uptime"] == 120
+        assert row["vm_monitoring"]["maximum_resets"] == 3
+        assert row["vm_monitoring"]["maximum_resets_window"] == 180
+        assert row["vm_monitoring"]["use_cluster_settings"] is False


### PR DESCRIPTION
#### SUMMARY

This change adds `cluster_ha_vm_overrides` and `cluster_ha_vm_overrides_info` so clusters can manage and report HA VM override settings. 

Additionally, 
- shared logic between these modules, `cluster_ha` and the DRS override modules was moved into `plugins/module_utils/_cluster_settings.py` to avoid duplication.
- `cluster_drs_vm_overrides` and `cluster_drs_vm_overrides_info` were refactored to align with the same patterns as the new HA override modules. 

#### ISSUE TYPE

- Feature Pull Request

#### COMPONENT NAME

- `plugins/module_utils/_cluster_settings.py`
- `plugins/modules/cluster_ha.py`
- `plugins/modules/cluster_ha_vm_overrides.py`
- `plugins/modules/cluster_ha_vm_overrides_info.py`
- `plugins/modules/cluster_drs_vm_overrides.py`
- `plugins/modules/cluster_drs_vm_overrides_info.py`

#### ADDITIONAL INFORMATION

- Related internal ticket context: ACA-2283.

*This PR description was drafted with AI assistance and reviewed by the author.*