### PR TITLE
feat(vm): add enable_vtpm parameter for virtual TPM management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,17 +53,10 @@ sanity: upgrade-collections
 
 .PHONY: units
 units: upgrade-collections
-<<<<<<< HEAD
 	cd $(COLLECTION_ROOT); \
 	ansible-test units --docker --python $(UNIT_PYTHON_VERSION) --coverage $(UNIT_TARGETS); \
 	ansible-test coverage combine --requirements --export tests/output/coverage/; \
 	ansible-test coverage report --requirements --docker --omit 'tests/*' --show-missing;
-=======
-	cd ~/.ansible/collections/ansible_collections/vmware/vmware; \
-	ansible-test units --docker --python 3.12 --coverage $(UNIT_TARGETS); \
-	ansible-test coverage combine --requirements --export tests/output/coverage/; \
-	ansible-test coverage report --requirements --docker --omit 'tests/*' --show-missing
->>>>>>> c9d42de (add vtpm support to vm module)
 
 .PHONY: units-coverage
 units-coverage: units

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,17 @@ sanity: upgrade-collections
 
 .PHONY: units
 units: upgrade-collections
+<<<<<<< HEAD
 	cd $(COLLECTION_ROOT); \
 	ansible-test units --docker --python $(UNIT_PYTHON_VERSION) --coverage $(UNIT_TARGETS); \
 	ansible-test coverage combine --requirements --export tests/output/coverage/; \
 	ansible-test coverage report --requirements --docker --omit 'tests/*' --show-missing;
+=======
+	cd ~/.ansible/collections/ansible_collections/vmware/vmware; \
+	ansible-test units --docker --python 3.12 --coverage $(UNIT_TARGETS); \
+	ansible-test coverage combine --requirements --export tests/output/coverage/; \
+	ansible-test coverage report --requirements --docker --omit 'tests/*' --show-missing
+>>>>>>> c9d42de (add vtpm support to vm module)
 
 .PHONY: units-coverage
 units-coverage: units

--- a/changelogs/fragments/05192026-vm-vtpm.yml
+++ b/changelogs/fragments/05192026-vm-vtpm.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - vm - Add enable_vtpm parameter to enable or disable virtual Trusted Platform Module (vTPM) on virtual machines.

--- a/plugins/module_utils/vm/objects/_vtpm.py
+++ b/plugins/module_utils/vm/objects/_vtpm.py
@@ -1,0 +1,89 @@
+"""
+vTPM object representation for VM configuration management.
+
+This module provides the Vtpm class for managing VMware virtual Trusted
+Platform Module (vTPM) devices. A vTPM is a virtual device compatible with
+TPM 2.0 that depends on VM encryption and a configured key provider.
+"""
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ._abstract import AbstractVsphereObject
+
+
+class Vtpm(AbstractVsphereObject):
+    """
+    Object representation of a virtual Trusted Platform Module (vTPM) device.
+
+    vTPM devices cannot be meaningfully updated after creation; they are added
+    or removed only. There is at most one vTPM per virtual machine.
+    """
+
+    @classmethod
+    def from_live_device_spec(cls, live_device_spec):
+        """
+        Create Vtpm instance from an existing VMware TPM device.
+
+        Args:
+            live_device_spec: VMware VirtualTPM device object
+
+        Returns:
+            Vtpm: Configured vTPM instance representing the live device
+        """
+        return cls(raw_object=live_device_spec)
+
+    def __str__(self):
+        return "vTPM"
+
+    def to_new_spec(self):
+        """
+        Create a VMware device specification for adding a new vTPM.
+
+        Returns:
+            vim.vm.device.VirtualDeviceSpec: VMware device specification for vTPM creation
+        """
+        spec = vim.vm.device.VirtualDeviceSpec()
+        spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        spec.device = vim.vm.device.VirtualTPM()
+        spec.device.deviceInfo = vim.Description()
+        spec.device.key = self._new_spec_key
+
+        return spec
+
+    def to_update_spec(self):
+        """
+        No update options are available for vTPM devices.
+        """
+        return None
+
+    def differs_from_live_object(self):
+        """
+        Check if the linked VM device differs from desired configuration.
+
+        vTPM presence is managed by add/remove only; an existing linked device
+        is always considered in sync.
+
+        Returns:
+            bool: True if the device is not linked, False if already present
+        """
+        if not self.has_a_linked_live_vm_device():
+            return True
+
+        return False
+
+    def _to_module_output(self):
+        """
+        Generate module output friendly representation of this object.
+
+        Returns:
+            dict
+        """
+        output = {
+            "object_type": "vtpm",
+            "label": str(self),
+        }
+
+        return output

