### PR TITLE
fix: improve vms and esxi_hosts inventory property gathering performance

### DIFF
--- a/changelogs/fragments/prop_set_inven_318.yml
+++ b/changelogs/fragments/prop_set_inven_318.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - inventory plugins - Improve how properties are gathered to decrease execution time (https://github.com/ansible-collections/vmware.vmware/issues/318).

--- a/changelogs/fragments/prop_set_inven_318.yml
+++ b/changelogs/fragments/prop_set_inven_318.yml
@@ -1,3 +1,6 @@
 ---
 minor_changes:
   - inventory plugins - Improve how properties are gathered to decrease execution time (https://github.com/ansible-collections/vmware.vmware/issues/318).
+
+bugfixes:
+  - inventory plugins - Fix a bug where the customValue property was always gathered, even when not requested

--- a/plugins/inventory/esxi_hosts.py
+++ b/plugins/inventory/esxi_hosts.py
@@ -137,12 +137,13 @@ class EsxiInventoryHost(VmwareInventoryHost):
         self._management_ip = None
 
     @classmethod
-    def create_from_object(cls, vmware_object, properties_to_gather, pyvmomi_client):
-        """
-        Create the class from a host object that we got from pyvmomi. The host properties will be populated
-        from the object and additional calls to vCenter
-        """
-        host = super().create_from_object(vmware_object, properties_to_gather, pyvmomi_client)
+    def create_from_vcenter_object(cls, vmware_object, properties_to_gather, pyvmomi_client, prop_set=None):
+        host = super().create_from_vcenter_object(
+            vmware_object,
+            properties_to_gather,
+            pyvmomi_client,
+            prop_set=prop_set,
+        )
         host.properties['management_ip'] = host.management_ip
         return host
 
@@ -242,6 +243,12 @@ class InventoryModule(VmwareInventoryBase):
             )
             self.add_host_object_from_vcenter_to_inventory(esxi_host, hostvars)
 
+    def _host_connection_state(self, esxi_host):
+        try:
+            return esxi_host.properties['summary']['runtime']['connectionState']
+        except KeyError:
+            return esxi_host.object.summary.runtime.connectionState
+
     def populate_from_vcenter(self):
         """
         Populate inventory data from vCenter
@@ -252,15 +259,19 @@ class InventoryModule(VmwareInventoryBase):
         if self.get_option("gather_tags"):
             self.initialize_rest_client()
 
-        for host_object in self.get_objects_by_type(vim_type=[vim.HostSystem]):
-            if host_object.runtime.connectionState in ("disconnected", "notResponding"):
-                continue
-
-            esxi_host = EsxiInventoryHost.create_from_object(
-                vmware_object=host_object,
+        for vmware_object, prop_set in self.iter_inventory_sources(
+            vim.HostSystem,
+            properties_to_gather,
+        ):
+            esxi_host = EsxiInventoryHost.create_from_vcenter_object(
+                vmware_object=vmware_object,
                 properties_to_gather=properties_to_gather,
-                pyvmomi_client=self.pyvmomi_client
+                pyvmomi_client=self.pyvmomi_client,
+                prop_set=prop_set,
             )
+
+            if self._host_connection_state(esxi_host) in ("disconnected", "notResponding"):
+                continue
 
             if self.get_option("gather_tags"):
                 self.add_tags_to_object_properties(esxi_host)

--- a/plugins/inventory/vms.py
+++ b/plugins/inventory/vms.py
@@ -343,8 +343,6 @@ class InventoryModule(VmwareInventoryBase):
     def populate_from_vcenter(self):
         """
         Populate inventory data from vCenter.
-        If there are specific properties to gather, use the PropertyCollector to retrieve the objects and only the requested properties.
-        Otherwise,
         """
         hostvars = {}
         properties_to_gather = self.parse_properties_param()

--- a/plugins/inventory/vms.py
+++ b/plugins/inventory/vms.py
@@ -342,7 +342,9 @@ class InventoryModule(VmwareInventoryBase):
 
     def populate_from_vcenter(self):
         """
-        Populate inventory data from vCenter
+        Populate inventory data from vCenter.
+        If there are specific properties to gather, use the PropertyCollector to retrieve the objects and only the requested properties.
+        Otherwise,
         """
         hostvars = {}
         properties_to_gather = self.parse_properties_param()
@@ -350,11 +352,15 @@ class InventoryModule(VmwareInventoryBase):
         if self.get_option("gather_tags"):
             self.initialize_rest_client()
 
-        for vm_object in self.get_objects_by_type(vim_type=[vim.VirtualMachine]):
-            vm = VmInventoryHost.create_from_object(
-                vmware_object=vm_object,
+        for vmware_object, prop_set in self.iter_inventory_sources(
+            vim.VirtualMachine,
+            properties_to_gather,
+        ):
+            vm = VmInventoryHost.create_from_vcenter_object(
+                vmware_object=vmware_object,
                 properties_to_gather=properties_to_gather,
-                pyvmomi_client=self.pyvmomi_client
+                pyvmomi_client=self.pyvmomi_client,
+                prop_set=prop_set,
             )
 
             if self.get_option("gather_tags"):

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -284,7 +284,7 @@ class VmwareInventoryBase(BaseInventoryPlugin, Constructable, Cacheable):
             properties_to_gather: List of property paths. An empty list is not supported here.
 
         Returns:
-            List of vmodl query ObjectContent results (obj + propSet), deduplicated by MOID.
+            List of vmodl query ObjectContent results (obj + propSet)
         """
         query_paths = [prop for prop in properties_to_gather if prop != 'customValue']
         if not self.get_option('search_paths'):

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -93,7 +93,7 @@ class VmwareInventoryHost(ABC):
         if not hasattr(self.object, "customValue"):
             return
 
-        self.properties['customValue'] = dict()
+        self.properties['customValue'] = {}
         field_mgr = pyvmomi_client.custom_field_mgr
         for cust_value in self.object.customValue:
             self.properties['customValue'][
@@ -287,30 +287,23 @@ class VmwareInventoryBase(BaseInventoryPlugin, Constructable, Cacheable):
             List of vmodl query ObjectContent results (obj + propSet), deduplicated by MOID.
         """
         query_paths = [prop for prop in properties_to_gather if prop != 'customValue']
-        seen_moids = set()
-        results = []
-
-        def _collect_from_folder(folder):
-            for obj_content in self.pyvmomi_client.get_managed_object_references(
+        if not self.get_option('search_paths'):
+            return self.pyvmomi_client.get_managed_object_references(
                 vimtype=vim_type,
                 properties=query_paths,
-                folder=folder,
-            ):
-                moid = obj_content.obj._GetMoId()
-                if moid in seen_moids:
-                    continue
-                seen_moids.add(moid)
-                results.append(obj_content)
+                folder=None,
+            )
 
-        if not self.get_option('search_paths'):
-            _collect_from_folder(folder=None)
-            return results
-
+        results = []
         for search_path in self.get_option('search_paths'):
             folder = self.pyvmomi_client.si.content.searchIndex.FindByInventoryPath(search_path)
             if not folder:
                 continue
-            _collect_from_folder(folder=folder)
+            results.extend(self.pyvmomi_client.get_managed_object_references(
+                vimtype=vim_type,
+                properties=query_paths,
+                folder=folder,
+            ))
 
         return results
 

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -73,7 +73,6 @@ class VmwareInventoryHost(ABC):
         host._set_inventory_properties(properties_to_gather, pyvmomi_client, prop_set)
         return host
 
-
     @abstractmethod
     def get_tags(self, rest_client):
         pass
@@ -88,7 +87,7 @@ class VmwareInventoryHost(ABC):
         self._add_custom_values_to_properties(properties_to_gather, pyvmomi_client)
 
     def _add_custom_values_to_properties(self, properties_to_gather, pyvmomi_client):
-        if 'customValue' not in properties_to_gather:
+        if properties_to_gather and 'customValue' not in properties_to_gather:
             return
 
         if not hasattr(self.object, "customValue"):

--- a/plugins/inventory_utils/_base.py
+++ b/plugins/inventory_utils/_base.py
@@ -26,6 +26,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils._folder_paths import
 )
 from ansible_collections.vmware.vmware.plugins.module_utils._facts import (
     vmware_obj_to_json,
+    properties_from_collector,
     flatten_dict
 )
 
@@ -59,36 +60,46 @@ class VmwareInventoryHost(ABC):
         return host
 
     @classmethod
-    def create_from_object(cls, vmware_object, properties_to_gather, pyvmomi_client):
+    def create_from_vcenter_object(cls, vmware_object, properties_to_gather, pyvmomi_client, prop_set=None):
         """
-        Create the class from a host object that we got from pyvmomi. The host properties will be populated
-        from the object and additional calls to vCenter
+        Create the class from a vCenter object reference.
+
+        When prop_set is provided, properties come from a PropertyCollector result.
+        Otherwise properties are read from the object via vmware_obj_to_json().
         """
         host = cls()
         host.object = vmware_object
         host.path = get_folder_path_of_vsphere_object(vmware_object)
-        host.properties = host.get_properties_from_pyvmomi(properties_to_gather, pyvmomi_client)
+        host._set_inventory_properties(properties_to_gather, pyvmomi_client, prop_set)
         return host
+
 
     @abstractmethod
     def get_tags(self, rest_client):
         pass
 
-    def get_properties_from_pyvmomi(self, properties_to_gather, pyvmomi_client):
-        properties = vmware_obj_to_json(self.object, properties_to_gather)
-        properties['path'] = self.path
-        properties['moid'] = self.object._GetMoId()
+    def _set_inventory_properties(self, properties_to_gather, pyvmomi_client, prop_set=None):
+        if prop_set is not None:
+            self.properties = properties_from_collector(prop_set)
+        else:
+            self.properties = vmware_obj_to_json(self.object, properties_to_gather)
+        self.properties['path'] = self.path
+        self.properties['moid'] = self.object._GetMoId()
+        self._add_custom_values_to_properties(properties_to_gather, pyvmomi_client)
 
-        # Custom values
-        if hasattr(self.object, "customValue"):
-            properties['customValue'] = dict()
-            field_mgr = pyvmomi_client.custom_field_mgr
-            for cust_value in self.object.customValue:
-                properties['customValue'][
-                    [y.name for y in field_mgr if y.key == cust_value.key][0]
-                ] = cust_value.value
+    def _add_custom_values_to_properties(self, properties_to_gather, pyvmomi_client):
+        if 'customValue' not in properties_to_gather:
+            return
 
-        return properties
+        if not hasattr(self.object, "customValue"):
+            return
+
+        self.properties['customValue'] = dict()
+        field_mgr = pyvmomi_client.custom_field_mgr
+        for cust_value in self.object.customValue:
+            self.properties['customValue'][
+                [y.name for y in field_mgr if y.key == cust_value.key][0]
+            ] = cust_value.value
 
     def sanitize_properties(self):
         self.properties = camel_dict_to_snake_dict(self.properties)
@@ -264,6 +275,59 @@ class VmwareInventoryBase(BaseInventoryPlugin, Constructable, Cacheable):
             objects += self.pyvmomi_client.get_all_objs_by_type(vimtype=vim_type, folder=folder)
 
         return objects
+
+    def get_property_collector_results_by_type(self, vim_type, properties_to_gather):
+        """
+        Use the PropertyCollector to retrieve objects and only the requested properties.
+
+        Args:
+            vim_type: A single vim type, for example vim.VirtualMachine
+            properties_to_gather: List of property paths. An empty list is not supported here.
+
+        Returns:
+            List of vmodl query ObjectContent results (obj + propSet), deduplicated by MOID.
+        """
+        query_paths = [prop for prop in properties_to_gather if prop != 'customValue']
+        seen_moids = set()
+        results = []
+
+        def _collect_from_folder(folder):
+            for obj_content in self.pyvmomi_client.get_managed_object_references(
+                vimtype=vim_type,
+                properties=query_paths,
+                folder=folder,
+            ):
+                moid = obj_content.obj._GetMoId()
+                if moid in seen_moids:
+                    continue
+                seen_moids.add(moid)
+                results.append(obj_content)
+
+        if not self.get_option('search_paths'):
+            _collect_from_folder(folder=None)
+            return results
+
+        for search_path in self.get_option('search_paths'):
+            folder = self.pyvmomi_client.si.content.searchIndex.FindByInventoryPath(search_path)
+            if not folder:
+                continue
+            _collect_from_folder(folder=folder)
+
+        return results
+
+    def iter_inventory_sources(self, vim_type, properties_to_gather):
+        """
+        Yield (vmware_object, prop_set) pairs for inventory construction.
+
+        prop_set is None when all properties should be read from the object.
+        """
+        if properties_to_gather:
+            for obj_content in self.get_property_collector_results_by_type(vim_type, properties_to_gather):
+                yield obj_content.obj, obj_content.propSet
+            return
+
+        for vmware_object in self.get_objects_by_type(vim_type=[vim_type]):
+            yield vmware_object, None
 
     def add_tags_to_object_properties(self, vmware_host_object):
         """

--- a/plugins/module_utils/_facts.py
+++ b/plugins/module_utils/_facts.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import base64
 import json
 import os
 
@@ -604,12 +605,83 @@ def _jsonify_vmware_object(obj):
                                  sort_keys=True, strip_dynamic=True))
 
 
