### PR TITLE
fix: stream local ISO uploads in import_content_library_iso

### DIFF
--- a/changelogs/fragments/385-import_content_library_iso-streaming.yaml
+++ b/changelogs/fragments/385-import_content_library_iso-streaming.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "import_content_library_iso - Fix OOM error when uploading large local ISO files by streaming the file instead of loading it into memory (https://github.com/ansible-collections/vmware.vmware/issues/385)."

--- a/plugins/modules/import_content_library_iso.py
+++ b/plugins/modules/import_content_library_iso.py
@@ -156,7 +156,6 @@ import os
 
 from urllib.parse import urlparse
 
-from ansible.module_utils.urls import open_url
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.vmware.vmware.plugins.module_utils._module_rest_base import (
@@ -167,6 +166,7 @@ from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import
 )
 
 try:
+    import requests
     from com.vmware.content.library.item_client import UpdateSessionModel
     from com.vmware.content.library_client import ItemModel
     from com.vmware.content.library.item.updatesession_client import (
@@ -312,12 +312,11 @@ class VmwareRemoteIso(ModuleRestBase):
                     "Content-Length": str(os.path.getsize(f_path)),
                     "Content-Type": "text/ovf",
                 }
-                open_url(
-                    method="POST",
+                requests.post(
                     url=file_info.upload_endpoint.uri,
-                    data=local_file.read(),
+                    data=local_file,
                     headers=headers,
-                    validate_certs=self.params["validate_certs"],
+                    verify=self.params["validate_certs"],
                     timeout=self.params["timeout"],
                 )
 

--- a/tests/unit/plugins/modules/test_import_content_library_iso.py
+++ b/tests/unit/plugins/modules/test_import_content_library_iso.py
@@ -98,13 +98,8 @@ class TestVmwareRemoteIso(ModuleTestCase):
         )
         mocker.patch.object(os.path, "getsize", return_value=10)
 
-        # Mock open_url to prevent real HTTP call
-        mock_response = mocker.Mock()
-        mock_response.read.return_value = b"OK"
-        mock_response.getcode.return_value = 200
-        mocker.patch(
-            "ansible_collections.vmware.vmware.plugins.modules.import_content_library_iso.open_url",
-            return_value=mock_response,
+        mock_post = mocker.patch(
+            "ansible_collections.vmware.vmware.plugins.modules.import_content_library_iso.requests.post"
         )
 
         # Selectively mock open() for ISO file
@@ -120,3 +115,8 @@ class TestVmwareRemoteIso(ModuleTestCase):
 
         assert result["changed"] is True
         assert result["library_item"]["id"] == "2"
+        assert mock_post.call_count == 1
+        assert hasattr(mock_post.call_args.kwargs["data"], "read")
+        assert mock_post.call_args.kwargs["verify"] is True
+        assert mock_post.call_args.kwargs["timeout"] == 300
+        assert mock_post.call_args.kwargs["headers"]["Content-Length"] == "10"


### PR DESCRIPTION
## Summary
- stream local ISO uploads in `import_content_library_iso` instead of reading the entire file into memory
- align the ISO upload path with the existing streamed OVF upload behavior
- update unit coverage and add a changelog fragment

## Problem
`import_content_library_iso` used `local_file.read()` for local uploads, which loads the full ISO into memory and can trigger OOM failures for large files.

Fixes #385

## Testing
- `python3 -m py_compile plugins/modules/import_content_library_iso.py tests/unit/plugins/modules/test_import_content_library_iso.py`
- `make upgrade-collections`
- `ansible-test units --venv --python 3.14 tests/unit/plugins/modules/test_import_content_library_iso.py`
- `ansible-test sanity --venv --python 3.14 plugins/modules/import_content_library_iso.py tests/unit/plugins/modules/test_import_content_library_iso.py`