### PR TITLE
Fix 'netsted' typo

### DIFF
--- a/plugins/modules/folder_template_from_vm.py
+++ b/plugins/modules/folder_template_from_vm.py
@@ -123,7 +123,7 @@ EXAMPLES = r'''
     password: "password"
     datacenter: "my-datacenter"
     vm_uuid: "11111111-11111111-11111111"
-    template_folder: "my-datacenter/vm/netsted/folder/path/templates"
+    template_folder: "my-datacenter/vm/nested/folder/path/templates"
     template_name: "my_template"
 
 - name: Create A New Template Using VM Name


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the folder_template_from_vm module, 'nested' is written as 'netsted'.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
folder_template_from_vm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible [core 2.20.5]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/mike/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.14/site-packages/ansible
  ansible collection location = /etc/ansible:/etc/ansible/ansible_collections:/home/mike/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.14.4 (main, Apr  8 2026, 17:48:49) [GCC 15.2.1 20260209] (/usr/bin/python)
  jinja version = 3.1.6
  pyyaml version = 6.0.3 (with libyaml v0.2.5)
```
