### PR TITLE
Fix NoneType issue when adding a new native key provider

### DIFF
--- a/changelogs/fragments/key_provider_native_default_cluster.yaml
+++ b/changelogs/fragments/key_provider_native_default_cluster.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - key_provider_native - Fix an ``AttributeError`` when gathering the default KMS cluster and no default cluster is configured.

--- a/plugins/modules/key_provider_native.py
+++ b/plugins/modules/key_provider_native.py
@@ -183,6 +183,8 @@ class NativeKeyProviderModule(ModuleRestBase):
 
     def is_provider_cluster_default(self):
         default_provider_id = self.pyvmomi_crypto_manager.GetDefaultKmsCluster()
+        if default_provider_id is None:
+            return False
         return default_provider_id.id == self.provider_name
 
     def create_key_provider(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When creating a new native key provider on a fresh vCenter environment where no default key provider cluster is configured yet, got this error:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'id'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1785395242.4903882-303925-117840215690470/AnsiballZ_key_provider_native.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1785395242.4903882-303925-117840215690470/AnsiballZ_key_provider_native.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1785395242.4903882-303925-117840215690470/AnsiballZ_key_provider_native.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.vmware.vmware.plugins.modules.key_provider_native', init_globals=dict(_module_fqn='ansible_collections.vmware.vmware.plugins.modules.key_provider_native', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_vmware.vmware.key_provider_native_payload_h4h99i0x/ansible_vmware.vmware.key_provider_native_payload.zip/ansible_collections/vmware/vmware/plugins/modules/key_provider_native.py\", line 269, in <module>\n  File \"/tmp/ansible_vmware.vmware.key_provider_native_payload_h4h99i0x/ansible_vmware.vmware.key_provider_native_payload.zip/ansible_collections/vmware/vmware/plugins/modules/key_provider_native.py\", line 258, in main\n  File \"/tmp/ansible_vmware.vmware.key_provider_native_payload_h4h99i0x/ansible_vmware.vmware.key_provider_native_payload.zip/ansible_collections/vmware/vmware/plugins/modules/key_provider_native.py\", line 231, in do_present_state\n  File \"/tmp/ansible_vmware.vmware.key_provider_native_payload_h4h99i0x/ansible_vmware.vmware.key_provider_native_payload.zip/ansible_collections/vmware/vmware/plugins/modules/key_provider_native.py\", line 186, in is_provider_cluster_default\nAttributeError: 'NoneType' object has no attribute 'id'\n", "module_stdout": "", "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error", "rc": 1}
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
key_provider_native

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
