### PR TITLE
vm_snapshot: Add timeout parameter

### DIFF
--- a/changelogs/fragments/361-vm_snapshot.yml
+++ b/changelogs/fragments/361-vm_snapshot.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vm_snapshot - Add a timeout parameter to define how long the module will wait for the task to finish
+    (https://github.com/ansible-collections/vmware.vmware/issues/361).

--- a/plugins/modules/vm_snapshot.py
+++ b/plugins/modules/vm_snapshot.py
@@ -123,7 +123,7 @@ options:
         type: str
     timeout:
         description:
-        - The value sets a timeout in seconds for the module to wait for the task to finish.
+        - The timeout value in seconds for the module to wait for the task to finish.
         default: 3600
         type: int
 

--- a/plugins/modules/vm_snapshot.py
+++ b/plugins/modules/vm_snapshot.py
@@ -121,6 +121,11 @@ options:
         description:
         - If the snapshot already exists, it will be renamed to this value.
         type: str
+    timeout:
+        description:
+        - The value sets a timeout in seconds for the module to wait for the task to finish.
+        default: 3600
+        type: int
 
 
 
@@ -377,7 +382,7 @@ class VmSnapshotModule(ModulePyvmomiBase):
                 task = None
 
             if task:
-                success, task_result = RunningTaskMonitor(task).wait_for_completion()
+                success, task_result = RunningTaskMonitor(task).wait_for_completion(timeout=self.params['timeout'])
                 del task_result['result']
                 self.result['result'] = task_result
 
@@ -414,6 +419,7 @@ def main():
                 memory_dump=dict(type='bool', default=False),
                 remove_children=dict(type='bool', default=False),
                 new_snapshot_name=dict(type='str'),
+                timeout=dict(type='int', default=3600),
             )
         },
         supports_check_mode=True,


### PR DESCRIPTION
##### SUMMARY
Fixes #361

Add a timeout for snapshot operations to override the default 1 hour (3600 seconds) the module waits for the task to succeed before failing.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vm_snapshot

##### ADDITIONAL INFORMATION
I didn't find the time to test this, but since the change is very simple and straightforward I think this isn't really necessary.