+def _normalize_property_name(prop):
+    if prop.lower() == '_moid':
+        return 'moid'
+    if prop.lower() == '_vimref':
+        return 'vimref'
+    return prop
+
+
+def _jsonify_vmware_value(vim_prop):
+    """
+    Convert a single pyVmomi property value to JSON-compatible Python types.
+    Uses _jsonify_vmware_object for vim DataObject values; scalars and enums are converted directly.
+    """
+    if vim_prop is None:
+        return None
+
+    prop_type = type(vim_prop).__name__
+    if prop_type in ('bool', 'int', 'float', 'str', 'NoneType'):
+        return vim_prop
+
+    if prop_type == 'datetime':
+        from pyVmomi import Iso8601
+        return Iso8601.ISO8601Format(vim_prop)
+
+    if prop_type == 'long':
+        return int(vim_prop)
+
+    if prop_type == 'long[]':
+        return [int(x) for x in vim_prop]
+
+    if isinstance(vim_prop, (list, tuple)):
+        return [_jsonify_vmware_value(item) for item in vim_prop]
+
+    if isinstance(vim_prop, Mapping):
+        return {key: _jsonify_vmware_value(value) for key, value in vim_prop.items()}
+
+    if prop_type.startswith(("vim", "vmodl", "Link")):
+        try:
+            from pyVmomi.VmomiSupport import DataObject
+        except ImportError:
+            return _jsonify_vmware_object(vim_prop)
+        if isinstance(vim_prop, DataObject):
+            return _jsonify_vmware_object(vim_prop)
+        return str(vim_prop)
+
+    if prop_type == 'binary':
+        return to_text(base64.b64encode(vim_prop))
+
+    return to_text(vim_prop)
+
+
+def _merge_dotted_property(result, prop_name, value):
+    prop_dict = _jsonify_vmware_value(value)
+    for key in reversed(prop_name.split('.')):
+        prop_dict = {key: prop_dict}
+    deepmerge_dicts(result, prop_dict)
+
+
+def properties_from_collector(prop_set):
+    """
+    Convert a PropertyCollector propSet into the nested dict used by inventory hostvars.
+    """
+    result = dict()
+    for prop in prop_set:
+        _merge_dotted_property(result, prop.name, prop.val)
+    return result
+
+
 def vmware_obj_to_json(obj, properties=None):
     """
     Convert a vSphere (pyVmomi) Object into JSON.  This is a deep
     transformation.  The list of properties is optional - if not
     provided then all properties are deeply converted.  The resulting
     JSON is sorted to improve human readability.
+
+    Dotted properties under the same top-level name share one parent fetch
+    and JSON conversion per top-level key.
 
     Args:
         - obj (object): vim object
@@ -621,28 +693,26 @@ def vmware_obj_to_json(obj, properties=None):
     Return:
         dict
     """