--- a/plugins/module_utils/vm/parameter_handlers/device_linked/_vtpms.py
+++ b/plugins/module_utils/vm/parameter_handlers/device_linked/_vtpms.py
@@ -1,0 +1,123 @@
+"""
+vTPM parameter handler for VM configuration.
+
+This module provides the VtpmParameterHandler class which manages virtual
+Trusted Platform Module (vTPM) configuration. It handles enabling and
+disabling vTPM devices on virtual machines through the enable_vtpm parameter.
+"""
+
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers._abstract import (
+    AbstractDeviceLinkedParameterHandler,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._vtpm import (
+    Vtpm,
+)
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+
+class VtpmParameterHandler(AbstractDeviceLinkedParameterHandler):
+    """
+    Handler for virtual Trusted Platform Module (vTPM) configuration.
+
+    Managed Parameters:
+        - enable_vtpm (bool): When true, ensure a vTPM device is present on the VM.
+          When false, ensure no vTPM device is present. When omitted, vTPM is not managed.
+    """
+
+    HANDLER_NAME = "vtpm"
+
+    def __init__(
+        self, error_handler, params, change_set, vm, device_tracker, **kwargs
+    ):
+        """
+        Initialize the vTPM parameter handler.
+
+        Args:
+            error_handler: Service for parameter validation error handling
+            params (dict): Module parameters containing vTPM configuration
+            change_set: Service for tracking configuration changes and requirements
+            vm: VM object being configured (None for new VM creation)
+            device_tracker: Service for device identification and error reporting
+        """
+        super().__init__(error_handler, params, change_set, vm, device_tracker)
+        self._check_if_params_are_defined_by_user(
+            "enable_vtpm", required_for_vm_creation=False
+        )
+
+        if self.params.get("enable_vtpm") is True:
+            self.managed_parameter_objects[0] = Vtpm()
+
+    @property
+    def vim_device_class(self):
+        """
+        Get the VMware device class for virtual TPM devices.
+        """
+        return vim.vm.device.VirtualTPM
+
+    def verify_parameter_constraints(self):
+        """
+        Validate vTPM parameter constraints and requirements.
+
+        When enable_vtpm is true, validates EFI boot firmware and that the VM has
+        no snapshots.
+
+        Raises:
+            Calls error_handler.fail_with_parameter_error() for constraint violations.
+        """
+        if not self.params.get("enable_vtpm"):
+            return
+
+        boot_firmware = self.params.get("vm_options", dict()).get("boot_firmware")
+        if self.vm is not None:
+            if boot_firmware is None:
+                boot_firmware = self.vm.config.firmware
+
+            if self.vm.snapshot:
+                self.error_handler.fail_with_parameter_error(
+                    parameter_name="enable_vtpm",
+                    message="vTPM cannot be enabled on a VM that has snapshots."
+                )
+
+        if boot_firmware != "efi":
+            self.error_handler.fail_with_parameter_error(
+                parameter_name="enable_vtpm",
+                message="vTPM requires EFI boot firmware.",
+                details={"firmware": boot_firmware},
+            )
+
+        return
+
+    def link_vm_device(self, device):
+        """
+        Link a VMware vTPM device to the handler's managed object.
+
+        When enable_vtpm is true, links the live device to the desired vTPM object.
+        When enable_vtpm is false, returns a live vTPM representation so the device
+        tracker can schedule it for removal.
+
+        Args:
+            device: VMware VirtualTPM device to link
+
+        Returns:
+            Vtpm or None: Live vTPM object to remove when enable_vtpm is false,
+            otherwise None when the device was linked successfully.
+        """
+        if not self.managed_parameter_objects:
+            return Vtpm.from_live_device_spec(device)
+
+        vtpm = self.managed_parameter_objects[0]
+        if vtpm.has_a_linked_live_vm_device():
+            self.error_handler.fail_with_parameter_error(
+                parameter_name="enable_vtpm",
+                message="vTPM is already enabled, but more than one vTPM device was found. This is not a supported configuration.",
+                details={"vtpm": str(vtpm)},
+            )
+
+        vtpm.link_corresponding_live_object(
+            Vtpm.from_live_device_spec(device)
+        )
+        return

--- a/plugins/module_utils/vm/parameter_handlers/device_linked/_vtpms.py
+++ b/plugins/module_utils/vm/parameter_handlers/device_linked/_vtpms.py
@@ -89,8 +89,6 @@ class VtpmParameterHandler(AbstractDeviceLinkedParameterHandler):
                 details={"firmware": boot_firmware},
             )
 
