### PR TITLE
chore: Remove setuptools < 82 pin; require vmware-vcenter >= 9.1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pyVmomi>=8.0.3.0.1
-vmware-vcenter
-setuptools < 82
+vmware-vcenter>=9.1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+# Versions >=9.1 are recommended, but not required
 pyVmomi>=8.0.3.0.1
-vmware-vcenter>=9.1.0.0
+vmware-vcenter

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,5 +2,4 @@ ansible-core
 
 aiohttp
 pyVmomi>=8.0.3.0.1
-vmware-vcenter
-setuptools < 82
+vmware-vcenter>=9.1.0.0

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,2 @@
 pyVmomi>=8.0.3.0.1
-vmware-vcenter
-setuptools < 82
+vmware-vcenter>=9.1.0.0


### PR DESCRIPTION
##### SUMMARY

The setuptools < 82 pin (added in PR #325) worked around a pkg_resources import failure in vmware-vapi-runtime 2.61.2. setuptools 82.0.0 removed pkg_resources, which caused vmware-vapi-runtime to crash on import.

Pin vmware-vcenter >= 9.1.0.0 to ensure the fixed
vmware-vapi-runtime is always resolved; older versions of vmware-vcenter pull vmware-vapi-runtime <= 2.61.2 which would still break without the setuptools cap.

Fixes #350

Upstream references:
- vmware/vcf-sdk-python#6
- vmware/vsphere-automation-sdk-python#443

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