+    if not properties:
+        return _jsonify_vmware_object(obj)
+
     result = dict()
-    if properties:
-        for prop in properties:
-            try:
-                if '.' in prop:
-                    key, remainder = prop.split('.', 1)
-                    tmp = dict()
-                    tmp[key] = extract_dotted_property_to_dict(_jsonify_vmware_object(getattr(obj, key)), remainder)
-                    deepmerge_dicts(result, tmp)
-                else:
-                    result[prop] = _jsonify_vmware_object(getattr(obj, prop))
-                    # To match gather_vm_facts output
-                    prop_name = prop
-                    if prop.lower() == '_moid':
-                        prop_name = 'moid'
-                    elif prop.lower() == '_vimref':
-                        prop_name = 'vimref'
-                    result[prop_name] = result[prop]
-            except (AttributeError, KeyError):
-                raise AttributeError("Property '%s' not found." % prop)
-    else:
-        result = _jsonify_vmware_object(obj)
+    jsonified_parents = {}
+
+    for prop in properties:
+        try:
+            if '.' in prop:
+                key, remainder = prop.split('.', 1)
+                if key not in jsonified_parents:
+                    jsonified_parents[key] = _jsonify_vmware_object(getattr(obj, key))
+                tmp = {key: extract_dotted_property_to_dict(jsonified_parents[key], remainder)}
+                deepmerge_dicts(result, tmp)
+            else:
+                prop_name = _normalize_property_name(prop)
+                result[prop_name] = _jsonify_vmware_object(getattr(obj, prop))
+        except (AttributeError, KeyError) as exc:
+            raise AttributeError("Property '%s' not found." % prop) from exc
+
     return result
 
 

