### PR TITLE
Fix python and template syntax in building proxy config

### DIFF
--- a/changelogs/fragments/bugfix-354.yml
+++ b/changelogs/fragments/bugfix-354.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - module_utils/vmware_rest_client - correct python syntax and proxy url syntax.

--- a/plugins/module_utils/clients/rest.py
+++ b/plugins/module_utils/clients/rest.py
@@ -139,8 +139,8 @@ class VmwareRestClient():
         if all([self.proxy_host, self.proxy_port, self.proxy_protocol]):
             http_proxies = {
                 self.proxy_protocol: (
-                    "{%s}://{%s}:{%s}" %
-                    self.proxy_protocol, self.proxy_host, self.proxy_port
+                    "%s://%s:%s" %
+                    (self.proxy_protocol, self.proxy_host, self.proxy_port)
                 )
             }
 


### PR DESCRIPTION
##### SUMMARY
The python syntax for printf-style formatting was wrong, as the multiple values were not in a tuple. The built string was wrong too, as the curly braces are not part of the formatting and ended up in the resulting string verbatim.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/clients/rest

##### ADDITIONAL INFORMATION
Simply specifying `proxy_host` and `proxy_port` in a call to `vmware.vmware.guest_info` appears to be enough to trigger errors.