### PR TITLE
docs: add guest isolation example to vm_advanced_settings

### DIFF
--- a/plugins/modules/vm_advanced_settings.py
+++ b/plugins/modules/vm_advanced_settings.py
@@ -95,7 +95,7 @@ extends_documentation_fragment:
     - vmware.vmware.base_options
 '''
 
-EXAMPLES = r'''
+EXAMPLES = fr'''
 - name: Make Sure The Following Advanced Settings Are Present
   vmware.vmware.vm_advanced_settings:
     hostname: "{{ vcenter_hostname }}"
@@ -120,6 +120,15 @@ EXAMPLES = r'''
       one: 1    # remove advanced setting if it has both key == 'one' and value == 1
       two: ""   # remove any advanced setting with the key 'two', regardless of value
     state: absent
+
+- name: Configure Guest OS Isolation Settings
+  vmware.vmware.vm_advanced_settings:
+    name: "{{ vm }}"
+    state: present
+    settings:
+      'isolation.tools.copy.disable': 'TRUE'    # disable copy
+      'isolation.tools.paste.disable': 'TRUE'   # disable paste
+      'isolation.tools.dnd.disable': 'TRUE'     # disable drag and drop
 '''
 
 RETURN = r'''

--- a/plugins/modules/vm_advanced_settings.py
+++ b/plugins/modules/vm_advanced_settings.py
@@ -95,7 +95,7 @@ extends_documentation_fragment:
     - vmware.vmware.base_options
 '''
 
-EXAMPLES = fr'''
+EXAMPLES = r'''
 - name: Make Sure The Following Advanced Settings Are Present
   vmware.vmware.vm_advanced_settings:
     hostname: "{{ vcenter_hostname }}"


### PR DESCRIPTION
#### SUMMARY
- Add a documentation example to `vm_advanced_settings` showing how to configure guest OS isolation settings (disable copy, paste, and drag-and-drop via `isolation.tools.*` advanced settings).

#### ISSUE TYPE
- Docs Pull Request

#### COMPONENT NAME
- plugins/modules/vm_advanced_settings.py

#### ADDITIONAL INFORMATION
- Documentation-only change; no module behavior changes.

---
*This PR body was generated using AI and reviewed by the author.*