--- a/plugins/module_utils/_facts.py
+++ b/plugins/module_utils/_facts.py
@@ -696,7 +696,7 @@ def vmware_obj_to_json(obj, properties=None):
     if not properties:
         return _jsonify_vmware_object(obj)
 
-    result = dict()
+    result = {}
     jsonified_parents = {}
 
     for prop in properties:

--- a/tests/unit/plugins/inventory/test_esxi_hosts.py
+++ b/tests/unit/plugins/inventory/test_esxi_hosts.py
@@ -91,3 +91,90 @@ class TestEsxiInventoryModule(object):
 
         assert inventory_module.iter_inventory_sources.call_count == 1
         assert EsxiInventoryHost.create_from_vcenter_object.call_count == 1
+
+    def test_host_connection_state_from_properties(self):
+        inventory_module = InventoryModule()
+        esxi_host = EsxiInventoryHost()
+        esxi_host.properties = {
+            'summary': {
+                'runtime': {
+                    'connectionState': 'connected',
+                },
+            },
+        }
+
+        assert inventory_module._host_connection_state(esxi_host) == 'connected'
+
+    def test_host_connection_state_from_object_fallback(self, mocker):
+        inventory_module = InventoryModule()
+        esxi_host = EsxiInventoryHost()
+        esxi_host.properties = {}
+        esxi_host.object = mocker.Mock()
+        esxi_host.object.summary.runtime.connectionState = 'disconnected'
+
+        assert inventory_module._host_connection_state(esxi_host) == 'disconnected'
+
+    def test_populate_from_vcenter_skips_disconnected_hosts(self, mocker):
+        inventory_module = InventoryModule()
+        mocker.patch.object(inventory_module, 'parse_properties_param', return_value=['name'])
+        mocker.patch.object(
+            inventory_module,
+            'initialize_pyvmomi_client',
+            side_effect=setattr(inventory_module, 'pyvmomi_client', mocker.Mock()),
+        )
+        mocker.patch.object(
+            inventory_module,
+            'iter_inventory_sources',
+            return_value=[
+                (mocker.Mock(), mocker.Mock()),
+                (mocker.Mock(), mocker.Mock()),
+            ],
+        )
+        mocker.patch.object(
+            EsxiInventoryHost,
+            'create_from_vcenter_object',
+            side_effect=[EsxiInventoryHost(), EsxiInventoryHost()],
+        )
+        mocker.patch.object(
+            inventory_module,
+            '_host_connection_state',
+            side_effect=['disconnected', 'connected'],
+        )
+        mocker.patch.object(inventory_module, 'set_inventory_hostname')
+        mocker.patch.object(inventory_module, 'add_host_object_from_vcenter_to_inventory')
+        inventory_module.get_option = mocker.Mock(return_value=False)
+
+        inventory_module.populate_from_vcenter()
+
+        assert EsxiInventoryHost.create_from_vcenter_object.call_count == 2
+        inventory_module.add_host_object_from_vcenter_to_inventory.assert_called_once()
+
+    def test_populate_from_vcenter_with_gather_tags(self, mocker):
+        inventory_module = InventoryModule()
+        mocker.patch.object(inventory_module, 'parse_properties_param', return_value=['name'])
+        mocker.patch.object(
+            inventory_module,
+            'initialize_pyvmomi_client',
+            side_effect=setattr(inventory_module, 'pyvmomi_client', mocker.Mock()),
+        )
+        mocker.patch.object(inventory_module, 'initialize_rest_client')
+        mocker.patch.object(
+            inventory_module,
+            'iter_inventory_sources',
+            return_value=[(mocker.Mock(), mocker.Mock())],
+        )
+        mocker.patch.object(
+            EsxiInventoryHost,
+            'create_from_vcenter_object',
+            return_value=EsxiInventoryHost(),
+        )
+        mocker.patch.object(inventory_module, '_host_connection_state', return_value='connected')
+        mocker.patch.object(inventory_module, 'add_tags_to_object_properties')
+        mocker.patch.object(inventory_module, 'set_inventory_hostname')
+        mocker.patch.object(inventory_module, 'add_host_object_from_vcenter_to_inventory')
+        inventory_module.get_option = mocker.Mock(side_effect=lambda key: key == 'gather_tags')
+
+        inventory_module.populate_from_vcenter()
+
+        inventory_module.initialize_rest_client.assert_called_once()
+        inventory_module.add_tags_to_object_properties.assert_called_once()

