### PR TITLE
fix: folder module check mode for create and delete

### DIFF
--- a/changelogs/fragments/387-folder-check-mode.yaml
+++ b/changelogs/fragments/387-folder-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - folder - Add check mode support for create and delete operations (https://github.com/ansible-collections/vmware.vmware/issues/387).

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -187,7 +187,10 @@ class VmwareFolder(ModulePyvmomiBase):
                 % (self.absolute_folder_path, to_native(generic_exc))
             ))
 
-    def delete_folder(self):
+    def delete_folder(self) -> None:
+        if self.module.check_mode:
+            return
+
         try:
             if self.folder_type == 'vm' and not self.params['remove_vm_data']:
                 task = self.folder_object.UnregisterAndDestroy()
@@ -213,7 +216,7 @@ class VmwareFolder(ModulePyvmomiBase):
         except Exception as e:
             self.module.fail_json(msg=("Failed to remove folder due to unexpected error %s " % to_native(e)))
 
-    def create_folder(self):
+    def create_folder(self) -> dict:
         """
         Create the folder requested by the user. To save time, we split the folder path in half and check
         if the folder at that point exists. If it does, we start the search there. If it doesn't, we start
@@ -232,11 +235,21 @@ class VmwareFolder(ModulePyvmomiBase):
             starting_index = 2
             starting_folder = self.lookup_folder_object('/'.join(split_path[:2]), fail_on_missing=True)
 
-        return self.__create_folders_on_path(
-            starting_folder=starting_folder,
-            starting_index=starting_index,
-            path_parts=split_path,
-        )
+        if self.module.check_mode:
+            return {
+                'moid': "",
+                'name': split_path[-1]
+            }
+        else:
+            new_folder = self.__create_folders_on_path(
+                starting_folder=starting_folder,
+                starting_index=starting_index,
+                path_parts=split_path,
+            )
+            return {
+                'moid': new_folder._GetMoId(),
+                'name': new_folder.name
+            }
 
     def __create_folders_on_path(self, starting_index, starting_folder, path_parts):
         """
@@ -301,11 +314,8 @@ def main():
                 'name': vmware_folder.folder_object.name
             })
 
-        new_folder = vmware_folder.create_folder()
-        module.exit_json(changed=True, folder={
-            'moid': new_folder._GetMoId(),
-            'name': new_folder.name
-        })
+        new_folder_result = vmware_folder.create_folder()
+        module.exit_json(changed=True, folder=new_folder_result)
 
     if module.params['state'] == 'absent':
         if not vmware_folder.folder_object:

--- a/tests/integration/targets/vmware_folder/tasks/test.yml
+++ b/tests/integration/targets/vmware_folder/tasks/test.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create Folder In Check Mode
+  vmware.vmware.folder:
+    absolute_path: "{{ vmware_folder_absolute_folder_name }}"
+  check_mode: true
+  register: _check_create
+
 - name: Create Folder With Relative Path
   vmware.vmware.folder:
     datacenter: "{{ vcenter_datacenter }}"
@@ -23,10 +29,17 @@
       - _rel.folder.moid == _abs.folder.moid
       - _rel is changed
       - _abs is not changed
+      - _check_create is changed
 
 - name: Additional Eco Vcenter Tests
   when: run_on_vcenter
   block:
+    - name: Delete Folder In Check Mode
+      vmware.vmware.folder:
+        absolute_path: "{{ vmware_folder_absolute_folder_name }}"
+        state: absent
+      check_mode: true
+      register: _check_delete
     - name: Delete The Folder
       vmware.vmware.folder:
         absolute_path: "{{ vmware_folder_absolute_folder_name }}"
@@ -39,3 +52,4 @@
       ansible.builtin.assert:
         that:
           - _abs is changed
+          - _check_delete is changed

--- a/tests/unit/plugins/modules/test_folder.py
+++ b/tests/unit/plugins/modules/test_folder.py
@@ -101,3 +101,37 @@ class TestEsxiMaintenanceMode(ModuleTestCase):
 
         assert result["changed"] is True
         assert result["folder"]["moid"] == "2"
+
+    def test_check_mode_state_present_with_change(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(VmwareFolder, 'get_folder_by_absolute_path', side_effect=[
+            None, self.mock_folder
+        ])
+
+        module_args = dict(
+            absolute_path="/DC0/host/test",
+            state="present",
+            _ansible_check_mode=True
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+
+        assert result["changed"] is True
+        assert result["folder"]["moid"] == ""
+        assert result["folder"]["name"] == "test"
+
+    def test_check_mode_state_absent_with_change(self, mocker):
+        self.__prepare(mocker)
+        mocker.patch.object(VmwareFolder, 'get_folder_by_absolute_path', return_value=self.mock_folder)
+        self.mock_folder.Destroy = mock.Mock(return_value=MockVsphereTask())
+
+        module_args = dict(
+            absolute_path="/DC0/host/test",
+            state="absent",
+            _ansible_check_mode=True
+        )
+
+        result = run_module(module_entry=module_main, module_args=module_args)
+
+        assert result["changed"] is True
+        self.mock_folder.Destroy.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

The folder module declared `supports_check_mode=True` but did not actually skip
mutating vSphere API calls during check mode. This adds early returns in
`create_folder` and `delete_folder` so that check mode reports the correct
`changed` status without modifying infrastructure.

Fixes #387

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
folder

##### ADDITIONAL INFORMATION

- `create_folder` now returns a stub result (`moid: ""`) in check mode instead
  of calling `CreateFolder` / `UnregisterAndDestroy` / `Destroy`.
- `delete_folder` returns immediately in check mode.
- Added unit tests for both check mode paths.
- Added integration test tasks for check mode create and delete.
- Changelog fragment added.