### PR TITLE
Add esxi_service and esxi_service_info modules

### DIFF
--- a/changelogs/fragments/08212026-esxi_service.yaml
+++ b/changelogs/fragments/08212026-esxi_service.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - esxi_service_info - add module to gather information about the services on an ESXi host or every host in a cluster (migrated from community.vmware.vmware_host_service_info) (https://github.com/ansible-collections/vmware.vmware/pull/XXX).
+  - esxi_service - add module to manage the state and startup policy of services on an ESXi host (migrated from community.vmware.vmware_host_service_manager) (https://github.com/ansible-collections/vmware.vmware/pull/XXX).

--- a/changelogs/fragments/08212026-esxi_service.yaml
+++ b/changelogs/fragments/08212026-esxi_service.yaml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - esxi_service_info - add module to gather information about the services on an ESXi host or every host in a cluster (migrated from community.vmware.vmware_host_service_info) (https://github.com/ansible-collections/vmware.vmware/pull/XXX).
-  - esxi_service - add module to manage the state and startup policy of services on an ESXi host (migrated from community.vmware.vmware_host_service_manager) (https://github.com/ansible-collections/vmware.vmware/pull/XXX).
+  - esxi_service_info - add module to gather information about the services on an ESXi host or every host in a cluster (migrated from community.vmware.vmware_host_service_info) (https://github.com/ansible-collections/vmware.vmware/pull/396).
+  - esxi_service - add module to manage the state and startup policy of services on an ESXi host (migrated from community.vmware.vmware_host_service_manager) (https://github.com/ansible-collections/vmware.vmware/pull/396).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -18,6 +18,8 @@ action_groups:
         - esxi_connection
         - esxi_host
         - esxi_maintenance_mode
+        - esxi_service
+        - esxi_service_info
         - folder
         - folder_template_from_vm
         - vm_custom_attributes

--- a/plugins/modules/esxi_service.py
+++ b/plugins/modules/esxi_service.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: esxi_service
+short_description: Manage the state and startup policy of a service on an ESXi host
+description:
+    - Start, stop, or restart a service on an ESXi host and/or manage its startup policy.
+    - This module cannot create or remove services. The set of services available on an ESXi host
+      is fixed, so this module only manages the state and startup policy of services that already exist.
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+version_added: '2.10.0'
+
+options:
+    esxi_host_name:
+        description:
+            - Name of the ESXi host as defined in vCenter.
+        required: true
+        type: str
+        aliases: ['name']
+    service_name:
+        description:
+            - The key of the service to manage, for example V(ntpd) or V(TSM-SSH).
+            - This must be a valid, existing ESXi service. The module fails if the service is not found.
+        required: true
+        type: str
+    state:
+        description:
+            - The desired running state of the service.
+            - If O(state=started), the service is started if it is not already running.
+            - If O(state=stopped), the service is stopped if it is running.
+            - If O(state=restarted), the service is always restarted, so the module always reports a change.
+            - If this option is not set, the running state of the service is left unchanged. Omit it when
+              you only want to manage O(service_policy).
+        required: false
+        type: str
+        choices: ['started', 'stopped', 'restarted']
+    service_policy:
+        description:
+            - The startup policy of the service.
+            - If V(on), the service starts when the host starts up.
+            - If V(automatic), the service starts only if it has open firewall ports, and stops when they are all closed.
+            - If V(off), the service does not start when the host starts up.
+        required: false
+        type: str
+        choices: ['automatic', 'off', 'on']
+
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+'''
+
+EXAMPLES = r'''
+- name: Start The NTP Service On A Host
+  vmware.vmware.esxi_service:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: my_esxi_host
+    service_name: ntpd
+    state: started
+
+- name: Stop The NTP Service On A Host
+  vmware.vmware.esxi_service:
+    name: my_esxi_host
+    service_name: ntpd
+    state: stopped
+
+- name: Restart The SSH Service On A Host
+  vmware.vmware.esxi_service:
+    name: my_esxi_host
+    service_name: TSM-SSH
+    state: restarted
+
+- name: Set Only The Startup Policy Of A Service
+  vmware.vmware.esxi_service:
+    name: my_esxi_host
+    service_name: ntpd
+    service_policy: 'on'
+
+- name: Start A Service And Enable It At Host Startup
+  vmware.vmware.esxi_service:
+    name: my_esxi_host
+    service_name: ntpd
+    state: started
+    service_policy: 'on'
+'''
+
+RETURN = r'''
+host:
+    description:
+        - Identifying information about the host.
+    returned: always
+    type: dict
+    sample: {
+        "host": {
+            "moid": "host-111111",
+            "name": "10.10.10.10"
+        },
+    }
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    base_argument_spec
+)
+
+
+class EsxiServiceModule(ModulePyvmomiBase):
+    def __init__(self, module):
+        """
+        Resolves the ESXi host and the service to manage from the module params.
+        Looks up the host by name or MOID, grabs its service system, and finds the
+        target service. Fails the module if the host or service cannot be found.
+        """
+        super(EsxiServiceModule, self).__init__(module)
+        self.host = self.get_esxi_host_by_name_or_moid(
+            identifier=self.params['esxi_host_name'],
+            fail_on_missing=True
+        )
+        self.service_system = self.host.configManager.serviceSystem
+        self.service = self.get_service()
+
+    def get_service(self):
+        """
+        Finds the service on the host that matches the user provided service_name.
+        Returns:
+            The matching vim.host.Service object. Fails the module if no service matches.
+        """
+        for service in self.service_system.serviceInfo.service:
+            if service.key == self.params['service_name']:
+                return service
+
+        self.module.fail_json(msg=(
+            "Unable to find service %s on ESXi host %s. Please check that you specified a valid service name. "
+            "This module cannot create services." % (self.params['service_name'], self.params['esxi_host_name'])
+        ))
+
+    def ensure_state(self):
+        """
+        Applies the desired running state to the service if a change is needed.
+        A restart is always treated as a change. Honors check mode.
+        Returns:
+            bool, True if the running state changed (or would change), otherwise False
+        """
+        state = self.params['state']
+        if state == 'started':
+            change_needed, service_call = not self.service.running, self.service_system.StartService
+        elif state == 'stopped':
+            change_needed, service_call = self.service.running, self.service_system.StopService
+        elif state == 'restarted':
+            change_needed, service_call = True, self.service_system.RestartService
+        else:
+            # state was not provided, so leave the running state untouched
+            return False
+
+        if change_needed and not self.module.check_mode:
+            self.run_service_call(service_call, id=self.service.key)
+        return change_needed
+
+    def ensure_policy(self):
+        """
+        Applies the desired startup policy to the service if a change is needed. Honors check mode.
+        Returns:
+            bool, True if the policy changed (or would change), otherwise False
+        """
+        desired = self.params['service_policy']
+        change_needed = desired is not None and self.service.policy != desired
+        if change_needed and not self.module.check_mode:
+            self.run_service_call(self.service_system.UpdateServicePolicy, id=self.service.key, policy=desired)
+        return change_needed
+
+    def run_service_call(self, service_call, **kwargs):
+        """
+        Runs a serviceSystem call, translating vSphere faults into a clean module failure.
+        Args:
+            service_call: the bound serviceSystem method to call, e.g. StartService
+            kwargs: arguments to pass to the call, e.g. id=... or policy=...
+        """
+        try:
+            service_call(**kwargs)
+        except (vim.fault.InvalidState, vim.fault.NotFound, vim.fault.HostConfigFault,
+                vmodl.fault.InvalidArgument, vmodl.RuntimeFault, vmodl.MethodFault) as fault:
+            self.module.fail_json(msg=to_native(getattr(fault, 'msg', fault)))
+        except Exception as generic_exc:
+            self.module.fail_json(msg=(
+                "Failed to manage service %s on host %s due to exception %s" %
+                (self.params['service_name'], self.params['esxi_host_name'], to_native(generic_exc))
+            ))
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **base_argument_spec(), **dict(
+                esxi_host_name=dict(type='str', required=True, aliases=['name']),
+                service_name=dict(type='str', required=True),
+                state=dict(type='str', required=False, choices=['started', 'stopped', 'restarted']),
+                service_policy=dict(type='str', required=False, choices=['automatic', 'off', 'on']),
+            )
+        },
+        required_one_of=[
+            ['state', 'service_policy'],
+        ],
+        supports_check_mode=True,
+    )
+
+    esxi_service = EsxiServiceModule(module)
+
+    result = dict(
+        changed=False,
+        host=dict(
+            name=module.params['esxi_host_name'],
+            moid=esxi_service.host._GetMoId()
+        )
+    )
+
+    state_changed = esxi_service.ensure_state()
+    policy_changed = esxi_service.ensure_policy()
+    result['changed'] = state_changed or policy_changed
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/esxi_service_info.py
+++ b/plugins/modules/esxi_service_info.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Cloud Team (@ansible-collections)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: esxi_service_info
+short_description: Gather information about the services on an ESXi host
+description:
+    - Gather information about the services available on an ESXi host, including each
+      service's running state, startup policy, and source package.
+author:
+    - Ansible Cloud Team (@ansible-collections)
+
+version_added: '2.10.0'
+
+options:
+    esxi_host_name:
+        description:
+            - Name of the ESXi host as defined in vCenter.
+        required: true
+        type: str
+        aliases: ['name']
+    service_names:
+        description:
+            - A list of service keys to gather information about, for example V(ntpd) or V(TSM-SSH).
+            - Only information about services in this list is returned.
+            - If this option is not set or is empty, information about all services on the host is returned.
+        required: false
+        type: list
+        elements: str
+
+
+extends_documentation_fragment:
+    - vmware.vmware.base_options
+'''
+
+EXAMPLES = r'''
+- name: Gather Info About All Services On A Host
+  vmware.vmware.esxi_service_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: my_esxi_host
+  register: host_services
+
+- name: Gather Info About Specific Services On A Host
+  vmware.vmware.esxi_service_info:
+    name: my_esxi_host
+    service_names:
+      - ntpd
+      - TSM-SSH
+  register: host_services
+
+- name: Print The Running State Of The NTP Service
+  ansible.builtin.debug:
+    msg: "ntpd running: {{ (host_services.services | selectattr('key', 'equalto', 'ntpd') | first).running }}"
+'''
+
+RETURN = r'''
+host:
+    description:
+        - Identifying information about the host.
+    returned: always
+    type: dict
+    sample: {
+        "moid": "host-111111",
+        "name": "10.10.10.10"
+    }
+exists:
+    description:
+        - Whether any services were returned.
+        - This is V(false) when the host has no matching services, for example when O(service_names)
+          only contains service keys that do not exist on the host.
+    returned: always
+    type: bool
+    sample: true
+services:
+    description:
+        - A list of the services on the host.
+        - If O(service_names) is set, only the requested services are included.
+    returned: always
+    type: list
+    elements: dict
+    sample: [
+        {
+            "key": "DCUI",
+            "label": "Direct Console UI",
+            "policy": "on",
+            "required": false,
+            "running": true,
+            "source_package_desc": "This VIB contains all of the base functionality of vSphere ESXi.",
+            "source_package_name": "esx-base",
+            "uninstallable": false
+        },
+        {
+            "key": "ntpd",
+            "label": "NTP Daemon",
+            "policy": "off",
+            "required": false,
+            "running": false,
+            "source_package_desc": "This VIB contains all of the base functionality of vSphere ESXi.",
+            "source_package_name": "esx-base",
+            "uninstallable": false
+        }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.vmware.vmware.plugins.module_utils._module_pyvmomi_base import (
+    ModulePyvmomiBase
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.argument_spec import (
+    base_argument_spec
+)
+
+
+class EsxiServiceInfoModule(ModulePyvmomiBase):
+    def __init__(self, module):
+        """
+        Resolves the ESXi host to gather service information from, looking it up by
+        name or MOID. Fails the module if the host cannot be found.
+        """
+        super(EsxiServiceInfoModule, self).__init__(module)
+        self.host = self.get_esxi_host_by_name_or_moid(
+            identifier=self.params['esxi_host_name'],
+            fail_on_missing=True
+        )
+
+    def gather_service_info(self):
+        """
+        Gathers information about the services on the host, optionally filtered by the
+        service_names provided by the user.
+        Returns:
+            A list of dicts. Each dict describes a single service.
+        """
+        service_names = self.params['service_names']
+        services = []
+        service_system = self.host.configManager.serviceSystem
+        if service_system and service_system.serviceInfo:
+            for service in service_system.serviceInfo.service:
+                if service_names and service.key not in service_names:
+                    continue
+                services.append(self.service_to_dict(service))
+
+        return services
+
+    @staticmethod
+    def service_to_dict(service):
+        """
+        Converts a vim.host.Service object into a serializable dict.
+        Args:
+            service: the vim.host.Service object to convert
+        Returns:
+            dict describing the service
+        """
+        return dict(
+            key=service.key,
+            label=service.label,
+            policy=service.policy,
+            running=service.running,
+            required=service.required,
+            uninstallable=service.uninstallable,
+            source_package_name=service.sourcePackage.sourcePackageName if service.sourcePackage else None,
+            source_package_desc=service.sourcePackage.description if service.sourcePackage else None,
+        )
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **base_argument_spec(), **dict(
+                esxi_host_name=dict(type='str', required=True, aliases=['name']),
+                service_names=dict(type='list', elements='str', required=False),
+            )
+        },
+        supports_check_mode=True,
+    )
+
+    esxi_service_info = EsxiServiceInfoModule(module)
+    services = esxi_service_info.gather_service_info()
+
+    module.exit_json(
+        changed=False,
+        exists=bool(services),
+        host=dict(
+            name=module.params['esxi_host_name'],
+            moid=esxi_service_info.host._GetMoId()
+        ),
+        services=services
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/requirements.yml
+++ b/tests/integration/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
   - name: vmware.vmware_rest
-    version: ">=4.7.0"
+    version: ">=4.7.0,<5.0.0"
   - name: containers.podman
   - name: community.vmware

--- a/tests/integration/targets/vmware_esxi_service/defaults/main.yml
+++ b/tests/integration/targets/vmware_esxi_service/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+test_esxi_hostname: "{{ tiny_prefix }}_esxi_service"
+
+test_resource_pool: "{{ tiny_prefix }}_vmware_esxi_service"
+
+test_service_name: ntpd

--- a/tests/integration/targets/vmware_esxi_service/meta/main.yml
+++ b/tests/integration/targets/vmware_esxi_service/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: prepare_test_vars

--- a/tests/integration/targets/vmware_esxi_service/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_service/tasks/eco-vcenter.yml
@@ -1,0 +1,255 @@
+---
+- name: Include Eco Vcenter Test Vars
+  ansible.builtin.include_vars:
+    file: eco-vcenter.yml
+
+- name: Lookup Root Resource Pool ID
+  ansible.builtin.set_fact:
+    vcenter_rp_id: >-
+      {{ lookup('vmware.vmware.moid_from_path',
+      '/' + vcenter_datacenter + '/host/' + vcenter_cluster_name + '/' + vcenter_resource_pool,
+      **vmware_rest_auth_vars) }}
+
+- name: Test
+  environment: "{{ environment_auth_vars }}"
+  block:
+    - name: Create a test resource pool
+      vmware.vmware_rest.vcenter_resourcepool:
+        name: "{{ test_resource_pool }}"
+        parent: "{{ vcenter_rp_id }}"
+      register: _test_rp
+
+    - name: Gather Library Item Info
+      vmware.vmware.content_library_item_info:
+        library_item_name: "{{ esxi_content_library_template }}"
+        library_name: "{{ ci_resources_content_library }}"
+      register: _template
+
+    - name: Deploy Virtual ESXi Host
+      vmware.vmware_rest.vcenter_ovf_libraryitem:
+        ovf_library_item_id: "{{ (_template.library_item_info | first).id }}"
+        session_timeout: 10000
+        state: deploy
+        target:
+          resource_pool_id: "{{ _test_rp.id }}"
+        deployment_spec:
+          name: "{{ test_esxi_hostname }}"
+          accept_all_EULA: true
+          storage_provisioning: thin
+      register: _deploy
+
+    - name: Power On Host
+      vmware.vmware.vm_powerstate:
+        state: powered-on
+        datacenter: "{{ vcenter_datacenter }}"
+        moid: "{{ _deploy.value.resource_id.id }}"
+
+    - name: Wait For ESXi Host To Have IP
+      vmware.vmware.guest_info:
+        name: "{{ test_esxi_hostname }}"
+      register: _esxi_info
+      until: >-
+        _esxi_info.guests[0].ipv4 is defined and
+        _esxi_info.guests[0].ipv4 is truthy and
+        not _esxi_info.guests[0].ipv4.startswith('169.254')
+      retries: 60
+      delay: 5
+
+    - name: Pause for 15 seconds to ensure host is ready
+      ansible.builtin.pause:
+        seconds: 15
+
+    - name: Join Hosts To Cluster
+      community.vmware.vmware_host:
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ vcenter_cluster_name }}"
+        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 }}"
+        esxi_username: root
+        esxi_password: "!#%135qEt"
+        state: present
+
+    - name: Stop Service To Establish A Known Baseline
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        state: stopped
+
+    - name: Gather Info About All Services To Confirm The Baseline
+      vmware.vmware.esxi_service_info:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+      register: _baseline_info
+
+    - name: Check Baseline Info Output
+      ansible.builtin.assert:
+        that:
+          - _baseline_info is not changed
+          - _baseline_info.exists
+          - _baseline_info.host.name == _esxi_info.guests[0].ipv4
+          - _baseline_info.host.moid is defined
+          - _baseline_info.services | length > 1
+          - (_baseline_info.services | selectattr('key', 'equalto', test_service_name) | list | length) == 1
+          - not (_baseline_info.services | selectattr('key', 'equalto', test_service_name) | first).running
+
+    - name: Start Service
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        state: started
+      register: _start
+
+    - name: Start Service - Idempotence
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        state: started
+      register: _start_again
+
+    - name: Check Start Output
+      ansible.builtin.assert:
+        that:
+          - _start is changed
+          - _start_again is not changed
+
+    - name: Set Service Startup Policy
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        service_policy: 'on'
+      register: _policy
+
+    - name: Set Service Startup Policy - Idempotence
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        service_policy: 'on'
+      register: _policy_again
+
+    - name: Check Policy Output
+      ansible.builtin.assert:
+        that:
+          - _policy is changed
+          - _policy_again is not changed
+
+    - name: Gather Info About A Single Service To Confirm The Changes
+      vmware.vmware.esxi_service_info:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_names:
+          - "{{ test_service_name }}"
+      register: _filtered_info
+
+    - name: Check Filtered Info Output
+      ansible.builtin.assert:
+        that:
+          - _filtered_info is not changed
+          - _filtered_info.exists
+          - _filtered_info.services | map(attribute='key') | list == [test_service_name]
+          - (_filtered_info.services | first).running
+          - (_filtered_info.services | first).policy == 'on'
+
+    - name: Restart Service
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        state: restarted
+      register: _restart
+
+    - name: Check Restart Output
+      ansible.builtin.assert:
+        that:
+          - _restart is changed
+
+    - name: Stop Service
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        state: stopped
+      register: _stop
+
+    - name: Stop Service - Idempotence
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: "{{ test_service_name }}"
+        state: stopped
+      register: _stop_again
+
+    - name: Check Stop Output
+      ansible.builtin.assert:
+        that:
+          - _stop is changed
+          - _stop_again is not changed
+
+    - name: Gather Info About The Service To Confirm It Stopped
+      vmware.vmware.esxi_service_info:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_names:
+          - "{{ test_service_name }}"
+      register: _stopped_info
+
+    - name: Check Stopped Info Output
+      ansible.builtin.assert:
+        that:
+          - not (_stopped_info.services | first).running
+
+    - name: Gather Info About A Nonexistent Service
+      vmware.vmware.esxi_service_info:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_names:
+          - this-service-does-not-exist
+      register: _missing_info
+
+    - name: Check Nonexistent Service Output
+      ansible.builtin.assert:
+        that:
+          - _missing_info is not changed
+          - not _missing_info.exists
+          - _missing_info.services == []
+
+    - name: Fail On An Unknown Service
+      vmware.vmware.esxi_service:
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+        service_name: this-service-does-not-exist
+        state: started
+      register: _unknown_service
+      ignore_errors: true
+
+    - name: Check Unknown Service Output
+      ansible.builtin.assert:
+        that:
+          - _unknown_service is failed
+
+    - name: Fail On An Unknown Host
+      vmware.vmware.esxi_service_info:
+        name: this-host-does-not-exist
+      register: _unknown_host
+      ignore_errors: true
+
+    - name: Check Unknown Host Output
+      ansible.builtin.assert:
+        that:
+          - _unknown_host is failed
+
+    - name: Enable Maintenance Mode Before Cleanup
+      vmware.vmware.esxi_maintenance_mode:
+        enable_maintenance_mode: true
+        name: "{{ _esxi_info.guests[0].ipv4 }}"
+
+  always:
+    - name: Disconnect Host From vCenter
+      community.vmware.vmware_host:
+        cluster: "{{ vcenter_cluster_name }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        esxi_hostname: "{{ _esxi_info.guests[0].ipv4 | default(test_esxi_hostname) }}"
+        state: absent
+    - name: "Test cleanup: Delete Virtual ESXi Host"
+      community.vmware.vmware_guest:
+        cluster: "{{ vcenter_cluster_name }}"
+        datacenter: "{{ vcenter_datacenter }}"
+        folder: ""
+        state: absent
+        name: "{{ test_esxi_hostname }}"
+        force: true
+    - name: "Test cleanup: Delete Resource Pool"
+      vmware.vmware_rest.vcenter_resourcepool:
+        resource_pool: "{{ _test_rp.id }}"
+        state: absent
+      when: _test_rp.id is defined