--- a/tests/unit/plugins/inventory/test_esxi_hosts.py
+++ b/tests/unit/plugins/inventory/test_esxi_hosts.py
@@ -1,0 +1,93 @@
+# Copyright: (c) 2025, Ansible Cloud Team
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.inventory.esxi_hosts import (
+    EsxiInventoryHost,
+    InventoryModule,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestEsxiInventoryHost(object):
+
+    def test_create_from_vcenter_object_sets_management_ip(self, mocker):
+        host = EsxiInventoryHost()
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory.esxi_hosts.VmwareInventoryHost.create_from_vcenter_object',
+            return_value=host,
+        )
+        mocker.patch.object(
+            EsxiInventoryHost,
+            'management_ip',
+            new_callable=mocker.PropertyMock,
+            return_value='10.0.0.5',
+        )
+
+        result = EsxiInventoryHost.create_from_vcenter_object(
+            mocker.Mock(),
+            ['name'],
+            mocker.Mock(),
+            prop_set=mocker.Mock(),
+        )
+
+        assert result.properties['management_ip'] == '10.0.0.5'
+
+
+class TestEsxiInventoryModule(object):
+
+    def test_parse_properties_param(self, mocker):
+        inventory_module = InventoryModule()
+        inventory_module.get_option = mocker.Mock(return_value=['name', 'capability'])
+
+        assert inventory_module.parse_properties_param() == [
+            'name',
+            'capability',
+            'summary.runtime.connectionState',
+            'summary.runtime.powerState',
+        ]
+
+    def test_populate_from_vcenter(self, mocker):
+        inventory_module = InventoryModule()
+        mocker.patch.object(inventory_module, 'parse_properties_param', return_value=['name'])
+        mocker.patch.object(
+            inventory_module,
+            'initialize_pyvmomi_client',
+            side_effect=setattr(inventory_module, 'pyvmomi_client', mocker.Mock()),
+        )
+        mocker.patch.object(inventory_module, 'initialize_rest_client')
+        mocker.patch.object(
+            inventory_module,
+            'iter_inventory_sources',
+            return_value=[(mocker.Mock(), mocker.Mock())],
+        )
+        mocker.patch.object(
+            EsxiInventoryHost,
+            'create_from_vcenter_object',
+            return_value=EsxiInventoryHost(),
+        )
+        mocker.patch.object(inventory_module, '_host_connection_state', return_value='connected')
+        mocker.patch.object(inventory_module, 'add_tags_to_object_properties')
+        mocker.patch.object(inventory_module, 'set_inventory_hostname')
+        mocker.patch.object(
+            inventory_module,
+            'add_host_object_from_vcenter_to_inventory',
+            return_value={},
+        )
+        inventory_module.get_option = mocker.Mock(return_value=False)
+
+        inventory_module.populate_from_vcenter()
+
+        assert inventory_module.iter_inventory_sources.call_count == 1
+        assert EsxiInventoryHost.create_from_vcenter_object.call_count == 1

--- a/tests/unit/plugins/inventory/test_vms.py
+++ b/tests/unit/plugins/inventory/test_vms.py
@@ -101,3 +101,56 @@ class TestInventoryModule():
         assert inventory_module.iter_inventory_sources.call_count == 1
         assert inventory_module.set_inventory_hostname.call_count == 1
         assert inventory_module.add_host_object_from_vcenter_to_inventory.call_count == 1
+
+    def test_populate_from_vcenter_with_gather_tags(self, mocker):
+        inventory_module = InventoryModule()
+        mocker.patch.object(inventory_module, 'parse_properties_param', return_value=['name'])
+        mocker.patch.object(
+            inventory_module,
+            'initialize_pyvmomi_client',
+            side_effect=setattr(inventory_module, 'pyvmomi_client', mocker.Mock()),
+        )
+        mocker.patch.object(inventory_module, 'initialize_rest_client')
+        mocker.patch.object(
+            inventory_module,
+            'iter_inventory_sources',
+            return_value=[(mocker.Mock(), mocker.Mock())],
+        )
+        vm = VmInventoryHost()
+        mocker.patch.object(VmInventoryHost, 'create_from_vcenter_object', return_value=vm)
+        mocker.patch.object(inventory_module, 'add_tags_to_object_properties')
+        mocker.patch.object(inventory_module, 'set_inventory_hostname')
+        mocker.patch.object(inventory_module, 'add_host_object_from_vcenter_to_inventory')
+        inventory_module.get_option = mocker.Mock(side_effect=lambda key: key == 'gather_tags')
+
+        inventory_module.populate_from_vcenter()
+
+        inventory_module.initialize_rest_client.assert_called_once()
+        inventory_module.add_tags_to_object_properties.assert_called_once_with(vm)
+
+    def test_populate_from_vcenter_with_gather_compute_objects(self, mocker):
+        inventory_module = InventoryModule()
+        mocker.patch.object(inventory_module, 'parse_properties_param', return_value=['name'])
+        mocker.patch.object(
+            inventory_module,
+            'initialize_pyvmomi_client',
+            side_effect=setattr(inventory_module, 'pyvmomi_client', mocker.Mock()),
+        )
+        mocker.patch.object(
+            inventory_module,
+            'iter_inventory_sources',
+            return_value=[(mocker.Mock(), mocker.Mock())],
+        )
+        vm = VmInventoryHost()
+        vm.properties = {}
+        mocker.patch.object(VmInventoryHost, 'create_from_vcenter_object', return_value=vm)
+        mocker.patch.object(VmInventoryHost, 'cluster', new_callable=mocker.PropertyMock, return_value={'name': 'c1', 'moid': '1'})
+        mocker.patch.object(VmInventoryHost, 'esxi_host', new_callable=mocker.PropertyMock, return_value={'name': 'h1', 'moid': '2'})
+        mocker.patch.object(inventory_module, 'set_inventory_hostname')
+        mocker.patch.object(inventory_module, 'add_host_object_from_vcenter_to_inventory')
+        inventory_module.get_option = mocker.Mock(side_effect=lambda key: key == 'gather_compute_objects')
+
+        inventory_module.populate_from_vcenter()
+
+        assert vm.properties['cluster'] == {'name': 'c1', 'moid': '1'}
+        assert vm.properties['esxi_host'] == {'name': 'h1', 'moid': '2'}

