### PR TITLE
docs: fix typo `netsted` → `nested` in folder_template_from_vm example

### DIFF
--- a/plugins/modules/folder_template_from_vm.py
+++ b/plugins/modules/folder_template_from_vm.py
@@ -123,7 +123,7 @@ EXAMPLES = r'''
     password: "password"
     datacenter: "my-datacenter"
     vm_uuid: "11111111-11111111-11111111"
-    template_folder: "my-datacenter/vm/netsted/folder/path/templates"
+    template_folder: "my-datacenter/vm/nested/folder/path/templates"
     template_name: "my_template"
 
 - name: Create A New Template Using VM Name


### PR DESCRIPTION
##### SUMMARY

Fixes the spelling typo reported in #364: the `EXAMPLES` block of the
`folder_template_from_vm` module writes `netsted` instead of `nested`.

```yaml
# before
template_folder: "my-datacenter/vm/netsted/folder/path/templates"
# after
template_folder: "my-datacenter/vm/nested/folder/path/templates"
```

Documentation-only change (a single example string); no code or behaviour change.

The additional "more examples for `vm_snapshot`" suggestion in #364 is left for
the maintainers, so this PR uses `Ref` rather than auto-closing the issue.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- folder_template_from_vm

Ref #364