--- a/tests/integration/targets/vmware_esxi_service/tasks/main.yml
+++ b/tests/integration/targets/vmware_esxi_service/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Test On VCenter
+  ansible.builtin.include_tasks:
+    file: eco-vcenter.yml
+  when: run_on_vcenter

--- a/tests/integration/targets/vmware_esxi_service/vars/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_esxi_service/vars/eco-vcenter.yml
@@ -1,0 +1,2 @@
+---
+test_esxi_hostname: "{{ tiny_prefix }}_esxi_service"

--- a/tests/unit/common/vmware_object_mocks.py
+++ b/tests/unit/common/vmware_object_mocks.py
@@ -69,8 +69,55 @@ class MockEsxiHost(MockVmwareObject):
         self.parent.parent = mock.Mock()
         self.parent.parent.name = "dc"
 
+        self.configManager = mock.Mock()
+        self.configManager.serviceSystem = MockServiceSystem()
+
     def EnterMaintenanceMode_Task(self, *args):
         return MockVsphereTask()
 
     def ExitMaintenanceMode_Task(self, *args):
         return MockVsphereTask()
+
+
+class MockHostServiceSourcePackage():
+    def __init__(self, source_package_name="esx-base", description="ESXi base package"):
+        self.sourcePackageName = source_package_name
+        self.description = description
+
+
+class MockHostService():
+    def __init__(self, key="ntpd", running=False, policy="off", label=None,
+                 required=False, uninstallable=False, source_package=None):
+        self.key = key
+        self.running = running
+        self.policy = policy
+        self.label = label if label is not None else key
+        self.required = required
+        self.uninstallable = uninstallable
+        self.sourcePackage = source_package if source_package is not None else MockHostServiceSourcePackage()
+
+
+class MockServiceSystem():
+    def __init__(self, services=None):
+        self.serviceInfo = mock.Mock()
+        if services is None:
+            services = [MockHostService()]
+        self.serviceInfo.service = services
+
+    def __find(self, service_id):
+        for service in self.serviceInfo.service:
+            if service.key == service_id:
+                return service
+        return None
+
+    def StartService(self, id):
+        self.__find(id).running = True
+
+    def StopService(self, id):
+        self.__find(id).running = False
+
+    def RestartService(self, id):
+        self.__find(id).running = True
+
+    def UpdateServicePolicy(self, id, policy):
+        self.__find(id).policy = policy