--- a/tests/unit/plugins/inventory/test_vms.py
+++ b/tests/unit/plugins/inventory/test_vms.py
@@ -81,8 +81,16 @@ class TestInventoryModule():
         ])
         mocker.patch.object(inventory_module, 'initialize_pyvmomi_client', side_effect=setattr(inventory_module, 'pyvmomi_client', mocker.Mock()))
         mocker.patch.object(inventory_module, 'initialize_rest_client', side_effect=setattr(inventory_module, 'rest_client', mocker.Mock()))
-        mocker.patch.object(inventory_module, 'get_objects_by_type', return_value=[mocker.Mock()])
-        mocker.patch.object(VmInventoryHost, 'create_from_object', return_value=VmInventoryHost())
+        mocker.patch.object(
+            inventory_module,
+            'iter_inventory_sources',
+            return_value=[(mocker.Mock(), mocker.Mock())],
+        )
+        mocker.patch.object(
+            VmInventoryHost,
+            'create_from_vcenter_object',
+            return_value=VmInventoryHost(),
+        )
         mocker.patch.object(inventory_module, 'add_tags_to_object_properties')
         mocker.patch.object(inventory_module, 'set_inventory_hostname')
         mocker.patch.object(inventory_module, 'add_host_object_from_vcenter_to_inventory', return_value={})
@@ -90,6 +98,6 @@ class TestInventoryModule():
         mocker.patch.object(inventory_module, 'get_option', side_effect=(False, False, False))
         inventory_module.populate_from_vcenter()
 
-        assert inventory_module.get_objects_by_type.call_count == 1
+        assert inventory_module.iter_inventory_sources.call_count == 1
         assert inventory_module.set_inventory_hostname.call_count == 1
         assert inventory_module.add_host_object_from_vcenter_to_inventory.call_count == 1

--- a/tests/unit/plugins/inventory_utils/test_base.py
+++ b/tests/unit/plugins/inventory_utils/test_base.py
@@ -154,20 +154,32 @@ class TestVmwareInventoryHost():
     def __prepare(self, mocker):
         self.test_host = self.TestHost()
 
-    def test_get_properties_from_pyvmomi(self, mocker):
+    def test_create_from_vcenter_object_adds_inventory_metadata(self, mocker):
         self.__prepare(mocker)
-        self.test_host.object = create_mock_vsphere_object()
+        vmware_object = create_mock_vsphere_object()
         cust_val = mocker.Mock()
         cust_val.key, cust_val.value = "foo", "bar"
-        self.test_host.object.customValue = [cust_val]
+        vmware_object.customValue = [cust_val]
 
         pyvmomi_client = mocker.Mock()
         field = mocker.Mock()
         field.name, field.key = "bizz", "foo"
         pyvmomi_client.custom_field_mgr = [field]
-        mocker.patch('ansible_collections.vmware.vmware.plugins.inventory_utils._base.vmware_obj_to_json', return_value={})
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.get_folder_path_of_vsphere_object',
+            return_value='/dc/vm/folder',
+        )
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.vmware_obj_to_json',
+            return_value={},
+        )
 
-        properties = self.test_host.get_properties_from_pyvmomi([], pyvmomi_client)
-        print(properties)
-        assert properties['moid'] == self.test_host.object._GetMoId()
-        assert properties['customValue']['bizz'] == "bar"
+        host = self.TestHost.create_from_vcenter_object(
+            vmware_object,
+            ['customValue'],
+            pyvmomi_client,
+        )
+
+        assert host.properties['path'] == '/dc/vm/folder'
+        assert host.properties['moid'] == vmware_object._GetMoId()
+        assert host.properties['customValue']['bizz'] == "bar"

--- a/tests/unit/plugins/inventory_utils/test_base.py
+++ b/tests/unit/plugins/inventory_utils/test_base.py
@@ -183,3 +183,155 @@ class TestVmwareInventoryHost():
         assert host.properties['path'] == '/dc/vm/folder'
         assert host.properties['moid'] == vmware_object._GetMoId()
         assert host.properties['customValue']['bizz'] == "bar"
