### PR TITLE
Add more diversity for the folder parameter in the vm_snapshot examples

### DIFF
--- a/plugins/modules/vm_snapshot.py
+++ b/plugins/modules/vm_snapshot.py
@@ -152,7 +152,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    folder: "/{{ datacenter_name }}/vm/"
+    folder: "/{{ datacenter_name }}/vm/nested/folder/path"
     name: "{{ guest_name }}"
     state: absent
     snapshot_name: snap1
@@ -174,7 +174,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    folder: "/{{ datacenter_name }}/vm/"
+    folder: "/{{ datacenter_name }}/vm/nested/folder/path"
     moid: vm-42
     state: absent
     remove_all: true
@@ -185,7 +185,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    folder: "/{{ datacenter_name }}/vm/"
+    folder: "nested/folder/path"
     name: "{{ guest_name }}"
     state: present
     snapshot_name: dummy_vm_snap_0001
@@ -210,7 +210,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    folder: "/{{ datacenter_name }}/vm/"
+    folder: "/{{ datacenter_name }}/vm/nested/folder/path"
     name: "{{ guest_name }}"
     snapshot_id: 10
     state: absent
@@ -221,7 +221,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    folder: "/{{ datacenter_name }}/vm/"
+    folder: "nested/folder/path"
     name: "{{ guest_name }}"
     state: present
     snapshot_name: current_snap_name


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I like how mikemorency documented the usage of the folder parameter in the provided examples for folder_template_from_vm. I think similar examples would be helpful for the vm_snapshot module. I was a bit confused at first when using the folder parameter for the vm_snapshot module because I didn't realize that 'vm' had to be part of the path. Absolute paths are explained clearly in the documentation for the folder parameter, but I think that more diversity in the examples might prevent future confusion for people like myself who like to skip down to the examples section.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vm_snapshot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible [core 2.20.5]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/mike/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.14/site-packages/ansible
  ansible collection location = /etc/ansible:/etc/ansible/ansible_collections:/home/mike/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.14.4 (main, Apr  8 2026, 17:48:49) [GCC 15.2.1 20260209] (/usr/bin/python)
  jinja version = 3.1.6
  pyyaml version = 6.0.3 (with libyaml v0.2.5)
```
