### PR TITLE
feat: add key provider modules for vCenter

### DIFF
--- a/changelogs/fragments/key-provider-modules.yml
+++ b/changelogs/fragments/key-provider-modules.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - key_provider_native - add module to manage native key providers in vCenter
+  - key_provider_standard - add module to manage standard key providers and KMS servers in vCenter
+  - key_provider_info - add module to gather information about key providers in vCenter

--- a/plugins/modules/key_provider_info.py
+++ b/plugins/modules/key_provider_info.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: key_provider_info
+short_description: Gather information about one or more key providers in a vCenter instance.
+description:
+    - This module allows you to gather information about one or more key providers in a vCenter instance.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    provider_name:
+        description:
+            - The name or ID of the key provider to gather information about.
+            - If this is not provided, all key providers will be returned.
+            - Only one of O(provider_name) or O(type) is allowed.
+        type: str
+        required: false
+        aliases: [name, id]
+
+    type:
+        description:
+            - The type of key provider to gather information about.
+            - If this is not provided, all key provider types will be returned.
+            - Only one of O(provider_name) or O(type) is allowed.
+        type: str
+        required: false
+        choices: [standard, native]
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+"""
+
+EXAMPLES = r"""
+- name: Gather information about all key providers
+  vmware.vmware.key_provider_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+
+- name: Gather information about a specific key provider
+  vmware.vmware.key_provider_info:
+    provider_name: my-standard-key-provider
+
+- name: Gather information about native key providers only
+  vmware.vmware.key_provider_info:
+    type: native
+
+- name: Gather information about standard key providers only
+  vmware.vmware.key_provider_info:
+    type: standard
+"""
+
+RETURN = r"""
+key_providers:
+    description:
+        - Dictionary of key providers in the vCenter instance.
+        - The key is the provider ID, the value is a dictionary with provider information.
+        - Each provider includes id, type, and default.
+        - Native providers also include backed_up and tpm_required.
+        - Standard providers include a servers list with KMIP server details
+          (id, address, port, username, proxy_address, proxy_port).
+    returned: always
+    type: dict
+    sample: {
+        "default-native-key-provider": {
+            "backed_up": true,
+            "default": true,
+            "id": "default-native-key-provider",
+            "type": "native"
+        },
+        "my-native-key-provider": {
+            "default": false,
+            "id": "my-native-key-provider",
+            "tpm_required": true,
+            "type": "native"
+        },
+        "my-standard-key-provider": {
+            "default": false,
+            "id": "my-standard-key-provider",
+            "servers": [
+                {
+                    "address": "10.0.0.1",
+                    "id": "kms-server-1",
+                    "port": 5696,
+                    "proxy_address": "10.0.0.2",
+                    "proxy_port": 5697,
+                    "username": "kmsuser"
+                },
+                {
+                    "address": "10.0.0.3",
+                    "id": "kms-server-2",
+                    "port": 5696,
+                    "proxy_address": "",
+                    "proxy_port": null,
+                    "username": ""
+                }
+            ],
+            "type": "standard"
+        }
+    }
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    base_argument_spec,
+)
+
+
+class KeyProviderInfoModule(ModulePyvmomiBase):
+    TYPE_MAP = {
+        "nativeProvider": "native",
+        "vCenter": "standard",
+    }
+
+    def __init__(self, module):
+        super().__init__(module)
+        self.crypto_manager = self.si.content.cryptoManager
+
+    def kmip_server_to_dict(self, kmip_server):
+        out = {
+            "id": kmip_server.name,
+            "address": kmip_server.address,
+            "port": kmip_server.port,
+            "username": kmip_server.userName,
+            "proxy_address": kmip_server.proxyAddress,
+            "proxy_port": kmip_server.proxyPort,
+        }
+        return out
+
+    def kmip_cluster_to_dict(self, kmip_cluster):
+        out = {
+            "id": kmip_cluster.clusterId.id,
+            "type": self.TYPE_MAP.get(kmip_cluster.managementType),
+            "default": kmip_cluster.useAsDefault,
+        }
+        if getattr(kmip_cluster, "servers", None) is not None:
+            out["servers"] = [
+                self.kmip_server_to_dict(server) for server in kmip_cluster.servers
+            ]
+
+        if getattr(kmip_cluster, "tpmRequired", None) is not None:
+            out["tpm_required"] = kmip_cluster.tpmRequired
+
+        if getattr(kmip_cluster, "hasBackup", None) is not None:
+            out["backed_up"] = kmip_cluster.hasBackup
+
+        return out
+
+    def gather_key_provider_info(self):
+        out = {}
+        name_filter = self.module.params.get("provider_name")
+        type_filter = self.module.params.get("type")
+        for kmip_cluster in self.crypto_manager.kmipServers:
+            if name_filter and kmip_cluster.clusterId.id != name_filter:
+                continue
+
+            if (
+                type_filter
+                and self.TYPE_MAP.get(kmip_cluster.managementType) != type_filter
+            ):
+                continue
+
+            out[kmip_cluster.clusterId.id] = self.kmip_cluster_to_dict(kmip_cluster)
+        return out
+
+
+def main():
+    argument_spec = base_argument_spec()
+    argument_spec.update(
+        dict(
+            provider_name=dict(type="str", required=False, aliases=["name", "id"]),
+            type=dict(type="str", choices=["standard", "native"], required=False),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[["provider_name", "type"]],
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    provider_module = KeyProviderInfoModule(module)
+    result["key_providers"] = provider_module.gather_key_provider_info()
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/key_provider_info.py
+++ b/plugins/modules/key_provider_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# Copyright: (c) 2026, Ansible Cloud Team (@ansible-collections)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -80,8 +80,10 @@ key_providers:
             "default": true,
             "id": "default-native-key-provider",
             "type": "native"
+            "tpm_required": true,
         },
         "my-native-key-provider": {
+            "backed_up": false,
             "default": false,
             "id": "my-native-key-provider",
             "tpm_required": true,

--- a/plugins/modules/key_provider_info.py
+++ b/plugins/modules/key_provider_info.py
@@ -79,8 +79,8 @@ key_providers:
             "backed_up": true,
             "default": true,
             "id": "default-native-key-provider",
-            "type": "native"
-            "tpm_required": true,
+            "type": "native",
+            "tpm_required": true
         },
         "my-native-key-provider": {
             "backed_up": false,

--- a/plugins/modules/key_provider_native.py
+++ b/plugins/modules/key_provider_native.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# Copyright: (c) 2026, Ansible Cloud Team (@ansible-collections)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,10 +23,13 @@ description:
 author:
     - Ansible Cloud Team (@ansible-collections)
 
+requirements:
+    - vSphere Automation SDK
+
 options:
     provider_name:
         description:
-            - The name or ID of the key provider to manage.
+            - The name or ID of the key provider to manage. The name and ID are interchangeable.
             - This is used as a unique identifier for the key provider in vSphere.
         type: str
         required: true

--- a/plugins/modules/key_provider_native.py
+++ b/plugins/modules/key_provider_native.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: key_provider_native
+short_description: Manage a native key provider in a vCenter instance.
+description:
+    - This module allows you to create, update, and delete a native key provider in a vCenter instance.
+    - Native key providers leverage the built-in cryptography libraries of the ESXi and vCenter appliance
+      to encrypt and decrypt data.
+    - You can optionally require TPM protection on the ESXi hosts that use the key provider.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    provider_name:
+        description:
+            - The name or ID of the key provider to manage.
+            - This is used as a unique identifier for the key provider in vSphere.
+        type: str
+        required: true
+        aliases: [name, id]
+
+    state:
+        description:
+            - Whether to ensure the key provider is present or absent.
+        type: str
+        default: present
+        choices: [present, absent]
+
+    tpm_required:
+        description:
+            - Whether to require ESXi hosts to have TPM protection before they can use the key provider.
+            - This setting cannot be changed once the provider is created. It is only used when creating new providers.
+        type: bool
+        default: true
+
+    default_provider:
+        description:
+            - Whether to set the key provider as the default provider for the vCenter instance.
+        type: bool
+        default: false
+
+    export_password:
+        description:
+            - The password to use when exporting or backing up the key provider. This is used to encrypt the exported key provider data (as a P12 file).
+            - Since this module does not actually perform the backup for you, this password is only applied to the backup
+              if you use the export URL and token from the module's return values to perform the backup.
+            - If no password is provided, the key provider data will be exported without encryption.
+            - If you choose to backup the key provider via the web UI, you can provide a password there instead.
+        type: str
+        required: false
+
+    disable_export_outputs:
+        description:
+            - If true, the module will not return the export URL and token.
+            - This is useful if you want to perform the backup via the web UI or other means and do not want to expose backup options in the logs
+              or memory.
+        type: bool
+        default: false
+
+notes:
+    - Key providers must be backed up and 'activated' before they can be used. You can do this at any time in vCenter, or use the module's
+      return values to perform the backup. See the examples below for more details.
+
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+    - vmware.vmware.additional_rest_options
+"""
+
+EXAMPLES = r"""
+- name: Ensure a native key provider is absent
+  vmware.vmware.key_provider_native:
+    provider_name: my-native-key-provider
+    state: absent
+
+- name: Create a native key provider
+  vmware.vmware.key_provider_native:
+    provider_name: my-native-key-provider
+    state: present
+    tpm_required: true
+    default_provider: false
+
+- name: Create a native key provider and return export details for backup
+  vmware.vmware.key_provider_native:
+    provider_name: my-native-key-provider
+    state: present
+    tpm_required: true
+    export_password: backup-password
+  register: native_key_provider
+
+- name: Set a native key provider as the default and do not log export information
+  vmware.vmware.key_provider_native:
+    provider_name: my-native-key-provider
+    state: present
+    default_provider: true
+    disable_export_outputs: true
+"""
+
+RETURN = r"""
+export_info:
+    description:
+        - Information needed to export and back up a newly created native key provider.
+        - Use the URL and token to download the key provider backup before the export token expires.
+        - This information is only available once, immediately after creation.
+        - You can perform the backup without this information via the vCenter web UI.
+        - Note that the token value may be considered sensitive. You can reduce the risk of its exposure
+          by setting the O(export_password) parameter, or by not logging it using the O(disable_export_outputs) parameter.
+    returned: when a new key provider was created and O(disable_export_outputs) is V(false)
+    type: dict
+    sample: {
+        "url": "https://vcenter.example.com/api/vcenter/crypto-manager/kms/providers/my-native-key-provider/export",
+        "token": "abc123exampletoken",
+        "expires_at": "2026-05-18T16:57:06"
+    }
+"""
+
+try:
+    from com.vmware.vapi.std.errors_client import NotFound
+except ImportError:
+    pass
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import (
+    ModuleRestBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    rest_compatible_argument_spec,
+)
+
+
+class NativeKeyProviderModule(ModuleRestBase):
+    def __init__(self, module):
+        super().__init__(module)
+        self.provider_name = module.params.get("provider_name")
+        self.providers_service = self.api_client.vcenter.crypto_manager.kms.Providers
+        self._pyvmomi_crypto_manager = None
+
+    @property
+    def pyvmomi_crypto_manager(self):
+        if self._pyvmomi_crypto_manager is None:
+            pyvmomi = ModulePyvmomiBase(self.module)
+            self._pyvmomi_crypto_manager = pyvmomi.si.content.cryptoManager
+        return self._pyvmomi_crypto_manager
+
+    def get_key_provider(self):
+        try:
+            return self.providers_service.get(self.provider_name)
+        except NotFound:
+            return None
+
+    def is_provider_cluster_default(self):
+        default_provider_id = self.pyvmomi_crypto_manager.GetDefaultKmsCluster()
+        return default_provider_id.id == self.provider_name
+
+    def create_key_provider(self):
+        spec = self.providers_service.CreateSpec(
+            self.provider_name,
+            constraints=self.providers_service.ConstraintsSpec(
+                tpm_required=self.params.get("tpm_required")
+            ),
+        )
+        return self.providers_service.create(spec)
+
+    def prepare_key_provider_export(self):
+        export_spec = self.providers_service.ExportSpec(provider=self.provider_name)
+        if self.params.get("export_password"):
+            export_spec.password = self.params.get("export_password")
+        export_response = self.providers_service.export(export_spec)
+
+        token = export_response.location.download_token
+        return dict(
+            url=export_response.location.url,
+            token=token.token,
+            expires_at=token.expiry,
+        )
+
+    def set_default_key_provider(self):
+        provider_id = vim.encryption.KeyProviderId()
+        provider_id.id = self.provider_name
+        self.pyvmomi_crypto_manager.MarkDefault(clusterId=provider_id)
+
+    def delete_key_provider(self):
+        self.providers_service.delete(self.provider_name)
+
+
+def main():
+    argument_spec = rest_compatible_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", choices=["present", "absent"], default="present"),
+            provider_name=dict(type="str", required=True, aliases=["name", "id"]),
+            tpm_required=dict(type="bool", default=True),
+            default_provider=dict(type="bool", default=False),
+            disable_export_outputs=dict(type="bool", default=False),
+            export_password=dict(type="str", required=False, no_log=True),
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    result = dict(changed=False)
+
+    provider_module = NativeKeyProviderModule(module)
+    provider = provider_module.get_key_provider()
+    if module.params.get("state") == "present":
+        if provider is None:
+            result["changed"] = True
+            if not module.check_mode:
+                provider = provider_module.create_key_provider()
+                if not module.params.get("disable_export_outputs"):
+                    result["export_info"] = (
+                        provider_module.prepare_key_provider_export()
+                    )
+
+        if (
+            module.params.get("default_provider")
+            and not provider_module.is_provider_cluster_default()
+        ):
+            result["changed"] = True
+            if not module.check_mode:
+                provider_module.set_default_key_provider()
+
+    elif module.params.get("state") == "absent":
+        if provider is not None:
+            result["changed"] = True
+            if not module.check_mode:
+                provider_module.delete_key_provider()
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/key_provider_native.py
+++ b/plugins/modules/key_provider_native.py
@@ -93,13 +93,22 @@ EXAMPLES = r"""
     tpm_required: true
     default_provider: false
 
-- name: Create a native key provider and return export details for backup
-  vmware.vmware.key_provider_native:
-    provider_name: my-native-key-provider
-    state: present
-    tpm_required: true
-    export_password: backup-password
-  register: native_key_provider
+- name: Create a key provider and back it up to activate it
+  block:
+    - name: Create a native key provider and return export details for backup
+      vmware.vmware.key_provider_native:
+        provider_name: my-native-key-provider
+        state: present
+        tpm_required: true
+        export_password: backup-password
+      register: native_key_provider
+    - name: Backup and activate the native key provider
+      ansible.builtin.get_url:
+        url: "{{ native_key_provider.export_info.url }}"
+        dest: "/tmp/native_key_provider.p12"
+        headers:
+        Authorization: "Bearer {{ native_key_provider.export_info.token }}"
+      when: native_key_provider is ansible.builtin.changed
 
 - name: Set a native key provider as the default and do not log export information
   vmware.vmware.key_provider_native:

--- a/plugins/modules/key_provider_native.py
+++ b/plugins/modules/key_provider_native.py
@@ -216,6 +216,25 @@ class NativeKeyProviderModule(ModuleRestBase):
         self.providers_service.delete(self.provider_name)
 
 
+def do_present_state(module, provider_module, provider, result):
+    if provider is None:
+        result["changed"] = True
+        if not module.check_mode:
+            provider_module.create_key_provider()
+            if not module.params.get("disable_export_outputs"):
+                result["export_info"] = (
+                    provider_module.prepare_key_provider_export()
+                )
+
+    if (
+        module.params.get("default_provider")
+        and not provider_module.is_provider_cluster_default()
+    ):
+        result["changed"] = True
+        if not module.check_mode:
+            provider_module.set_default_key_provider()
+
+
 def main():
     argument_spec = rest_compatible_argument_spec()
     argument_spec.update(
@@ -236,28 +255,12 @@ def main():
     provider_module = NativeKeyProviderModule(module)
     provider = provider_module.get_key_provider()
     if module.params.get("state") == "present":
-        if provider is None:
-            result["changed"] = True
-            if not module.check_mode:
-                provider = provider_module.create_key_provider()
-                if not module.params.get("disable_export_outputs"):
-                    result["export_info"] = (
-                        provider_module.prepare_key_provider_export()
-                    )
+        do_present_state(module, provider_module, provider, result)
 
-        if (
-            module.params.get("default_provider")
-            and not provider_module.is_provider_cluster_default()
-        ):
-            result["changed"] = True
-            if not module.check_mode:
-                provider_module.set_default_key_provider()
-
-    elif module.params.get("state") == "absent":
-        if provider is not None:
-            result["changed"] = True
-            if not module.check_mode:
-                provider_module.delete_key_provider()
+    elif module.params.get("state") == "absent" and provider is not None:
+        result["changed"] = True
+        if not module.check_mode:
+            provider_module.delete_key_provider()
 
     module.exit_json(**result)
 

--- a/plugins/modules/key_provider_standard.py
+++ b/plugins/modules/key_provider_standard.py
@@ -316,6 +316,25 @@ def update_cluster_servers_if_needed(provider_module, result, module):
                 provider_module.remove_kmip_server(param_server_id)
 
 
+def do_present_state(module, provider_module, result):
+    result["modified_kms_servers"] = list()
+    if provider_module.cluster_provider_obj is None:
+        result["changed"] = True
+        result["modified_kms_servers"] = [
+            s["id"] for s in module.params.get("kms_servers")
+        ]
+        if not module.check_mode:
+            provider_module.create_key_provider()
+    else:
+        update_cluster_servers_if_needed(provider_module, result, module)
+
+    if module.params.get("default_provider") and not getattr(
+        provider_module.cluster_provider_obj, "useAsDefault", False
+    ):
+        result["changed"] = True
+        if not module.check_mode:
+            provider_module.set_default_key_provider()
+
 def main():
     argument_spec = base_argument_spec()
     argument_spec.update(
@@ -368,29 +387,12 @@ def main():
 
     provider_module = StandardKeyProviderModule(module)
     if module.params.get("state") == "present":
-        result["modified_kms_servers"] = list()
-        if provider_module.cluster_provider_obj is None:
-            result["changed"] = True
-            result["modified_kms_servers"] = [
-                s["id"] for s in module.params.get("kms_servers")
-            ]
-            if not module.check_mode:
-                provider_module.create_key_provider()
-        else:
-            update_cluster_servers_if_needed(provider_module, result, module)
+        do_present_state(module, provider_module, result)
 
-        if module.params.get("default_provider") and not getattr(
-            provider_module.cluster_provider_obj, "useAsDefault", False
-        ):
-            result["changed"] = True
-            if not module.check_mode:
-                provider_module.set_default_key_provider()
-
-    elif module.params.get("state") == "absent":
-        if provider_module.cluster_provider_obj is not None:
-            result["changed"] = True
-            if not module.check_mode:
-                provider_module.delete_key_provider()
+    elif module.params.get("state") == "absent" and provider_module.cluster_provider_obj is not None:
+        result["changed"] = True
+        if not module.check_mode:
+            provider_module.delete_key_provider()
 
     module.exit_json(**result)
 

--- a/plugins/modules/key_provider_standard.py
+++ b/plugins/modules/key_provider_standard.py
@@ -1,0 +1,396 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: key_provider_standard
+short_description: Manage a standard key provider in a vCenter instance.
+description:
+    - This module allows you to create, update, and delete a standard key provider in a vCenter instance.
+    - Standard key providers leverage a third-party key management service (KMS) to encrypt and decrypt data.
+    - You define a provider 'cluster' that contains one or more external KMS servers.
+
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+options:
+    provider_name:
+        description:
+            - The name or ID of the key provider to manage.
+            - This is used as a unique identifier for the key provider cluster in vSphere.
+            - Each provider has one or more member KMS servers.
+        type: str
+        required: true
+        aliases: [name, id]
+
+    state:
+        description:
+            - Whether to ensure the key provider is present or absent.
+        type: str
+        default: present
+        choices: [present, absent]
+
+    default_provider:
+        description:
+            - Whether to set the key provider as the default provider for the vCenter instance.
+        type: bool
+        default: false
+
+    always_update_password:
+        description:
+            - If true and O(kms_servers[].password) is set, this module will always report a change and
+              set the password value to O(kms_servers[].password) .
+            - If false, other properties are still checked for differences. If a difference is found,
+              the value of O(kms_servers[].password) is still used.
+            - If O(kms_servers[].password) is unset, this parameter is ignored.
+            - This option is needed because there is no way to check the current password value and
+              compare it against the desired password value.
+        default: true
+        type: bool
+
+    kms_servers_state:
+        description:
+            - Whether to ensure the KMS servers are present or absent in the key provider cluster.
+        type: str
+        default: present
+        choices: [present, absent]
+
+    kms_servers:
+        description:
+            - List of KMS servers to manage in the key provider cluster.
+            - This parameter is required when O(state) is V(present).
+        type: list
+        elements: dict
+        required: false
+        suboptions:
+            id:
+                description:
+                    - The ID or name of the KMS server.
+                    - This must be unique within the key provider cluster, but does not need to be globally unique.
+                type: str
+                required: true
+            address:
+                description:
+                    - The address (IP or FQDN) of the KMS server.
+                    - This should be reachable from the vCenter server.
+                    - This parameter is required when O(kms_servers_state) is V(present).
+                type: str
+                required: false
+            port:
+                description:
+                    - The port number of the KMS server.
+                    - This parameter is required when O(kms_servers_state) is V(present).
+                type: int
+                required: false
+            proxy_address:
+                description:
+                    - The address (IP or FQDN) of the proxy server to use to connect to the KMS server.
+                type: str
+                required: false
+            proxy_port:
+                description:
+                    - The port number of the proxy server.
+                type: int
+                required: false
+            username:
+                description:
+                    - The username to use to authenticate to the KMS server.
+                type: str
+                required: false
+            password:
+                description:
+                    - The password to use to authenticate to the KMS server.
+                    - Because the password is encrypted in vCenter, this parameter cannot
+                      be checked for idempotency. See O(always_update_password) for more details.
+                type: str
+                required: false
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+"""
+
+EXAMPLES = r"""
+- name: Ensure a standard key provider is absent
+  vmware.vmware.key_provider_standard:
+    provider_name: my-standard-key-provider
+    state: absent
+
+- name: Create a standard key provider with a KMS server
+  vmware.vmware.key_provider_standard:
+    provider_name: my-standard-key-provider
+    state: present
+    kms_servers:
+      - id: kms-server-1
+        address: 10.0.0.1
+        port: 5696
+        proxy_address: 10.0.0.2
+        proxy_port: 5697
+        username: kmsuser
+        password: kms-password
+
+- name: Update a KMS server without forcing a password change
+  vmware.vmware.key_provider_standard:
+    provider_name: my-standard-key-provider
+    state: present
+    always_update_password: false
+    kms_servers:
+      - id: kms-server-1
+        address: 10.0.0.1
+        port: 5696
+        proxy_address: 10.0.0.2
+        proxy_port: 5697
+        username: kmsuser
+        password: kms-password
+
+- name: Add a second KMS server to the key provider cluster
+  vmware.vmware.key_provider_standard:
+    provider_name: my-standard-key-provider
+    state: present
+    kms_servers:
+      - id: kms-server-2
+        address: 10.0.0.3
+        port: 5696
+
+- name: Remove a KMS server from the key provider cluster
+  vmware.vmware.key_provider_standard:
+    provider_name: my-standard-key-provider
+    state: present
+    kms_servers_state: absent
+    kms_servers:
+      - id: kms-server-1
+
+- name: Set a standard key provider as the default
+  vmware.vmware.key_provider_standard:
+    provider_name: my-standard-key-provider
+    state: present
+    default_provider: true
+    kms_servers:
+      - id: kms-server-1
+        address: 10.0.0.1
+        port: 5696
+"""
+
+RETURN = r"""
+modified_kms_servers:
+    description:
+        - List of KMS server IDs that were created, updated, or removed.
+        - Empty when no KMS server changes were needed.
+    returned: when O(state) is V(present)
+    type: list
+    sample: ["kms-server-1"]
+"""
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    base_argument_spec,
+)
+
+
+class StandardKeyProviderModule(ModulePyvmomiBase):
+    CLUSTER_SERVER_UPDATE_FIELDS = {
+        "address": "address",
+        "port": "port",
+        "proxy_address": "proxyAddress",
+        "proxy_port": "proxyPort",
+        "username": "userName",
+    }
+
+    def __init__(self, module):
+        super().__init__(module)
+        self.provider_name = module.params.get("provider_name")
+        self._cluster_provider_obj = None
+        self.crypto_manager = self.si.content.cryptoManager
+
+    @property
+    def cluster_provider_obj(self):
+        if self._cluster_provider_obj is None:
+            for kmip_cluster in self.crypto_manager.kmipServers:
+                if kmip_cluster.clusterId.id == self.provider_name:
+                    self._cluster_provider_obj = kmip_cluster
+                    break
+        return self._cluster_provider_obj
+
+    def _create_kmip_server_spec(self, server):
+        server_spec = vim.encryption.KmipServerSpec()
+        server_spec.clusterId = vim.encryption.KeyProviderId(id=self.provider_name)
+        if server.get("password"):
+            server_spec.password = server.get("password")
+        server_spec.info = vim.encryption.KmipServerInfo()
+        server_spec.info.name = server.get("id")
+        server_spec.info.address = server.get("address")
+        server_spec.info.port = server.get("port")
+        server_spec.info.proxyAddress = server.get("proxy_address")
+        server_spec.info.proxyPort = server.get("proxy_port")
+        server_spec.info.userName = server.get("username")
+        return server_spec
+
+    def perform_present_server_action(self, param_server, server_action_function):
+        server_spec = self._create_kmip_server_spec(param_server)
+        server_action_function(server=server_spec)
+
+    def create_key_provider(self):
+        """
+        vCenter is really weird when creating a new key provider cluster. You need to create the KMIP server first, and that will create
+        the cluster if needed.
+        """
+        for server in self.params.get("kms_servers"):
+            server_spec = self._create_kmip_server_spec(server)
+            self.crypto_manager.RegisterKmipServer(server=server_spec)
+
+    def remove_kmip_server(self, server_id):
+        self.crypto_manager.RemoveKmipServer(
+            self.cluster_provider_obj.clusterId, serverName=server_id
+        )
+
+    def set_default_key_provider(self):
+        self.crypto_manager.MarkDefault(clusterId=self.cluster_provider_obj.clusterId)
+
+    def delete_key_provider(self):
+        self.crypto_manager.UnregisterKmsCluster(
+            clusterId=self.cluster_provider_obj.clusterId
+        )
+
+    def get_present_server_action_function(self, param_server):
+        existing_server = self.get_existing_server(param_server.get("id"))
+        if existing_server is None:
+            return self.crypto_manager.RegisterKmipServer
+
+        if param_server.get("password") and self.params.get("always_update_password"):
+            return self.crypto_manager.UpdateKmipServer
+
+        for param_name, attr_name in self.CLUSTER_SERVER_UPDATE_FIELDS.items():
+            if param_server.get(param_name) is None:
+                continue
+
+            if getattr(existing_server, attr_name) != param_server.get(param_name):
+                return self.crypto_manager.UpdateKmipServer
+
+        return None
+
+    def get_existing_server(self, server_id):
+        for _s in self.cluster_provider_obj.servers:
+            if _s.name == server_id:
+                return _s
+        return None
+
+
+def update_cluster_servers_if_needed(provider_module, result, module):
+    for param_server in module.params.get("kms_servers"):
+        param_server_id = param_server.get("id")
+        if module.params.get("kms_servers_state") == "present":
+            server_action_function = provider_module.get_present_server_action_function(
+                param_server
+            )
+            if server_action_function is not None:
+                result["changed"] = True
+                result["modified_kms_servers"].append(param_server_id)
+                if not module.check_mode:
+                    provider_module.perform_present_server_action(
+                        param_server, server_action_function
+                    )
+
+        elif provider_module.get_existing_server(param_server_id) is not None:
+            result["changed"] = True
+            result["modified_kms_servers"].append(param_server_id)
+            if not module.check_mode:
+                provider_module.remove_kmip_server(param_server_id)
+
+
+def main():
+    argument_spec = base_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", choices=["present", "absent"], default="present"),
+            provider_name=dict(type="str", required=True, aliases=["name", "id"]),
+            default_provider=dict(type="bool", default=False),
+            always_update_password=dict(type="bool", default=True),
+            kms_servers_state=dict(
+                type="str", choices=["present", "absent"], default="present"
+            ),
+            kms_servers=dict(
+                type="list",
+                elements="dict",
+                required=False,
+                options=dict(
+                    id=dict(type="str", required=True),
+                    address=dict(type="str", required=False),
+                    port=dict(type="int", required=False),
+                    proxy_address=dict(type="str", required=False),
+                    proxy_port=dict(type="int", required=False),
+                    username=dict(type="str", required=False),
+                    password=dict(type="str", required=False, no_log=True),
+                ),
+            ),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("kms_servers",)),
+        ],
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    if (
+        module.params.get("state") == "present"
+        and module.params.get("kms_servers_state") == "present"
+    ):
+        for server in module.params.get("kms_servers") or []:
+            if server.get("address") is None or server.get("port") is None:
+                module.fail_json(
+                    msg="address and port are required for each KMS server when kms_servers_state is present."
+                )
+
+    provider_module = StandardKeyProviderModule(module)
+    if module.params.get("state") == "present":
+        result["modified_kms_servers"] = list()
+        if provider_module.cluster_provider_obj is None:
+            result["changed"] = True
+            result["modified_kms_servers"] = [
+                s["id"] for s in module.params.get("kms_servers")
+            ]
+            if not module.check_mode:
+                provider_module.create_key_provider()
+        else:
+            update_cluster_servers_if_needed(provider_module, result, module)
+
+        if module.params.get("default_provider") and not getattr(
+            provider_module.cluster_provider_obj, "useAsDefault", False
+        ):
+            result["changed"] = True
+            if not module.check_mode:
+                provider_module.set_default_key_provider()
+
+    elif module.params.get("state") == "absent":
+        if provider_module.cluster_provider_obj is not None:
+            result["changed"] = True
+            if not module.check_mode:
+                provider_module.delete_key_provider()
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/key_provider_standard.py
+++ b/plugins/modules/key_provider_standard.py
@@ -335,6 +335,7 @@ def do_present_state(module, provider_module, result):
         if not module.check_mode:
             provider_module.set_default_key_provider()
 
+
 def main():
     argument_spec = base_argument_spec()
     argument_spec.update(

--- a/plugins/modules/key_provider_standard.py
+++ b/plugins/modules/key_provider_standard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2023, Ansible Cloud Team (@ansible-collections)
+# Copyright: (c) 2026, Ansible Cloud Team (@ansible-collections)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,9 @@ description:
     - This module allows you to create, update, and delete a standard key provider in a vCenter instance.
     - Standard key providers leverage a third-party key management service (KMS) to encrypt and decrypt data.
     - You define a provider 'cluster' that contains one or more external KMS servers.
+    - When adding a new KMS server to a provider 'cluster', vCenter will attempt to connect to the server
+      and verify its certificate chain. You can view the status of the connection and retry the validation
+      via the vCenter UI.
 
 author:
     - Ansible Cloud Team (@ansible-collections)
@@ -25,7 +28,7 @@ author:
 options:
     provider_name:
         description:
-            - The name or ID of the key provider to manage.
+            - The name or ID of the key provider to manage. The name and ID are interchangeable.
             - This is used as a unique identifier for the key provider cluster in vSphere.
             - Each provider has one or more member KMS servers.
         type: str

--- a/tests/integration/targets/vmware_key_provider/meta/main.yml
+++ b/tests/integration/targets/vmware_key_provider/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_vars

--- a/tests/integration/targets/vmware_key_provider/tasks/main.yml
+++ b/tests/integration/targets/vmware_key_provider/tasks/main.yml
@@ -1,0 +1,158 @@
+---
+- name: Test key provider modules on vCenter
+  when: run_on_vcenter
+  environment: "{{ environment_auth_vars }}"
+
+  block:
+    - name: Include Eco vCenter test vars
+      ansible.builtin.include_vars:
+        file: eco-vcenter.yml
+
+    - name: Create native key provider
+      vmware.vmware.key_provider_native:
+        provider_name: "{{ test_native_provider_name }}"
+        state: present
+        tpm_required: false
+        disable_export_outputs: true
+      register: _create_native
+
+    - name: Create native key provider - idempotency
+      vmware.vmware.key_provider_native:
+        provider_name: "{{ test_native_provider_name }}"
+        state: present
+        tpm_required: false
+        disable_export_outputs: true
+      register: _create_native_idem
+
+    - name: Create standard key provider with a KMS server
+      vmware.vmware.key_provider_standard:
+        provider_name: "{{ test_standard_provider_name }}"
+        state: present
+        kms_servers:
+          - id: "{{ test_kms_server_1_id }}"
+            address: "{{ test_kms_address_1 }}"
+            port: "{{ test_kms_port }}"
+            proxy_address: "{{ test_kms_proxy_address }}"
+            proxy_port: "{{ test_kms_proxy_port }}"
+            username: "{{ test_kms_username }}"
+            password: "{{ test_kms_password }}"
+      register: _create_standard
+
+    - name: Create standard key provider with a KMS server - idempotency
+      vmware.vmware.key_provider_standard:
+        provider_name: "{{ test_standard_provider_name }}"
+        state: present
+        always_update_password: false
+        kms_servers:
+          - id: "{{ test_kms_server_1_id }}"
+            address: "{{ test_kms_address_1 }}"
+            port: "{{ test_kms_port }}"
+            proxy_address: "{{ test_kms_proxy_address }}"
+            proxy_port: "{{ test_kms_proxy_port }}"
+            username: "{{ test_kms_username }}"
+            password: "{{ test_kms_password }}"
+      register: _create_standard_idem
+
+    - name: Add a second KMS server to the standard key provider
+      vmware.vmware.key_provider_standard:
+        provider_name: "{{ test_standard_provider_name }}"
+        state: present
+        kms_servers:
+          - id: "{{ test_kms_server_2_id }}"
+            address: "{{ test_kms_address_2 }}"
+            port: "{{ test_kms_port }}"
+      register: _add_kms_server_2
+
+    - name: Add a second KMS server - idempotency
+      vmware.vmware.key_provider_standard:
+        provider_name: "{{ test_standard_provider_name }}"
+        state: present
+        kms_servers:
+          - id: "{{ test_kms_server_2_id }}"
+            address: "{{ test_kms_address_2 }}"
+            port: "{{ test_kms_port }}"
+      register: _add_kms_server_2_idem
+
+    - name: Gather information about all key providers
+      vmware.vmware.key_provider_info: {}
+      register: _all_key_providers
+
+    - name: Gather information about the test standard key provider
+      vmware.vmware.key_provider_info:
+        provider_name: "{{ test_standard_provider_name }}"
+      register: _standard_key_provider_info
+
+    - name: Gather information about native key providers
+      vmware.vmware.key_provider_info:
+        type: native
+      register: _native_key_providers_info
+
+    - name: Gather information about standard key providers
+      vmware.vmware.key_provider_info:
+        type: standard
+      register: _standard_key_providers_info
+
+    - name: Remove a KMS server from the standard key provider
+      vmware.vmware.key_provider_standard:
+        provider_name: "{{ test_standard_provider_name }}"
+        state: present
+        kms_servers_state: absent
+        kms_servers:
+          - id: "{{ test_kms_server_1_id }}"
+      register: _remove_kms_server_1
+
+    - name: Remove a KMS server from the standard key provider - idempotency
+      vmware.vmware.key_provider_standard:
+        provider_name: "{{ test_standard_provider_name }}"
+        state: present
+        kms_servers_state: absent
+        kms_servers:
+          - id: "{{ test_kms_server_1_id }}"
+      register: _remove_kms_server_1_idem
+
+    - name: Gather standard key provider info after KMS server removal
+      vmware.vmware.key_provider_info:
+        provider_name: "{{ test_standard_provider_name }}"
+      register: _standard_key_provider_after_remove
+
+    - name: Check module results
+      ansible.builtin.assert:
+        that:
+          - _create_native is changed
+          - _create_native.export_info is not defined
+          - _create_native_idem is not changed
+          - _create_standard is changed
+          - test_kms_server_1_id in _create_standard.modified_kms_servers
+          - _create_standard_idem is not changed
+          - _create_standard_idem.modified_kms_servers | length == 0
+          - _add_kms_server_2 is changed
+          - test_kms_server_2_id in _add_kms_server_2.modified_kms_servers
+          - _add_kms_server_2_idem is not changed
+          - _remove_kms_server_1 is changed
+          - test_kms_server_1_id in _remove_kms_server_1.modified_kms_servers
+          - test_native_provider_name in _all_key_providers.key_providers
+          - test_standard_provider_name in _all_key_providers.key_providers
+          - _all_key_providers.key_providers[test_native_provider_name].type == 'native'
+          - _all_key_providers.key_providers[test_standard_provider_name].type == 'standard'
+          - test_standard_provider_name in _standard_key_provider_info.key_providers
+          - _standard_key_provider_info.key_providers | length == 1
+          - test_native_provider_name in _native_key_providers_info.key_providers
+          - test_standard_provider_name in _standard_key_providers_info.key_providers
+          - _standard_key_provider_info.key_providers[test_standard_provider_name].servers | length == 2
+          - _standard_key_provider_after_remove.key_providers[test_standard_provider_name].servers | length == 1
+          - _standard_key_provider_after_remove.key_providers[test_standard_provider_name].servers[0].id == test_kms_server_2_id
+          - _remove_kms_server_1 is changed
+          - _remove_kms_server_1_idem is not changed
+          - _remove_kms_server_1.modified_kms_servers | length == 1
+          - _remove_kms_server_1.modified_kms_servers[0] == test_kms_server_1_id
+
+  always:
+    - name: Remove test standard key provider
+      vmware.vmware.key_provider_standard:
+        provider_name: "{{ test_standard_provider_name }}"
+        state: absent
+
+    - name: Remove test native key provider
+      vmware.vmware.key_provider_native:
+        provider_name: "{{ test_native_provider_name }}"
+        state: absent

--- a/tests/integration/targets/vmware_key_provider/vars/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_key_provider/vars/eco-vcenter.yml
@@ -1,0 +1,12 @@
+---
+test_native_provider_name: "{{ tiny_prefix }}-vmware-key-provider-native"
+test_standard_provider_name: "{{ tiny_prefix }}-vmware-key-provider-standard"
+test_kms_server_1_id: "{{ tiny_prefix }}-kms-server-1"
+test_kms_server_2_id: "{{ tiny_prefix }}-kms-server-2"
+test_kms_address_1: "192.0.2.1"
+test_kms_address_2: "192.0.2.2"
+test_kms_proxy_address: "192.0.2.3"
+test_kms_port: 5696
+test_kms_proxy_port: 5697
+test_kms_username: kmsuser
+test_kms_password: kms-password

--- a/tests/unit/plugins/modules/test_key_provider_info.py
+++ b/tests/unit/plugins/modules/test_key_provider_info.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.key_provider_info import (
+    main as module_main,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient,
+)
+from ...common.utils import run_module, ModuleTestCase
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestKeyProviderInfo(ModuleTestCase):
+
+    def _mock_kmip_clusters(self, mocker):
+        native_cluster = mocker.Mock(
+            spec=[
+                "clusterId",
+                "managementType",
+                "useAsDefault",
+                "tpmRequired",
+                "hasBackup",
+            ]
+        )
+        native_cluster.clusterId.id = "native-1"
+        native_cluster.managementType = "nativeProvider"
+        native_cluster.useAsDefault = True
+        native_cluster.tpmRequired = True
+        native_cluster.hasBackup = True
+
+        standard_server = mocker.Mock()
+        standard_server.name = "kms-1"
+        standard_server.address = "10.0.0.1"
+        standard_server.port = 5696
+        standard_server.userName = "kmsuser"
+        standard_server.proxyAddress = "10.0.0.2"
+        standard_server.proxyPort = 5697
+
+        standard_cluster = mocker.Mock()
+        standard_cluster.clusterId.id = "standard-1"
+        standard_cluster.managementType = "vCenter"
+        standard_cluster.useAsDefault = False
+        standard_cluster.servers = [standard_server]
+
+        return [native_cluster, standard_cluster]
+
+    def __prepare(self, mocker):
+        content_mock = mocker.Mock()
+        content_mock.cryptoManager.kmipServers = self._mock_kmip_clusters(mocker)
+        si_mock = mocker.Mock()
+        si_mock.content = content_mock
+        mocker.patch.object(
+            PyvmomiClient, "connect_to_api", return_value=(si_mock, content_mock)
+        )
+
+    def test_gather_all(self, mocker):
+        self.__prepare(mocker)
+
+        result = run_module(module_entry=module_main)
+
+        assert result["changed"] is False
+        assert result["key_providers"]["native-1"] == {
+            "id": "native-1",
+            "type": "native",
+            "default": True,
+            "tpm_required": True,
+            "backed_up": True,
+        }
+        assert result["key_providers"]["standard-1"]["type"] == "standard"
+        assert result["key_providers"]["standard-1"]["servers"] == [
+            {
+                "id": "kms-1",
+                "address": "10.0.0.1",
+                "port": 5696,
+                "username": "kmsuser",
+                "proxy_address": "10.0.0.2",
+                "proxy_port": 5697,
+            }
+        ]
+
+    def test_filter_by_name(self, mocker):
+        self.__prepare(mocker)
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={"provider_name": "standard-1"},
+        )
+
+        assert list(result["key_providers"].keys()) == ["standard-1"]
+
+    def test_filter_by_type(self, mocker):
+        self.__prepare(mocker)
+
+        result = run_module(module_entry=module_main, module_args={"type": "native"})
+
+        assert list(result["key_providers"].keys()) == ["native-1"]

--- a/tests/unit/plugins/modules/test_key_provider_native.py
+++ b/tests/unit/plugins/modules/test_key_provider_native.py
@@ -31,12 +31,8 @@ class TestKeyProviderNative(ModuleTestCase):
         )
         self.providers_service = self.rest_client.vcenter.crypto_manager.kms.Providers
         self.providers_service.CreateSpec = mock.Mock(side_effect=self._create_spec)
-        self.providers_service.ConstraintsSpec = mock.Mock(
-            side_effect=lambda **kwargs: mock.Mock(**kwargs)
-        )
-        self.providers_service.ExportSpec = mock.Mock(
-            side_effect=lambda **kwargs: mock.Mock(**kwargs)
-        )
+        self.providers_service.ConstraintsSpec = mock.Mock(side_effect=mock.Mock)
+        self.providers_service.ExportSpec = mock.Mock(side_effect=mock.Mock)
 
         crypto_manager = mocker.Mock()
         default_id = mocker.Mock()

--- a/tests/unit/plugins/modules/test_key_provider_native.py
+++ b/tests/unit/plugins/modules/test_key_provider_native.py
@@ -1,0 +1,145 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+from unittest import mock
+
+from ansible_collections.vmware.vmware.plugins.modules.key_provider_native import (
+    NativeKeyProviderModule,
+    main as module_main,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.rest import (
+    VmwareRestClient,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase,
+)
+from ...common.utils import run_module, ModuleTestCase
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestKeyProviderNative(ModuleTestCase):
+
+    def __prepare(self, mocker):
+        self.rest_client = mocker.Mock()
+        mocker.patch.object(
+            VmwareRestClient, "connect_to_api", return_value=self.rest_client
+        )
+        self.providers_service = self.rest_client.vcenter.crypto_manager.kms.Providers
+        self.providers_service.CreateSpec = mock.Mock(side_effect=self._create_spec)
+        self.providers_service.ConstraintsSpec = mock.Mock(
+            side_effect=lambda **kwargs: mock.Mock(**kwargs)
+        )
+        self.providers_service.ExportSpec = mock.Mock(
+            side_effect=lambda **kwargs: mock.Mock(**kwargs)
+        )
+
+        crypto_manager = mocker.Mock()
+        default_id = mocker.Mock()
+        default_id.id = "other-provider"
+        crypto_manager.GetDefaultKmsCluster.return_value = default_id
+        pyvmomi_base = mocker.patch.object(ModulePyvmomiBase, "__init__", return_value=None)
+        pyvmomi_base.return_value = None
+        mocker.patch.object(
+            NativeKeyProviderModule,
+            "pyvmomi_crypto_manager",
+            new_callable=mocker.PropertyMock,
+            return_value=crypto_manager,
+        )
+        self.crypto_manager = crypto_manager
+
+    def _create_spec(self, provider_name, constraints=None):
+        spec = mock.Mock()
+        spec.provider_name = provider_name
+        spec.constraints = constraints
+        return spec
+
+    def _mock_export_response(self):
+        export_response = mock.Mock()
+        export_response.location.url = "https://vcenter/export"
+        export_response.location.download_token.token = "token-123"
+        export_response.location.download_token.expiry = "2026-05-18T16:57:06"
+        return export_response
+
+    def test_create_present(self, mocker):
+        self.__prepare(mocker)
+        self.providers_service.get.return_value = None
+        self.providers_service.create.return_value = mock.Mock()
+        self.providers_service.export.return_value = self._mock_export_response()
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "new-native",
+                "state": "present",
+                "export_password": "backup-password",
+            },
+        )
+
+        assert result["changed"] is True
+        assert result["export_info"] == {
+            "url": "https://vcenter/export",
+            "token": "token-123",
+            "expires_at": "2026-05-18T16:57:06",
+        }
+        self.providers_service.create.assert_called_once()
+        self.providers_service.export.assert_called_once()
+
+    def test_present_no_change(self, mocker):
+        self.__prepare(mocker)
+        self.providers_service.get.return_value = mock.Mock()
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={"provider_name": "existing-native", "state": "present"},
+        )
+
+        assert result["changed"] is False
+        self.providers_service.create.assert_not_called()
+
+    def test_set_default(self, mocker):
+        self.__prepare(mocker)
+        self.providers_service.get.return_value = mock.Mock()
+        default_id = mock.Mock()
+        default_id.id = "other-provider"
+        self.crypto_manager.GetDefaultKmsCluster.return_value = default_id
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "existing-native",
+                "state": "present",
+                "default_provider": True,
+            },
+        )
+
+        assert result["changed"] is True
+        self.crypto_manager.MarkDefault.assert_called_once()
+
+    def test_absent(self, mocker):
+        self.__prepare(mocker)
+        self.providers_service.get.return_value = mock.Mock()
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={"provider_name": "existing-native", "state": "absent"},
+        )
+
+        assert result["changed"] is True
+        self.providers_service.delete.assert_called_once_with("existing-native")
+
+    def test_absent_no_change(self, mocker):
+        self.__prepare(mocker)
+        self.providers_service.get.return_value = None
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={"provider_name": "missing-native", "state": "absent"},
+        )
+
+        assert result["changed"] is False
+        self.providers_service.delete.assert_not_called()

--- a/tests/unit/plugins/modules/test_key_provider_standard.py
+++ b/tests/unit/plugins/modules/test_key_provider_standard.py
@@ -1,0 +1,172 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.key_provider_standard import (
+    main as module_main,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient,
+)
+from ...common.utils import run_module, ModuleTestCase
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestKeyProviderStandard(ModuleTestCase):
+
+    def _mock_kms_server(self, mocker, server_id="kms-1"):
+        server = mocker.Mock()
+        server.name = server_id
+        server.address = "10.0.0.1"
+        server.port = 5696
+        server.proxyAddress = "10.0.0.2"
+        server.proxyPort = 5697
+        server.userName = "kmsuser"
+        return server
+
+    def _mock_cluster(self, mocker, servers=None, use_as_default=False):
+        cluster = mocker.Mock()
+        cluster.clusterId.id = "standard-1"
+        cluster.useAsDefault = use_as_default
+        cluster.servers = servers or [self._mock_kms_server(mocker)]
+        return cluster
+
+    def __prepare(self, mocker, clusters=None):
+        content_mock = mocker.Mock()
+        content_mock.cryptoManager = mocker.Mock()
+        content_mock.cryptoManager.kmipServers = clusters or []
+        si_mock = mocker.Mock()
+        si_mock.content = content_mock
+        mocker.patch.object(
+            PyvmomiClient, "connect_to_api", return_value=(si_mock, content_mock)
+        )
+        self.crypto_manager = content_mock.cryptoManager
+
+    def _kms_server_args(self, server_id="kms-1", address="10.0.0.1"):
+        return {
+            "id": server_id,
+            "address": address,
+            "port": 5696,
+            "proxy_address": "10.0.0.2",
+            "proxy_port": 5697,
+            "username": "kmsuser",
+            "password": "kms-password",
+        }
+
+    def test_create_cluster(self, mocker):
+        self.__prepare(mocker)
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "standard-1",
+                "state": "present",
+                "kms_servers": [self._kms_server_args()],
+            },
+        )
+
+        assert result["changed"] is True
+        assert result["modified_kms_servers"] == ["kms-1"]
+        self.crypto_manager.RegisterKmipServer.assert_called_once()
+
+    def test_present_no_change(self, mocker):
+        self.__prepare(mocker, clusters=[self._mock_cluster(mocker)])
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "standard-1",
+                "state": "present",
+                "always_update_password": False,
+                "kms_servers": [self._kms_server_args()],
+            },
+        )
+
+        assert result["changed"] is False
+        assert result["modified_kms_servers"] == []
+
+    def test_update_server(self, mocker):
+        self.__prepare(mocker, clusters=[self._mock_cluster(mocker)])
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "standard-1",
+                "state": "present",
+                "always_update_password": False,
+                "kms_servers": [self._kms_server_args(address="10.0.0.99")],
+            },
+        )
+
+        assert result["changed"] is True
+        assert result["modified_kms_servers"] == ["kms-1"]
+        self.crypto_manager.UpdateKmipServer.assert_called_once()
+
+    def test_add_server(self, mocker):
+        self.__prepare(mocker, clusters=[self._mock_cluster(mocker)])
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "standard-1",
+                "state": "present",
+                "always_update_password": False,
+                "kms_servers": [
+                    self._kms_server_args(),
+                    self._kms_server_args(server_id="kms-2", address="10.0.0.3"),
+                ],
+            },
+        )
+
+        assert result["changed"] is True
+        assert result["modified_kms_servers"] == ["kms-2"]
+        self.crypto_manager.RegisterKmipServer.assert_called_once()
+
+    def test_remove_server(self, mocker):
+        self.__prepare(mocker, clusters=[self._mock_cluster(mocker)])
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "standard-1",
+                "state": "present",
+                "kms_servers_state": "absent",
+                "kms_servers": [{"id": "kms-1"}],
+            },
+        )
+
+        assert result["changed"] is True
+        assert result["modified_kms_servers"] == ["kms-1"]
+        self.crypto_manager.RemoveKmipServer.assert_called_once()
+
+    def test_set_default(self, mocker):
+        self.__prepare(mocker, clusters=[self._mock_cluster(mocker)])
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={
+                "provider_name": "standard-1",
+                "state": "present",
+                "default_provider": True,
+                "kms_servers": [self._kms_server_args()],
+            },
+        )
+
+        assert result["changed"] is True
+        self.crypto_manager.MarkDefault.assert_called_once()
+
+    def test_absent(self, mocker):
+        self.__prepare(mocker, clusters=[self._mock_cluster(mocker)])
+
+        result = run_module(
+            module_entry=module_main,
+            module_args={"provider_name": "standard-1", "state": "absent"},
+        )
+
+        assert result["changed"] is True
+        self.crypto_manager.UnregisterKmsCluster.assert_called_once()


### PR DESCRIPTION
#### SUMMARY
- Add `key_provider_native` to create, delete, and set default native key providers in vCenter (REST API for provider lifecycle; PyVmomi for default provider)
- Add `key_provider_standard` to manage standard key provider clusters and KMS servers (PyVmomi)
- Add `key_provider_info` to gather key provider details, with optional filtering by name or type
- Include unit tests and an integration test target (`vmware_key_provider`)

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/key_provider_native.py
- plugins/modules/key_provider_standard.py
- plugins/modules/key_provider_info.py
- tests/unit/plugins/modules/test_key_provider_native.py
- tests/unit/plugins/modules/test_key_provider_standard.py
- tests/unit/plugins/modules/test_key_provider_info.py
- tests/integration/targets/vmware_key_provider/
- changelogs/fragments/key-provider-modules.yml

#### ADDITIONAL INFORMATION
- Sanity tests pass on all three modules
- Unit tests cover present/absent, KMS server add/update/remove, default provider, and info filtering

> This PR body was generated using AI and reviewed by the author.