+
+    def test_create_from_vcenter_object_uses_prop_set(self, mocker):
+        self.__prepare(mocker)
+        vmware_object = create_mock_vsphere_object()
+        prop_set = [mocker.Mock(name='name', val='host-one')]
+
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.get_folder_path_of_vsphere_object',
+            return_value='/dc/host/folder',
+        )
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.properties_from_collector',
+            return_value={'name': 'host-one'},
+        )
+
+        host = self.TestHost.create_from_vcenter_object(
+            vmware_object,
+            ['name'],
+            mocker.Mock(),
+            prop_set=prop_set,
+        )
+
+        assert host.properties['name'] == 'host-one'
+        assert host.properties['path'] == '/dc/host/folder'
+        assert host.properties['moid'] == vmware_object._GetMoId()
+
+    def test_create_from_vcenter_object_skips_custom_values_when_not_requested(self, mocker):
+        self.__prepare(mocker)
+        vmware_object = create_mock_vsphere_object()
+        vmware_object.customValue = [mocker.Mock(key='foo', value='bar')]
+
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.get_folder_path_of_vsphere_object',
+            return_value='/dc/host/folder',
+        )
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.vmware_obj_to_json',
+            return_value={},
+        )
+
+        host = self.TestHost.create_from_vcenter_object(
+            vmware_object,
+            ['name'],
+            mocker.Mock(),
+        )
+
+        assert 'customValue' not in host.properties
+
+    def test_create_from_vcenter_object_skips_custom_values_without_attribute(self, mocker):
+        self.__prepare(mocker)
+        vmware_object = create_mock_vsphere_object()
+        del vmware_object.customValue
+
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.get_folder_path_of_vsphere_object',
+            return_value='/dc/host/folder',
+        )
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.inventory_utils._base.vmware_obj_to_json',
+            return_value={},
+        )
+
+        host = self.TestHost.create_from_vcenter_object(
+            vmware_object,
+            ['customValue'],
+            mocker.Mock(),
+        )
+
+        assert 'customValue' not in host.properties
+
+
+class TestInventoryPropertyCollector():
+    def __prepare(self, mocker):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        mocker.patch.object(VmwareRestClient, 'connect_to_api', return_value=mocker.Mock())
+        mocker.patch.object(VmwareInventoryBase, 'get_option', side_effect=get_option)
+        mocker.patch.object(VmwareInventoryBase, '_consume_options')
+        self.test_base = VmwareInventoryBase()
+        self.test_base.templar = mocker.Mock()
+        self.test_base.pyvmomi_client = mocker.Mock()
+
+    def test_get_property_collector_results_without_search_paths(self, mocker):
+        self.__prepare(mocker)
+        obj_content = mocker.Mock()
+        self.test_base.pyvmomi_client.get_managed_object_references.return_value = [obj_content]
+
+        results = self.test_base.get_property_collector_results_by_type(
+            mocker.sentinel.vim_type,
+            ['name', 'customValue', 'summary.runtime.powerState'],
+        )
+
+        assert results == [obj_content]
+        self.test_base.pyvmomi_client.get_managed_object_references.assert_called_once_with(
+            vimtype=mocker.sentinel.vim_type,
+            properties=['name', 'summary.runtime.powerState'],
+            folder=None,
+        )
+
+    def test_get_property_collector_results_with_search_paths(self, mocker):
+        self.__prepare(mocker)
+        options = {'search_paths': ['/dc1/host', '/missing/path']}
+        mocker.patch.object(self.test_base, 'get_option', side_effect=options.get)
+
+        folder = mocker.Mock()
+        first_result = mocker.Mock()
+        second_result = mocker.Mock()
+        self.test_base.pyvmomi_client.si.content.searchIndex.FindByInventoryPath.side_effect = [
+            folder,
+            None,
+        ]
+        self.test_base.pyvmomi_client.get_managed_object_references.return_value = [first_result]
+
+        results = self.test_base.get_property_collector_results_by_type(
+            mocker.sentinel.vim_type,
+            ['name'],
+        )
+
+        assert results == [first_result]
+        self.test_base.pyvmomi_client.get_managed_object_references.assert_called_once_with(
+            vimtype=mocker.sentinel.vim_type,
+            properties=['name'],
+            folder=folder,
+        )
+
+    def test_iter_inventory_sources_with_properties(self, mocker):
+        self.__prepare(mocker)
+        obj_content = mocker.Mock()
+        obj_content.obj = mocker.Mock()
+        obj_content.propSet = [mocker.Mock()]
+        mocker.patch.object(
+            self.test_base,
+            'get_property_collector_results_by_type',
+            return_value=[obj_content],
+        )
+
+        sources = list(self.test_base.iter_inventory_sources(mocker.sentinel.vim_type, ['name']))
+
+        assert sources == [(obj_content.obj, obj_content.propSet)]
+
+    def test_iter_inventory_sources_without_properties(self, mocker):
+        self.__prepare(mocker)
+        vmware_object = mocker.Mock()
+        mocker.patch.object(
+            self.test_base,
+            'get_objects_by_type',
+            return_value=[vmware_object],
+        )
+
+        sources = list(self.test_base.iter_inventory_sources(mocker.sentinel.vim_type, []))
+
+        assert sources == [(vmware_object, None)]
+        self.test_base.get_objects_by_type.assert_called_once_with(vim_type=[mocker.sentinel.vim_type])

--- a/tests/unit/plugins/module_utils/test_facts.py
+++ b/tests/unit/plugins/module_utils/test_facts.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import pytest
-
 from ansible_collections.vmware.vmware.plugins.module_utils import _facts
 
 

--- a/tests/unit/plugins/module_utils/test_facts.py
+++ b/tests/unit/plugins/module_utils/test_facts.py
@@ -1,0 +1,83 @@
+# Copyright: (c) 2025, Ansible Cloud Team
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.module_utils import _facts
+
+
+class _Hardware(object):
+    numCPU = 4
+
+
+class _Config(object):
+    cpuHotAddEnabled = True
+    name = 'vm-one'
+    hardware = _Hardware()
+
+
+class _Guest(object):
+    ipAddress = '10.0.0.1'
+
+
+class _VM(object):
+    name = 'VM-one'
+    config = _Config()
+    guest = _Guest()
+
+
+class TestVmwareObjToJson(object):
+
+    def test_dotted_properties_share_top_level_jsonify(self, mocker):
+        jsonify = mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.module_utils._facts._jsonify_vmware_object',
+            side_effect=lambda obj: {
+                _Config: {
+                    'cpuHotAddEnabled': True,
+                    'name': 'vm-one',
+                    'hardware': {'numCPU': 4},
+                },
+                _Guest: {'ipAddress': '10.0.0.1'},
+                str: obj,
+            }.get(type(obj), obj),
+        )
+
+        result = _facts.vmware_obj_to_json(
+            _VM(),
+            ['config.cpuHotAddEnabled', 'config.name', 'config.hardware.numCPU', 'guest.ipAddress', 'name'],
+        )
+
+        assert result['config']['cpuHotAddEnabled'] is True
+        assert result['config']['name'] == 'vm-one'
+        assert result['config']['hardware']['numCPU'] == 4
+        assert result['guest']['ipAddress'] == '10.0.0.1'
+        assert jsonify.call_count == 3
+
+    def test_properties_from_collector(self):
+        class _Prop(object):
+            def __init__(self, name, val):
+                self.name = name
+                self.val = val
+
+        prop_set = [
+            _Prop('config.cpuHotAddEnabled', True),
+            _Prop('config.name', 'vm-one'),
+            _Prop('guest.ipAddress', '10.0.0.1'),
+            _Prop('name', 'VM-one'),
+        ]
+
+        result = _facts.properties_from_collector(prop_set)
+
+        assert result == {
+            'config': {
+                'cpuHotAddEnabled': True,
+                'name': 'vm-one',
+            },
+            'guest': {'ipAddress': '10.0.0.1'},
+            'name': 'VM-one',
+        }