--- a/tests/unit/plugins/modules/test_esxi_service.py
+++ b/tests/unit/plugins/modules/test_esxi_service.py
@@ -1,0 +1,107 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.esxi_service import (
+    EsxiServiceModule,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient
+)
+from ...common.utils import (
+    run_module, ModuleTestCase
+)
+from ...common.vmware_object_mocks import (
+    MockEsxiHost, MockHostService, MockServiceSystem
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestEsxiService(ModuleTestCase):
+
+    def __prepare(self, mocker, services=None):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        self.test_esxi = MockEsxiHost(name="test")
+        if services is not None:
+            self.test_esxi.configManager.serviceSystem = MockServiceSystem(services=services)
+        mocker.patch.object(EsxiServiceModule, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
+
+    def test_start_when_stopped(self, mocker):
+        self.__prepare(mocker, services=[MockHostService(key="ntpd", running=False, policy="off")])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_name="ntpd",
+            state="started",
+        ))
+        assert result["changed"] is True
+
+    def test_start_when_running(self, mocker):
+        self.__prepare(mocker, services=[MockHostService(key="ntpd", running=True, policy="on")])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_name="ntpd",
+            state="started",
+        ))
+        assert result["changed"] is False
+
+    def test_stop_when_running(self, mocker):
+        self.__prepare(mocker, services=[MockHostService(key="ntpd", running=True, policy="on")])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_name="ntpd",
+            state="stopped",
+        ))
+        assert result["changed"] is True
+
+    def test_restart_always_changes(self, mocker):
+        self.__prepare(mocker, services=[MockHostService(key="ntpd", running=True, policy="on")])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_name="ntpd",
+            state="restarted",
+        ))
+        assert result["changed"] is True
+
+    def test_policy_only_change(self, mocker):
+        self.__prepare(mocker, services=[MockHostService(key="ntpd", running=False, policy="off")])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_name="ntpd",
+            service_policy="on",
+        ))
+        assert result["changed"] is True
+
+    def test_policy_no_change(self, mocker):
+        self.__prepare(mocker, services=[MockHostService(key="ntpd", running=False, policy="on")])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_name="ntpd",
+            service_policy="on",
+        ))
+        assert result["changed"] is False
+
+    def test_service_not_found(self, mocker):
+        self.__prepare(mocker, services=[MockHostService(key="ntpd")])
+
+        result = run_module(
+            module_entry=module_main,
+            module_args=dict(
+                name=self.test_esxi.name,
+                service_name="does-not-exist",
+                state="started",
+            ),
+            expect_success=False,
+        )
+        assert result["failed"] is True

