### PR TITLE
fixes for vm powerstate wait and questions

### DIFF
--- a/changelogs/fragments/224-vm_powerstate-shutdown-wait.yml
+++ b/changelogs/fragments/224-vm_powerstate-shutdown-wait.yml
@@ -1,0 +1,11 @@
+---
+bugfixes:
+  - vm_powerstate - read the authoritative live C(runtime.powerState) instead of
+    the lazily-updated C(summary.runtime.powerState) so the module reliably waits
+    for the VM to reach the powered off state when using the shutdown-guest state.
+    Fixes https://github.com/ansible-collections/vmware.vmware/issues/224
+  - vm_powerstate - only attempt to answer VM questions when a question is actually
+    pending. Previously, supplying the question_answers parameter while no question
+    had appeared yet caused the module to error out before it could wait for and
+    answer the question, leaving the VM stuck.
+    Fixes https://github.com/ansible-collections/vmware.vmware/issues/224

--- a/plugins/module_utils/_vsphere_tasks.py
+++ b/plugins/module_utils/_vsphere_tasks.py
@@ -101,9 +101,11 @@ class VmQuestionHandler():
         See https://knowledge.broadcom.com/external/article/311492/answering-a-virtual-machine-related-ques.html
         for an example of what this looks like in the UI.
         """
-        if hasattr(self.vm, "runtime") and self.vm.runtime.question:
-            if not self.answers:
-                raise TaskError("Unanswered VM question: '%s'" % to_text(self.vm.runtime.question.text))
+        if not (hasattr(self.vm, "runtime") and self.vm.runtime.question):
+            return
+
+        if not self.answers:
+            raise TaskError("Unanswered VM question: '%s'" % to_text(self.vm.runtime.question.text))
 
         responses = self.format_vm_question_responses()
         self.send_vm_question_responses(responses)

--- a/plugins/modules/vm_powerstate.py
+++ b/plugins/modules/vm_powerstate.py
@@ -261,7 +261,7 @@ class VmPowerstateModule(ModulePyvmomiBase):
         self.vm = vm_list[0]
         state = self.params['state']
         self.desired_state = state.replace('_', '').replace('-', '').lower()
-        self.current_state = self.vm.summary.runtime.powerState.lower()
+        self.current_state = self.vm.runtime.powerState.lower()
         self.result["vm"]['moid'] = self.vm._GetMoId()
         self.result["vm"]['name'] = self.vm.name
 
@@ -287,7 +287,7 @@ class VmPowerstateModule(ModulePyvmomiBase):
 
         end_time = datetime.now() + timedelta(seconds=timeout)
         while datetime.now() < end_time:
-            if self.vm.summary.runtime.powerState.lower() == 'poweredoff':
+            if self.vm.runtime.powerState.lower() == 'poweredoff':
                 break
             time.sleep(5)
 

--- a/tests/integration/targets/vmware_vm_powerstate/tasks/eco-vcenter.yml
+++ b/tests/integration/targets/vmware_vm_powerstate/tasks/eco-vcenter.yml
@@ -237,6 +237,48 @@
       retries: 60
       delay: 5
 
+    - name: Shutdown the guest and wait for it to power off
+      vmware.vmware.vm_powerstate:
+        datacenter: "{{ vm_datacenter }}"
+        folder: "{{ vm_folder }}"
+        name: "{{ vm }}"
+        state: shutdown-guest
+        timeout: 600
+      register: shutdown_guest
+
+    - name: Gather VM info immediately after shutdown-guest returns
+      vmware.vmware.guest_info:
+        datacenter: "{{ vm_datacenter }}"
+        folder: "{{ vm_folder }}"
+        name: "{{ vm }}"
+      register: post_shutdown_info
+
+    # No until/retries here on purpose. If the module honored the timeout and
+    # waited for the guest to power off, the VM must already be poweredOff by
+    # the time control returns to Ansible.
+    - name: Verify the module waited for the guest to power off
+      ansible.builtin.assert:
+        that:
+          - shutdown_guest.changed
+          - post_shutdown_info.guests[0].hw_power_status == "poweredOff"
+
+    - name: Power the virtual machine back on
+      vmware.vmware.vm_powerstate:
+        datacenter: "{{ vm_datacenter }}"
+        folder: "{{ vm_folder }}"
+        name: "{{ vm }}"
+        state: powered-on
+
+    - name: Wait until VM is ready again
+      vmware.vmware_rest.vcenter_vm_tools_info:
+        vm: "{{ deploy.vm.moid }}"
+      register: vm_tools_info
+      until:
+        - vm_tools_info is not failed
+        - vm_tools_info.value.run_state == "RUNNING"
+      retries: 60
+      delay: 5
+
     - name: Reboot the virtual machine with force
       vmware.vmware.vm_powerstate:
         datacenter: "{{ vm_datacenter }}"

--- a/tests/unit/plugins/module_utils/test_vsphere_tasks.py
+++ b/tests/unit/plugins/module_utils/test_vsphere_tasks.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from unittest import mock
+
+import pytest
+
+from ansible_collections.vmware.vmware.plugins.module_utils._vsphere_tasks import (
+    TaskError,
+    VmQuestionHandler,
+)
+
+
+def _mock_vm_with_question(question_id="0", message_id="msg.uuid.altered",
+                           choices=None):
+    """
+    Build a VM mock whose runtime reports a pending question, matching the
+    pyVmomi shape used by VmQuestionHandler (message.id, choice.choiceInfo
+    with label/key, question.id and question.text).
+    """
+    if choices is None:
+        choices = {"button.uuid.copiedTheVM": "0", "button.uuid.movedTheVM": "1"}
+
+    vm = mock.Mock()
+    message = mock.Mock()
+    message.id = message_id
+
+    choice_infos = []
+    for label, key in choices.items():
+        choice = mock.Mock()
+        choice.label = label
+        choice.key = key
+        choice_infos.append(choice)
+
+    vm.runtime.question.id = question_id
+    vm.runtime.question.text = "Question text"
+    vm.runtime.question.message = [message]
+    vm.runtime.question.choice.choiceInfo = choice_infos
+    return vm
+
+
+class TestVmQuestionHandler():
+
+    def test_no_question_with_answers_is_noop(self):
+        """
+        Regression: supplying answers while no question is pending must not
+        raise (previously dereferenced runtime.question and raised
+        AttributeError, killing the module before it could answer).
+        """
+        vm = mock.Mock()
+        vm.runtime.question = None
+        answers = [{"question": "msg.uuid.altered", "response": "button.uuid.movedTheVM"}]
+
+        handler = VmQuestionHandler(vm=vm, answers=answers)
+        handler.handle_vm_questions()
+
+        vm.AnswerVM.assert_not_called()
+
+    def test_no_question_without_answers_is_noop(self):
+        vm = mock.Mock()
+        vm.runtime.question = None
+
+        handler = VmQuestionHandler(vm=vm, answers=None)
+        handler.handle_vm_questions()
+
+        vm.AnswerVM.assert_not_called()
+
+    def test_question_without_answers_raises(self):
+        vm = _mock_vm_with_question()
+
+        handler = VmQuestionHandler(vm=vm, answers=None)
+        with pytest.raises(TaskError):
+            handler.handle_vm_questions()
+
+        vm.AnswerVM.assert_not_called()
+
+    def test_question_with_answers_is_answered(self):
+        vm = _mock_vm_with_question()
+        answers = [{"question": "msg.uuid.altered", "response": "button.uuid.movedTheVM"}]
+
+        handler = VmQuestionHandler(vm=vm, answers=answers)
+        handler.handle_vm_questions()
+
+        vm.AnswerVM.assert_called_once_with("0", "1")
+
+    def test_question_with_unknown_answer_raises(self):
+        vm = _mock_vm_with_question()
+        answers = [{"question": "msg.uuid.altered", "response": "does.not.exist"}]
+
+        handler = VmQuestionHandler(vm=vm, answers=answers)
+        with pytest.raises(TaskError):
+            handler.handle_vm_questions()
+
+        vm.AnswerVM.assert_not_called()

--- a/tests/unit/plugins/modules/test_vm_powerstate.py
+++ b/tests/unit/plugins/modules/test_vm_powerstate.py
@@ -32,7 +32,7 @@ class TestVmPowerstate(ModuleTestCase):
         self.vm_mock = mocker.MagicMock()
         self.vm_mock.configure_mock(
             **{
-                "summary.runtime.powerState.lower.return_value": "poweredon",
+                "runtime.powerState.lower.return_value": "poweredon",
                 "runtime.question": False
             }
         )
@@ -73,7 +73,7 @@ class TestVmPowerstate(ModuleTestCase):
         self.vm_mock.configure_mock(
             **{
                 "PowerOn.return_value": MockVsphereTask(),
-                "summary.runtime.powerState.lower.return_value": "poweredoff"
+                "runtime.powerState.lower.return_value": "poweredoff"
             }
         )
 
@@ -123,7 +123,7 @@ class TestVmPowerstate(ModuleTestCase):
         assert result["changed"] is True
 
     def _side_effect_power_off_vm(self, *args, **kwargs):
-        self.vm_mock.summary.runtime.powerState = 'poweredoff'
+        self.vm_mock.runtime.powerState = 'poweredoff'
 
     def test_poll_vm_state_for_shutdown(self, mocker):
         self.__prepare(mocker)
@@ -131,7 +131,7 @@ class TestVmPowerstate(ModuleTestCase):
         self.vm_mock.configure_mock(
             **{
                 "ShutdownGuest.return_value": MockVsphereTask(),
-                "summary.runtime.powerState": 'poweredon',
+                "runtime.powerState": 'poweredon',
                 "guest.toolsRunningStatus": 'guestToolsRunning'
             }
         )


### PR DESCRIPTION
##### SUMMARY
fixes https://github.com/ansible-collections/vmware.vmware/issues/224

Addresses two bugs:
1. Use the runtime.powerState property for power status instead of summary. Summary is evaluated lazily so during loops it does not show an accurate status
2. Ensure that questions are answered if they are present. Previously answers were skipped

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vm_powerstate