--- a/tests/unit/plugins/module_utils/test_facts.py
+++ b/tests/unit/plugins/module_utils/test_facts.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import pytest
+
 from ansible_collections.vmware.vmware.plugins.module_utils import _facts
 
 
@@ -79,3 +81,69 @@ class TestVmwareObjToJson(object):
             'guest': {'ipAddress': '10.0.0.1'},
             'name': 'VM-one',
         }
+
+    def test_normalize_property_name(self):
+        assert _facts._normalize_property_name('_moid') == 'moid'
+        assert _facts._normalize_property_name('_VimRef') == 'vimref'
+        assert _facts._normalize_property_name('name') == 'name'
+
+    def test_jsonify_vmware_value_scalars(self):
+        assert _facts._jsonify_vmware_value(None) is None
+        assert _facts._jsonify_vmware_value(True) is True
+        assert _facts._jsonify_vmware_value(42) == 42
+        assert _facts._jsonify_vmware_value(3.14) == 3.14
+        assert _facts._jsonify_vmware_value('value') == 'value'
+
+    def test_jsonify_vmware_value_collections(self):
+        assert _facts._jsonify_vmware_value([1, 'two']) == [1, 'two']
+        assert _facts._jsonify_vmware_value((3, 4)) == [3, 4]
+        assert _facts._jsonify_vmware_value({'a': 1, 'b': 'two'}) == {'a': 1, 'b': 'two'}
+
+    def test_jsonify_vmware_value_long_and_binary(self):
+        long_type = type('long', (int,), {})
+        binary_type = type('binary', (bytes,), {})
+
+        assert _facts._jsonify_vmware_value(long_type(99)) == 99
+        assert _facts._jsonify_vmware_value(binary_type(b'abc')) == 'YWJj'
+
+    def test_jsonify_vmware_value_long_array(self):
+        long_type = type('long', (int,), {})
+        long_array_type = type('long[]', (list,), {})
+
+        assert _facts._jsonify_vmware_value(long_array_type([long_type(1), long_type(2)])) == [1, 2]
+
+    def test_jsonify_vmware_value_datetime(self, mocker):
+        datetime_type = type('datetime', (object,), {})
+        iso8601 = mocker.patch('pyVmomi.Iso8601')
+        iso8601.ISO8601Format.return_value = '2020-01-01T00:00:00Z'
+
+        assert _facts._jsonify_vmware_value(datetime_type()) == '2020-01-01T00:00:00Z'
+
+    def test_vmware_obj_to_json_normalizes_special_properties(self, mocker):
+        vm = mocker.Mock()
+        vm._moid = 'vm-1'
+        vm._vimref = 'vim.VirtualMachine:vm-1'
+        mocker.patch(
+            'ansible_collections.vmware.vmware.plugins.module_utils._facts._jsonify_vmware_object',
+            return_value='jsonified',
+        )
+
+        result = _facts.vmware_obj_to_json(vm, ['_moid', '_vimref'])
+
+        assert result == {'moid': 'jsonified', 'vimref': 'jsonified'}
+
+    def test_vmware_obj_to_json_missing_property_raises(self):
+        with pytest.raises(AttributeError, match="Property 'missing' not found."):
+            _facts.vmware_obj_to_json(_VM(), ['missing'])
+
+    def test_jsonify_vmware_value_vim_type_non_data_object(self):
+        vim_type = type('vim.test.Object', (object,), {})
+        vim_object = vim_type()
+
+        assert _facts._jsonify_vmware_value(vim_object) == str(vim_object)
+
+    def test_jsonify_vmware_value_unknown_type_uses_to_text(self):
+        unknown_type = type('custom_type', (object,), {})
+        unknown_object = unknown_type()
+
+        assert _facts._jsonify_vmware_value(unknown_object) == str(unknown_object)


### PR DESCRIPTION
Fixes #318

#### SUMMARY
- Gather inventory host properties with the vSphere PropertyCollector when a property list is configured, instead of lazy pyVmomi attribute access per property on each VM or host.
- Deduplicate top-level property fetches in `vmware_obj_to_json` when the full-object code path is used (`properties: all` and modules such as `guest_info`).
- Align `vms` and `esxi_hosts` on a shared flow via `iter_inventory_sources()` and `create_from_vcenter_object()`.
- Only gather `customValue` when it is included in the requested property list.

Profiling on 11 VMs with default properties and scoped `search_paths` showed total time dropping from ~75s to ~36–39s (~2× faster). The main remaining hotspot is `get_folder_path_of_vsphere_object`.

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- plugins/inventory/vms.py
- plugins/inventory/esxi_hosts.py
- plugins/inventory_utils/_base.py
- plugins/module_utils/_facts.py

#### ADDITIONAL INFORMATION

*This PR description was drafted with AI assistance and reviewed by the author.*