### PR TITLE
Fix inventory integration tests

### DIFF
--- a/tests/integration/targets/inventory_esxi_hosts/test.yml
+++ b/tests/integration/targets/inventory_esxi_hosts/test.yml
@@ -15,7 +15,7 @@
           - >-
             ((groups.poweredOn | default([])) | length) ==
             (hostvars.values() | selectattr('summary.runtime.powerState', 'equalto', 'poweredOn') | default([]) | length)
-          - groups | length >= 2 # we should have at least found three groups from the folder path groups
+          - groups | length >= 4 # powerstate(on) + each tier of folder path
           - ('test_' + vcenter_datacenter | replace('-', '_')) in groups
 
     - name: Check First Host

--- a/tests/integration/targets/inventory_vms/files/test.vms.yml
+++ b/tests/integration/targets/inventory_vms/files/test.vms.yml
@@ -5,7 +5,7 @@ cache: false
 group_by_paths: true
 group_by_paths_prefix: test
 gather_tags: true
-gather_compute_object_names: true
+gather_compute_objects: true
 rename_reserved_variables: true
 search_paths:
   - /Eco-Datacenter/vm/ansible_ci_vm_test_resources

--- a/tests/integration/targets/inventory_vms/test.yml
+++ b/tests/integration/targets/inventory_vms/test.yml
@@ -15,7 +15,7 @@
           - >-
             ((groups.poweredOff | default([])) | length) ==
             (hostvars.values() | selectattr('summary.runtime.powerState', 'equalto', 'poweredOff') | default([]) | length)
-          - groups | length >= 3 # we should have at least found three groups from the folder path groups
+          - groups | length >= 5 # at least powerstates + each tier of the folder path
           - ('test_' + vcenter_datacenter | replace('-', '_')) in groups
 
     - name: Check First Host
@@ -28,4 +28,4 @@
           - first_host.cluster.name is defined
           - first_host.esxi_host.name is defined
       vars:
-        first_host: "{{ hostvars.values() | first }}"
+        first_host: "{{ hostvars.values() | selectattr('summary.runtime.powerState', 'equalto', 'poweredOn') | first }}"


### PR DESCRIPTION
##### SUMMARY
Fixes inventory_vms and inventory_esxi_hosts integration tests:
- `inventory_vms/files/test.vms.yml` used a non-existent option `gather_compute_object_names` instead of `gather_compute_objects`, so `cluster`/`esxi_host` hostvars were never populated, failing the "Check First Host" assertion.
- Updated group-count assertions in both targets to match the actual number of groups produced.
- Selects a powered-on host (instead of the first host) when asserting `cluster`/`esxi_host` hostvars.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory_vms, inventory_esxi_hosts

##### ADDITIONAL INFORMATION
My best guess is that these tests actually werent running properly before the testing refactor, and now they are.