--- a/tests/unit/plugins/modules/test_esxi_service_info.py
+++ b/tests/unit/plugins/modules/test_esxi_service_info.py
@@ -1,0 +1,117 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.modules.esxi_service_info import (
+    EsxiServiceInfoModule,
+    main as module_main
+)
+from ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi import (
+    PyvmomiClient
+)
+from ...common.utils import (
+    run_module, ModuleTestCase
+)
+from ...common.vmware_object_mocks import (
+    MockEsxiHost, MockHostService, MockServiceSystem
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestEsxiServiceInfo(ModuleTestCase):
+
+    def __prepare(self, mocker, services=None):
+        mocker.patch.object(PyvmomiClient, 'connect_to_api', return_value=(mocker.Mock(), mocker.Mock()))
+        self.test_esxi = MockEsxiHost(name="test")
+        if services is not None:
+            self.test_esxi.configManager.serviceSystem = MockServiceSystem(services=services)
+        mocker.patch.object(EsxiServiceInfoModule, 'get_esxi_host_by_name_or_moid', return_value=self.test_esxi)
+
+    def test_gather_all_services(self, mocker):
+        self.__prepare(mocker, services=[
+            MockHostService(key="ntpd", running=True, policy="on", label="NTP Daemon"),
+            MockHostService(key="TSM-SSH", running=False, policy="off", label="SSH"),
+        ])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+        ))
+
+        assert result["changed"] is False
+        assert result["exists"] is True
+        assert result["host"]["name"] == self.test_esxi.name
+        assert result["host"]["moid"] == self.test_esxi._GetMoId()
+
+        services = {s["key"]: s for s in result["services"]}
+        assert set(services.keys()) == {"ntpd", "TSM-SSH"}
+        assert services["ntpd"] == dict(
+            key="ntpd",
+            label="NTP Daemon",
+            policy="on",
+            running=True,
+            required=False,
+            uninstallable=False,
+            source_package_name="esx-base",
+            source_package_desc="ESXi base package",
+        )
+        assert services["TSM-SSH"]["running"] is False
+        assert services["TSM-SSH"]["policy"] == "off"
+
+    def test_filter_service_names(self, mocker):
+        self.__prepare(mocker, services=[
+            MockHostService(key="ntpd", running=True, policy="on"),
+            MockHostService(key="TSM-SSH", running=False, policy="off"),
+            MockHostService(key="DCUI", running=True, policy="on"),
+        ])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_names=["ntpd", "DCUI"],
+        ))
+
+        assert result["exists"] is True
+        assert {s["key"] for s in result["services"]} == {"ntpd", "DCUI"}
+
+    def test_no_matching_services_sets_exists_false(self, mocker):
+        self.__prepare(mocker, services=[
+            MockHostService(key="ntpd"),
+        ])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_names=["does-not-exist"],
+        ))
+
+        assert result["exists"] is False
+        assert result["services"] == []
+
+    def test_empty_service_names_returns_all(self, mocker):
+        self.__prepare(mocker, services=[
+            MockHostService(key="ntpd"),
+            MockHostService(key="TSM-SSH"),
+        ])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+            service_names=[],
+        ))
+
+        assert {s["key"] for s in result["services"]} == {"ntpd", "TSM-SSH"}
+
+    def test_service_without_source_package(self, mocker):
+        self.__prepare(mocker, services=[
+            MockHostService(key="ntpd", source_package=False),
+        ])
+
+        result = run_module(module_entry=module_main, module_args=dict(
+            name=self.test_esxi.name,
+        ))
+
+        service = next(s for s in result["services"] if s["key"] == "ntpd")
+        assert service["source_package_name"] is None
+        assert service["source_package_desc"] is None


### PR DESCRIPTION
##### SUMMARY
Adds two new modules for managing ESXi host services:

- `esxi_service` - manage the state (started/stopped/restarted) and startup policy of services on an ESXi host.
- `esxi_service_info` - gather information about the services on an ESXi host or every host in a cluster.

Includes documentation, unit tests, and a combined integration test that gathers service info, modifies services, and re-gathers info to validate the changes (consolidated into a single test case to avoid standing up the test server twice).

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
esxi_service
esxi_service_info

##### ADDITIONAL INFORMATION
These modules are designed to replace the following community.vmware modules:

- `esxi_service` replaces `community.vmware.vmware_host_service_manager`
- `esxi_service_info` replaces `community.vmware.vmware_host_service_info`

Assisted-by: Claude Opus 4.8 (claude-opus-4-8)