-        return
-
     def link_vm_device(self, device):
         """
         Link a VMware vTPM device to the handler's managed object.
@@ -120,4 +118,3 @@ class VtpmParameterHandler(AbstractDeviceLinkedParameterHandler):
         vtpm.link_corresponding_live_object(
             Vtpm.from_live_device_spec(device)
         )
-        return

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -181,7 +181,7 @@ options:
         required: false
         default: 600
 
-    # resources
+    # begin compute resources
     cpu:
         description:
             - Options related to CPU resource allocation.
@@ -300,7 +300,9 @@ options:
                     - The maximum amount of memory the VM can use.
                 type: int
                 required: false
+    # end compute resources
 
+    # begin storage resources
     disks_remove_unmanaged:
         description:
             - Whether to remove disks that are not specified in the O(disks) parameter.
@@ -395,7 +397,9 @@ options:
                     - Only one of O(disks[].datastore) or O(disks[].filename) can be set.
                 type: str
                 required: false
+    # end storage resources
 
+    # begin devices
     cdroms_remove_unmanaged:
         description:
             - Whether to remove CD-ROMs that are not specified in the O(cdroms) parameter.
@@ -687,6 +691,20 @@ options:
                 type: int
                 required: true
 
+    enable_vtpm:
+        description:
+            - Whether to enable Virtual Trusted Platform Module (vTPM) for the VM.
+            - vTPM requires EFI boot firmware (O(vm_options.boot_firmware)).
+            - A TPM enabled key provider must already be configured in vCenter, and the host the VM
+              runs on must be TPM enabled.
+            - The VM must not have any existing snapshots before enabling vTPM.
+            - The VM must be powered off when adding or removing a vTPM device. See O(allow_power_cycling).
+
+        type: bool
+        required: false
+    # end devices
+
+    # begin vm options
     vm_options:
         description:
             - Advanced and miscellaneous options for the VM, including things like BIOS settings,
@@ -764,6 +782,7 @@ options:
                 type: str
                 required: false
                 choices: [ bios, efi ]
+    # end vm options
 
 extends_documentation_fragment:
     - vmware.vmware.base_options
@@ -821,6 +840,7 @@ EXAMPLES = r'''
         connected: true
         connect_at_power_on: true
         mac_address: 11:11:11:11:11:11
+    enable_vtpm: true
     vm_options:
       maximum_remote_console_sessions: 10
       enable_io_mmu: true
@@ -982,6 +1002,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handler
     _network_adapters,
     _cdroms,
     _nvdimms,
+    _vtpms,
 )
 from ansible_collections.vmware.vmware.plugins.module_utils.vm._configuration_builder import (
     ConfigurationRegistry,
@@ -1013,6 +1034,7 @@ class VmModule(ModulePyvmomiBase):
         self.configuration_registry.register_device_linked_handler(_network_adapters.NetworkAdapterParameterHandler)
         self.configuration_registry.register_device_linked_handler(_cdroms.CdromParameterHandler)
         self.configuration_registry.register_device_linked_handler(_nvdimms.NvdimmParameterHandler)
+        self.configuration_registry.register_device_linked_handler(_vtpms.VtpmParameterHandler)
 
         self.configuration_registry.register_controller_handler(_controllers.ScsiControllerParameterHandler)
         self.configuration_registry.register_controller_handler(_controllers.NvmeControllerParameterHandler)
@@ -1331,6 +1353,8 @@ def main():
                         size_mb=dict(type='int', required=True),
                     )
                 ),
+
+                enable_vtpm=dict(type='bool', required=False),
 
                 vm_options=dict(
                     type='dict', required=False, options=dict(

--- a/tests/integration/targets/vmware_vm/tasks/basic_vm_update_tests.yml
+++ b/tests/integration/targets/vmware_vm/tasks/basic_vm_update_tests.yml
@@ -38,6 +38,9 @@
     scsi_controllers:
       - controller_type: paravirtual
         bus_number: 0
+    enable_vtpm: true
+    vm_options:
+      boot_firmware: efi
   register: _update_vm
 
 - name: Update VM - Idempotent
@@ -65,8 +68,8 @@
       - vm_info.moid == _update_vm.vm.moid
       - vm_info.hw_name == _update_vm.vm.name
 
-      - (_update_vm.changes.changed_parameters.keys() | length) == 2 # guest_id and annotation
-      - _update_vm.changes.objects_to_add == []
+      - (_update_vm.changes.changed_parameters.keys() | length) == 3 # guest_id, annotation, and boot firmware
+      - _update_vm.changes.objects_to_add[0].object_type == 'vtpm'
       - _update_vm.changes.objects_to_update == []
       - _update_vm.changes.objects_to_remove == []
       - _update_vm.changes.changed_parameters['guest_id'] is defined
@@ -79,6 +82,7 @@
   vmware.vmware.vm: &update-vm-minimal
     name: "{{ test_vm_name }}"
     guest_id: amazonlinux3_64Guest
+    enable_vtpm: false
   register: _update_vm_minimal
 
 - name: Update VM with minimal options - Idempotent
@@ -98,9 +102,9 @@
       - vm_info.moid == _update_vm_minimal.vm.moid
       - vm_info.hw_name == _update_vm_minimal.vm.name
       - (_update_vm_minimal.changes.changed_parameters.keys() | length) == 1
-      - _update_vm.changes.objects_to_add == []
-      - _update_vm.changes.objects_to_update == []
-      - _update_vm.changes.objects_to_remove == []
+      - _update_vm_minimal.changes.objects_to_add == []
+      - _update_vm_minimal.changes.objects_to_update == []
+      - _update_vm_minimal.changes.objects_to_remove[0].object_type == 'vtpm'
   vars:
     vm_info: "{{ _lookup_vm_info.guests[0] }}"
 

--- a/tests/unit/plugins/module_utils/vm/objects/test_vtpm.py
+++ b/tests/unit/plugins/module_utils/vm/objects/test_vtpm.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from unittest.mock import Mock, patch
+
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._vtpm import (
+    Vtpm,
+)
+
+
+class TestVtpm:
+
+    @pytest.fixture
+    def vtpm(self):
+        return Vtpm()
+
+    def test_key(self, vtpm):
+        vtpm.represents_live_vm_device = Mock(return_value=True)
+        vtpm._raw_object = Mock(key=1001)
+        assert vtpm.key == 1001
+
+        vtpm.represents_live_vm_device = Mock(return_value=False)
+        vtpm.has_a_linked_live_vm_device = Mock(return_value=True)
+        vtpm._live_object = Mock(key=1000)
+        assert vtpm.key == 1000
+
+        vtpm.represents_live_vm_device = Mock(return_value=False)
+        vtpm.has_a_linked_live_vm_device = Mock(return_value=False)
+        assert vtpm.key is not None
+
+    def test_from_live_device_spec_and_str(self):
+        live_device = Mock()
+        vtpm = Vtpm.from_live_device_spec(live_device)
+        assert vtpm._raw_object is live_device
+        assert str(vtpm) == "vTPM"
+
+    @patch(
+        "ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._vtpm.vim.vm.device.VirtualDeviceSpec"
+    )
+    def test_to_new_spec(self, mock_spec, vtpm):
+        mock_spec.return_value = Mock()
+        spec = vtpm.to_new_spec()
+        assert spec.device.key is not None
+
+    def test_to_update_spec(self, vtpm):
+        assert vtpm.to_update_spec() is None
+
+    def test_differs_from_live_object(self, vtpm):
+        vtpm.has_a_linked_live_vm_device = Mock(return_value=False)
+        assert vtpm.differs_from_live_object() is True
+        vtpm.has_a_linked_live_vm_device = Mock(return_value=True)
+        assert vtpm.differs_from_live_object() is False
+
+    def test_to_module_output(self, vtpm):
+        assert vtpm._to_module_output() == {
+            "object_type": "vtpm",
+            "label": "vTPM",
+        }

--- a/tests/unit/plugins/module_utils/vm/parameter_handlers/device_linked/test_vtpms.py
+++ b/tests/unit/plugins/module_utils/vm/parameter_handlers/device_linked/test_vtpms.py
@@ -1,0 +1,120 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from unittest.mock import Mock
+
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.parameter_handlers.device_linked._vtpms import (
+    VtpmParameterHandler,
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.vm.objects._vtpm import (
+    Vtpm,
+)
+
+
+class TestVtpmParameterHandler:
+
+    @pytest.fixture
+    def handler_factory(self):
+        def _make(params, vm=None):
+            return VtpmParameterHandler(
+                Mock(), params, Mock(), vm, Mock()
+            )
+        return _make
+
+    def test_init_enable_vtpm(self, handler_factory):
+        handler = handler_factory({"enable_vtpm": True})
+        assert 0 in handler.managed_parameter_objects
+        assert isinstance(handler.managed_parameter_objects[0], Vtpm)
+
+        handler = handler_factory({})
+        assert handler.PARAMS_DEFINED_BY_USER is False
+        assert handler.managed_parameter_objects == {}
+
+    def test_verify_parameter_constraints(self, handler_factory):
+        handler = handler_factory({"enable_vtpm": False})
+        handler.verify_parameter_constraints()
+        handler.error_handler.fail_with_parameter_error.assert_not_called()
+
+        handler = handler_factory(
+            {"enable_vtpm": True},
+            vm=Mock(config=Mock(firmware="efi"), snapshot=None),
+        )
+        handler.verify_parameter_constraints()
+        handler.error_handler.fail_with_parameter_error.assert_not_called()
+
+        handler = handler_factory(
+            {"enable_vtpm": True},
+            vm=Mock(config=Mock(firmware="bios"), snapshot=None),
+        )
+        handler.error_handler.fail_with_parameter_error = Mock(
+            side_effect=ValueError("firmware")
+        )
+        with pytest.raises(ValueError, match="firmware"):
+            handler.verify_parameter_constraints()
+
+        handler = handler_factory(
+            {"enable_vtpm": True},
+            vm=Mock(config=Mock(firmware="efi"), snapshot=Mock()),
+        )
+        handler.error_handler.fail_with_parameter_error = Mock(
+            side_effect=ValueError("snapshot")
+        )
+        with pytest.raises(ValueError, match="snapshot"):
+            handler.verify_parameter_constraints()
+
+        handler = handler_factory(
+            {
+                "enable_vtpm": True,
+                "vm_options": {"boot_firmware": "efi"},
+            },
+            vm=None,
+        )
+        handler.error_handler.fail_with_parameter_error = Mock()
+        handler.verify_parameter_constraints()
+        handler.error_handler.fail_with_parameter_error.assert_not_called()
+
+    def test_compare_and_populate_config_spec(self, handler_factory):
+        handler = handler_factory({"enable_vtpm": True})
+        handler.change_set.objects_to_add = []
+        handler.change_set.objects_to_update = []
+        handler.compare_live_config_with_desired_config()
+        assert len(handler.change_set.objects_to_add) == 1
+
+        handler.change_set.objects_to_add = []
+        handler.managed_parameter_objects[0].link_corresponding_live_object(
+            Vtpm.from_live_device_spec(Mock())
+        )
+        handler.compare_live_config_with_desired_config()
+        assert handler.change_set.objects_to_add == []
+
+        configspec = Mock(deviceChange=[])
+        handler.change_set.objects_to_add = [handler.managed_parameter_objects[0]]
+        handler.populate_config_spec_with_parameters(configspec)
+        assert len(configspec.deviceChange) == 1
+
+    def test_link_vm_device(self, handler_factory):
+        device = Mock()
+
+        handler = handler_factory({"enable_vtpm": False})
+        result = handler.link_vm_device(device)
+        assert isinstance(result, Vtpm)
+        assert result._raw_object is device
+
+        handler = handler_factory({"enable_vtpm": True})
+        vtpm = handler.managed_parameter_objects[0]
+        assert handler.link_vm_device(device) is None
+        assert vtpm.has_a_linked_live_vm_device()
+
+    def test_link_vm_device_duplicate_vtpm(self, handler_factory):
+        handler = handler_factory({"enable_vtpm": True})
+        vtpm = handler.managed_parameter_objects[0]
+        vtpm.link_corresponding_live_object(Vtpm.from_live_device_spec(Mock()))
+
+        handler.error_handler.fail_with_parameter_error = Mock(
+            side_effect=ValueError("duplicate")
+        )
+        with pytest.raises(ValueError, match="duplicate"):
+            handler.link_vm_device(Mock())
+        handler.error_handler.fail_with_parameter_error.assert_called_once()


### PR DESCRIPTION
#### SUMMARY
- Add `enable_vtpm` parameter to the `vm` module to enable or disable virtual Trusted Platform Module (vTPM) on virtual machines.

#### ISSUE TYPE
- Feature Pull Request

#### COMPONENT NAME
- plugins/modules/vm.py
- plugins/module_utils/vm/objects/_vtpm.py
- plugins/module_utils/vm/parameter_handlers/device_linked/_vtpms.py

#### ADDITIONAL INFORMATION
- Unit tests added for the vTPM object and parameter handler.

---
*This PR description was drafted with AI assistance and reviewed by the author.*